### PR TITLE
Fix/gdb leaks and small stuff

### DIFF
--- a/src/Spice86/Emulator/Gdb/GdbCommandHandler.cs
+++ b/src/Spice86/Emulator/Gdb/GdbCommandHandler.cs
@@ -65,6 +65,9 @@ public class GdbCommandHandler {
                 'Z' => _gdbCommandBreakpointHandler.AddBreakpoint(commandContent),
                 _ => _gdbIo.GenerateUnsupportedResponse()
             };
+            if (_logger.IsEnabled(Serilog.Events.LogEventLevel.Information)) {
+                _logger.Information("Responded with {@Response}", response);
+            }
             if (response != null) {
                 _gdbIo.SendResponse(response);
             }

--- a/src/Spice86/Emulator/VM/Machine.cs
+++ b/src/Spice86/Emulator/VM/Machine.cs
@@ -276,6 +276,7 @@ public class Machine : IDisposable {
             if (disposing) {
                 SoundBlaster.Dispose();
                 OPL3FM.Dispose();
+                MachineBreakpoints.Dispose();
             }
             disposedValue = true;
         }

--- a/src/Spice86/Emulator/VM/MachineBreakpoints.cs
+++ b/src/Spice86/Emulator/VM/MachineBreakpoints.cs
@@ -4,7 +4,7 @@ using Spice86.Emulator.CPU;
 using Spice86.Emulator.VM.Breakpoint;
 using Spice86.Emulator.Memory;
 
-public class MachineBreakpoints {
+public class MachineBreakpoints : IDisposable {
     private readonly BreakPointHolder _cycleBreakPoints = new();
 
     private readonly BreakPointHolder _executionBreakPoints = new();
@@ -14,6 +14,7 @@ public class MachineBreakpoints {
     private readonly State _state;
 
     private BreakPoint? _machineStopBreakPoint;
+    private bool disposedValue;
 
     public MachineBreakpoints(Machine machine) {
         _state = machine.Cpu.State;
@@ -25,7 +26,7 @@ public class MachineBreakpoints {
         PauseHandler.WaitIfPaused();
     }
 
-    public PauseHandler PauseHandler { get; private set; } = new();
+    public PauseHandler PauseHandler { get; } = new();
 
     public void OnMachineStop() {
         if (_machineStopBreakPoint is not null) {
@@ -60,5 +61,20 @@ public class MachineBreakpoints {
             long cycles = _state.Cycles;
             _cycleBreakPoints.TriggerMatchingBreakPoints(cycles);
         }
+    }
+
+    protected virtual void Dispose(bool disposing) {
+        if (!disposedValue) {
+            if (disposing) {
+                PauseHandler.Dispose();
+            }
+            disposedValue = true;
+        }
+    }
+
+    public void Dispose() {
+        // Do not change this code. Put cleanup code in 'Dispose(bool disposing)' method
+        Dispose(disposing: true);
+        GC.SuppressFinalize(this);
     }
 }

--- a/src/Spice86/Emulator/VM/PauseHandler.cs
+++ b/src/Spice86/Emulator/VM/PauseHandler.cs
@@ -17,6 +17,8 @@ public class PauseHandler {
 
     private readonly object _locked = new();
 
+    private readonly ManualResetEvent _manualResetEvent = new(true);
+
     public void RequestPause() {
         _pauseRequested = true;
         LogStatus($"{nameof(RequestPause)} finished");
@@ -25,10 +27,7 @@ public class PauseHandler {
     public void RequestPauseAndWait() {
         LogStatus($"{nameof(RequestPauseAndWait)} started");
         _pauseRequested = true;
-        while (!_paused) {
-            ;
-        }
-
+        _manualResetEvent.WaitOne(Timeout.Infinite);
         LogStatus($"{nameof(RequestPauseAndWait)} finished");
     }
 
@@ -36,6 +35,7 @@ public class PauseHandler {
         LogStatus($"{nameof(RequestResume)} started");
         _pauseRequested = false;
         lock (_locked) {
+            _manualResetEvent.Set();
             Monitor.PulseAll(this);
         }
 

--- a/src/Spice86/Emulator/VM/PauseHandler.cs
+++ b/src/Spice86/Emulator/VM/PauseHandler.cs
@@ -6,7 +6,7 @@ using Spice86.Emulator.Errors;
 
 using System.Threading;
 
-public class PauseHandler {
+public class PauseHandler : IDisposable {
     private static readonly ILogger _logger = Program.Logger.ForContext<PauseHandler>();
 
     private volatile bool _paused;
@@ -14,7 +14,7 @@ public class PauseHandler {
     private volatile bool _pauseEnded;
 
     private volatile bool _pauseRequested;
-
+    private bool disposedValue;
     private readonly object _locked = new();
 
     private readonly ManualResetEvent _manualResetEvent = new(true);
@@ -69,5 +69,20 @@ public class PauseHandler {
         if (_logger.IsEnabled(Serilog.Events.LogEventLevel.Debug)) {
             _logger.Debug("{@Message}: {@PauseRequested},{@Paused},{@PauseEnded}", message, _pauseRequested, _paused, _pauseEnded);
         }
+    }
+
+    protected virtual void Dispose(bool disposing) {
+        if (!disposedValue) {
+            if (disposing) {
+                _manualResetEvent.Dispose();
+            }
+            disposedValue = true;
+        }
+    }
+
+    public void Dispose() {
+        // Do not change this code. Put cleanup code in 'Dispose(bool disposing)' method
+        Dispose(disposing: true);
+        GC.SuppressFinalize(this);
     }
 }

--- a/src/Spice86/Emulator/VM/PauseHandler.cs
+++ b/src/Spice86/Emulator/VM/PauseHandler.cs
@@ -15,6 +15,8 @@ public class PauseHandler {
 
     private volatile bool _pauseRequested;
 
+    private readonly object _locked = new();
+
     public void RequestPause() {
         _pauseRequested = true;
         LogStatus($"{nameof(RequestPause)} finished");
@@ -33,7 +35,7 @@ public class PauseHandler {
     public void RequestResume() {
         LogStatus($"{nameof(RequestResume)} started");
         _pauseRequested = false;
-        lock (this) {
+        lock (_locked) {
             Monitor.PulseAll(this);
         }
 
@@ -54,7 +56,7 @@ public class PauseHandler {
 
     private void Await() {
         try {
-            lock (this) {
+            lock (_locked) {
                 Monitor.Wait(this);
             }
         } catch (ThreadInterruptedException exception) {

--- a/src/Spice86/UI/ViewModels/MainWindowViewModel.cs
+++ b/src/Spice86/UI/ViewModels/MainWindowViewModel.cs
@@ -267,6 +267,7 @@ public partial class MainWindowViewModel : ObservableObject, IDisposable {
             if (disposing) {
                 DisposeBuffers();
                 _programExecutor?.Dispose();
+                _okayToContinueEvent.Dispose();
             }
             _disposedValue = true;
         }

--- a/src/Spice86/UI/ViewModels/MainWindowViewModel.cs
+++ b/src/Spice86/UI/ViewModels/MainWindowViewModel.cs
@@ -300,6 +300,6 @@ public partial class MainWindowViewModel : ObservableObject, IDisposable {
     }
 
     public void WaitOne() {
-        _okayToContinueEvent.WaitOne();
+        _okayToContinueEvent.WaitOne(Timeout.Infinite);
     }
 }


### PR DESCRIPTION
* Fixes ManualResetEvents not being disposed (possible resource leaks)
* PauseHandler uses a ManualResetEvent to pause/resume the running thread instead of a while loop and Monitor + lock.
* GdbServer uses a named Thread instead of a BackgroundWorker (less code, more easily debuggable)
* More logs on what is sent to GDB

Tested agaisnt master and the java version successfully :

- gdb startup
- -continue command
- gdb breakpoint from the Pause button from Spice86