### PR TITLE
Fix keyboard interrupt handlers not being able to get keyboard interrupts nor the keyboard buffer

### DIFF
--- a/src/Spice86.Core/Emulator/Callback/IndexBasedDispatcher.cs
+++ b/src/Spice86.Core/Emulator/Callback/IndexBasedDispatcher.cs
@@ -23,7 +23,7 @@ public abstract class IndexBasedDispatcher {
     }
 
     private ICallback GetCallback(int index) {
-        if (_dispatchTable.TryGetValue(index, out ICallback? handler) == false) {
+        if (!_dispatchTable.TryGetValue(index, out ICallback? handler)) {
             throw GenerateUnhandledOperationException(index);
         }
         return handler;

--- a/src/Spice86.Core/Emulator/Devices/Video/VgaCard.cs
+++ b/src/Spice86.Core/Emulator/Devices/Video/VgaCard.cs
@@ -167,9 +167,7 @@ public class VgaCard : DefaultIOPortHandler {
         if (mode == MODE_320_200_256) {
             const int videoHeight = 200;
             const int videoWidth = 320;
-            if (_gui != null) {
-                _gui.SetResolution(videoWidth, videoHeight, MemoryUtils.ToPhysicalAddress(MemoryMap.GraphicVideoMemorySegment, 0));
-            }
+            _gui?.SetResolution(videoWidth, videoHeight, MemoryUtils.ToPhysicalAddress(MemoryMap.GraphicVideoMemorySegment, 0));
         } else {
             if (_logger.IsEnabled(Serilog.Events.LogEventLevel.Error)) {
                 _logger.Error("UNSUPPORTED VIDEO MODE {@VideMode}", mode);
@@ -182,9 +180,5 @@ public class VgaCard : DefaultIOPortHandler {
         _crtStatusRegister = StatusRegisterRetraceInactive;
     }
 
-    public void UpdateScreen() {
-        if (_gui != null) {
-            _gui.Draw(_memory.Ram, VgaDac.Rgbs);
-        }
-    }
+    public void UpdateScreen() => _gui?.Draw(_memory.Ram, VgaDac.Rgbs);
 }

--- a/src/Spice86.Core/Emulator/InterruptHandlers/Input/Keyboard/BiosKeyboardBuffer.cs
+++ b/src/Spice86.Core/Emulator/InterruptHandlers/Input/Keyboard/BiosKeyboardBuffer.cs
@@ -39,6 +39,15 @@ public class BiosKeyboardBuffer : MemoryBasedDataStructureWithBaseAddress {
 
     public ushort HeadAddress { get => GetUint16(Head); set => SetUint16(Head, value); }
 
+    public ushort? GetKeyCodeStatus() {
+        ushort head = HeadAddress;
+        if (IsEmpty) {
+            return null;
+        }
+
+        return GetUint16(head);
+    }
+
     public ushort? GetKeyCode() {
         ushort head = HeadAddress;
         if (IsEmpty) {

--- a/src/Spice86.Core/Emulator/InterruptHandlers/Input/Keyboard/BiosKeyboardInt9Handler.cs
+++ b/src/Spice86.Core/Emulator/InterruptHandlers/Input/Keyboard/BiosKeyboardInt9Handler.cs
@@ -1,40 +1,45 @@
 ﻿namespace Spice86.Core.Emulator.InterruptHandlers.Input.Keyboard;
 
+using Serilog;
+
 using Spice86.Core.Emulator.Devices.Input.Keyboard;
 using Spice86.Core.Emulator.InterruptHandlers;
 using Spice86.Core.Emulator.VM;
+using Spice86.Logging;
 using Spice86.Shared.Interfaces;
 
 /// <summary>
 /// Crude implementation of Int9
 /// </summary>
 public class BiosKeyboardInt9Handler : InterruptHandler {
-    private readonly BiosKeyboardBuffer _biosKeyboardBuffer;
+    private readonly ILogger _logger = Serilogger.Logger.ForContext<BiosKeyboardInt9Handler>();
+
     private readonly Keyboard _keyboard;
     private readonly IKeyScanCodeConverter? _keyScanCodeConverter;
 
     public BiosKeyboardInt9Handler(Machine machine, IKeyScanCodeConverter? keyScanCodeConverter) : base(machine) {
         _keyboard = machine.Keyboard;
         _keyScanCodeConverter = keyScanCodeConverter;
-        _biosKeyboardBuffer = new BiosKeyboardBuffer(machine.Memory);
-        _biosKeyboardBuffer.Init();
+        BiosKeyboardBuffer = new BiosKeyboardBuffer(machine.Memory);
+        BiosKeyboardBuffer.Init();
     }
 
-    public BiosKeyboardBuffer BiosKeyboardBuffer => _biosKeyboardBuffer;
+    public BiosKeyboardBuffer BiosKeyboardBuffer { get; }
 
     public override byte Index => 0x9;
 
     public override void Run() {
         byte? scancode = _keyboard.GetScanCode();
-        if (scancode == null) {
+        if (scancode is null) {
             return;
         }
 
-        byte? ascii = _keyScanCodeConverter?.GetAsciiCode(scancode.Value);
-        if (ascii == null) {
-            ascii = 0;
+        byte ascii = (_keyScanCodeConverter?.GetAsciiCode(scancode.Value)) ?? 0;
+
+        if(_logger.IsEnabled(Serilog.Events.LogEventLevel.Information)) {
+            _logger.Information("{@BiosInt9KeyReceived}", ascii);
         }
 
-        _biosKeyboardBuffer.AddKeyCode((ushort)(scancode.Value << 8 | ascii.Value));
+        BiosKeyboardBuffer.AddKeyCode((ushort)(scancode.Value << 8 | ascii));
     }
 }

--- a/src/Spice86.Core/Emulator/InterruptHandlers/Input/Keyboard/KeyboardInt16Handler.cs
+++ b/src/Spice86.Core/Emulator/InterruptHandlers/Input/Keyboard/KeyboardInt16Handler.cs
@@ -46,7 +46,7 @@ public class KeyboardInt16Handler : InterruptHandler {
             SetZeroFlag(true, calledFromVm);
             _state.AX = 0;
         } else {
-            ushort? keyCode = _biosKeyboardBuffer.GetKeyCode();
+            ushort? keyCode = _biosKeyboardBuffer.GetKeyCodeStatus();
             if (keyCode != null) {
                 SetZeroFlag(false, calledFromVm);
                 _state.AX = keyCode.Value;

--- a/src/Spice86.Core/Emulator/LoadableFile/Dos/Com/ComLoader.cs
+++ b/src/Spice86.Core/Emulator/LoadableFile/Dos/Com/ComLoader.cs
@@ -24,6 +24,7 @@ public class ComLoader : ExecutableFileLoader {
         state.DS = _startSegment;
         state.ES = _startSegment;
         SetEntryPoint(_startSegment, ComOffset);
+        state.InterruptFlag = true;
         return com;
     }
 }

--- a/src/Spice86.Core/Emulator/LoadableFile/Dos/Exe/ExeLoader.cs
+++ b/src/Spice86.Core/Emulator/LoadableFile/Dos/Exe/ExeLoader.cs
@@ -65,6 +65,8 @@ public class ExeLoader : ExecutableFileLoader {
         state.DS = pspSegment;
         state.ES = pspSegment;
 
+        state.InterruptFlag = true;
+
         // Finally, MS-DOS reads the initial CS and IP values from the program's file
         // header, adjusts the CS register value by adding the start-segment address to
         // it, and transfers control to the program at the adjusted address.

--- a/src/Spice86.Core/Emulator/ReverseEngineer/CSharpOverrideHelper.cs
+++ b/src/Spice86.Core/Emulator/ReverseEngineer/CSharpOverrideHelper.cs
@@ -67,7 +67,6 @@ public class CSharpOverrideHelper {
 
     public ushort IP { get => State.IP; set => State.IP = value; }
 
-
     public bool AuxiliaryFlag { get => State.AuxiliaryFlag; set => State.AuxiliaryFlag = value; }
     public bool CarryFlag { get => State.CarryFlag; set => State.CarryFlag = value; }
     public bool DirectionFlag { get => State.DirectionFlag; set => State.DirectionFlag = value; }
@@ -123,7 +122,7 @@ public class CSharpOverrideHelper {
             FunctionInformation? parsedFunctionInformation = GhidraSymbolsDumper.NameToFunctionInformation(methodName);
             if (parsedFunctionInformation == null) {
                 throw new UnrecoverableException("Cannot parse " + methodName +
-                                                 " into a spice86 function name as format is not correct.");
+                    " into a spice86 function name as format is not correct.");
             }
 
             functionName = parsedFunctionInformation.Name;
@@ -221,6 +220,7 @@ public class CSharpOverrideHelper {
     public void InterruptCall(ushort expectedReturnCs, ushort expectedReturnIp, Func<int, Action> function) {
         ExecuteCallEnsuringSameStack(expectedReturnCs, expectedReturnIp, function, () => {
             Stack.Push16(State.Flags.FlagRegister16);
+            InterruptFlag = false;
             Stack.Push16(expectedReturnCs);
             Stack.Push16(expectedReturnIp);
             Action returnAction = function.Invoke(0);
@@ -259,8 +259,8 @@ public class CSharpOverrideHelper {
         ushort actualReturnIp = State.IP;
         uint actualStackAddress = State.StackPhysicalAddress;
         // Do not return to the caller until we are sure we are at the right place
-        while (actualReturnCs != expectedReturnCs ||
-               actualReturnIp != expectedReturnIp) {
+        while ( actualReturnCs != expectedReturnCs ||
+                actualReturnIp != expectedReturnIp) {
             SegmentedAddress expectedReturn = new SegmentedAddress(expectedReturnCs, expectedReturnIp);
             SegmentedAddress actualReturn = new SegmentedAddress(actualReturnCs, actualReturnIp);
             string message =

--- a/src/Spice86.Core/Emulator/ReverseEngineer/CSharpOverrideHelper.cs
+++ b/src/Spice86.Core/Emulator/ReverseEngineer/CSharpOverrideHelper.cs
@@ -109,7 +109,7 @@ public class CSharpOverrideHelper {
         string? name = null) {
         SegmentedAddress address = new(segment, offset);
         FunctionInformation? existing = GetFunctionAtAddress(failOnExisting, address);
-        if (existing != null && existing.HasOverride) {
+        if (existing?.HasOverride is true) {
             // Do not overwrite existing code with override
             return;
         }
@@ -233,7 +233,7 @@ public class CSharpOverrideHelper {
         ushort targetCS = Memory.GetUint16((ushort)(4 * vectorNumber + 2));
         SegmentedAddress target = new SegmentedAddress(targetCS, targetIP);
         Func<int, Action>? function = SearchFunctionOverride(target);
-        if (function == null) {
+        if (function is null) {
             throw FailAsUntested($"Could not find an override at address {target}");
         }
 
@@ -404,11 +404,7 @@ public class CSharpOverrideHelper {
         Machine.CallbackHandler.RunFromOverriden(vectorNumber);
     }
 
-    public Action Hlt() {
-        return () => {
-            Exit();
-        };
-    }
+    public Action Hlt() => () => Exit();
 
     protected void Exit() {
         _logger.Information("Program requested exit. Terminating now.");

--- a/src/Spice86.Core/Emulator/VM/Machine.cs
+++ b/src/Spice86.Core/Emulator/VM/Machine.cs
@@ -252,12 +252,12 @@ public class Machine : IDisposable {
             RunLoop();
         } catch (InvalidVMOperationException e) {
             e.Demystify();
-            if(System.Diagnostics.Debugger.IsAttached) {
+            if(Debugger.IsAttached) {
                 System.Diagnostics.Debugger.Break();
             }
             throw;
         } catch (Exception e) {
-            if(System.Diagnostics.Debugger.IsAttached) {
+            if(Debugger.IsAttached) {
                 System.Diagnostics.Debugger.Break();
             }
             e.Demystify();

--- a/src/Spice86.Shared/Interfaces/IKeyScanCodeConverter.cs
+++ b/src/Spice86.Shared/Interfaces/IKeyScanCodeConverter.cs
@@ -1,6 +1,5 @@
 ﻿namespace Spice86.Shared.Interfaces;
 public interface IKeyScanCodeConverter {
-
     public byte? GetAsciiCode(byte scancode);
 
     public byte? GetKeyPressedScancode(KeyboardInput keyCode);


### PR DESCRIPTION
Fixes #187 

Tested:
LOGO (emulated)
LOGO (overriden)
Dune (intro, keyboard driven cursor movements)

This totally breaks Prince of Persia (flames, swords, movements), so this is only a draft.