### PR TITLE
Allow specifying a custom interrupt handler location

### DIFF
--- a/src/Spice86.Core/Emulator/Callback/Callback.cs
+++ b/src/Spice86.Core/Emulator/Callback/Callback.cs
@@ -12,6 +12,9 @@ public class Callback : ICallback {
 
     public byte Index { get; private set; }
 
+    /// <inheritdoc />
+    public ushort? InterruptHandlerSegment => null;
+
     public void Run() {
         _runnable.Invoke();
     }

--- a/src/Spice86.Core/Emulator/Callback/CallbackHandler.cs
+++ b/src/Spice86.Core/Emulator/Callback/CallbackHandler.cs
@@ -65,7 +65,12 @@ public class CallbackHandler : IndexBasedDispatcher {
     }
 
     private void InstallCallbackInInterruptTable(ICallback callback) {
-        _offset += InstallInterruptWithCallback(callback.Index, _callbackHandlerSegment, _offset);
+        // Use either the provided segment or the default one.
+        if (callback.InterruptHandlerSegment.HasValue) {
+            InstallInterruptWithCallback(callback.Index, callback.InterruptHandlerSegment.Value, 0x0000);
+        } else {
+            _offset += InstallInterruptWithCallback(callback.Index, _callbackHandlerSegment, _offset);
+        }
     }
 
     private ushort InstallInterruptWithCallback(byte vectorNumber, ushort segment, ushort offset) {

--- a/src/Spice86.Core/Emulator/Callback/ICallback.cs
+++ b/src/Spice86.Core/Emulator/Callback/ICallback.cs
@@ -1,5 +1,11 @@
 ﻿namespace Spice86.Core.Emulator.Callback;
 public interface ICallback : IRunnable {
     public byte Index { get; }
+    /// <summary>
+    /// Optional segment where the interrupt handler is installed, if null the default interrupt location is used.
+    /// This is useful for device drivers which are expected to have their Device Driver Header at the start of
+    /// the segment where the interrupt handler is installed.
+    /// </summary>
+    ushort? InterruptHandlerSegment { get; }
     public void RunFromOverriden();
 }

--- a/src/Spice86.Core/Emulator/InterruptHandlers/InterruptHandler.cs
+++ b/src/Spice86.Core/Emulator/InterruptHandlers/InterruptHandler.cs
@@ -29,6 +29,9 @@ public abstract class InterruptHandler : IndexBasedDispatcher, ICallback {
 
     public abstract void Run();
 
+    /// <inheritdoc />
+    public virtual ushort? InterruptHandlerSegment => null;
+
     protected override UnhandledOperationException GenerateUnhandledOperationException(int index) {
         return new UnhandledInterruptException(_machine, Index, index);
     }


### PR DESCRIPTION
Allow device drivers to specify a custom memory location for their interrupt handler stub.

This is useful because by convention the Device Driver Header is installed at offset 0 of the same segment. 
For instance if a program wants to know if an EMS driver is installed it can call INT 21 35 to get the location of the INT 67 handler and then check offset 0xA of the returned segment to get the name of the driver.

See: https://www.lo-tech.co.uk/wiki/LIM_Expanded_Memory_Specification_V4:_Appendix_B