### PR TITLE
Initial prefix 67 support

### DIFF
--- a/src/Spice86.Core/Emulator/CPU/CPU.cs
+++ b/src/Spice86.Core/Emulator/CPU/CPU.cs
@@ -41,19 +41,11 @@ public class Cpu {
     private readonly Instructions16 _instructions16;
     private readonly Instructions32 _instructions32;
     private Instructions16Or32 _instructions16Or32;
-    private int _addressSize;
 
     /// <summary>
     /// Address size for the currently executing instruction.
     /// </summary>
-    public int AddressSize {
-        get => _addressSize;
-        private set {
-            if (value != 16 && value != 32)
-                throw new ArgumentOutOfRangeException(nameof(value), "Address size must be 16 or 32");
-            _addressSize = value;
-        }
-    }
+    public int AddressSize { get; private set; }
 
     public CallbackHandler? CallbackHandler { get; set; }
 

--- a/src/Spice86.Core/Emulator/CPU/Exceptions/CpuGeneralProtectionFaultException.cs
+++ b/src/Spice86.Core/Emulator/CPU/Exceptions/CpuGeneralProtectionFaultException.cs
@@ -1,0 +1,17 @@
+namespace Spice86.Core.Emulator.CPU.Exceptions;
+
+/// <summary>
+/// A General Protection Fault may occur for various reasons. The most common are:
+///   - Segment error (privilege, type, limit, read/write rights).
+///   - Executing a privileged instruction while CPL != 0.
+///   - Writing a 1 in a reserved register field or writing invalid value combinations (e.g. CR0 with PE=0 and PG=1).
+///   - Referencing or accessing a null-descriptor. 
+/// The saved instruction pointer points to the instruction which caused the exception.
+/// Error code: The General Protection Fault sets an error code, which is the segment selector index when the exception
+/// is segment related. Otherwise, 0. 
+/// </summary>
+public class CpuGeneralProtectionFaultException : CpuException {
+    public CpuGeneralProtectionFaultException(string message, ushort errorCode = 0)
+        : base(message, 0x0D, CpuExceptionType.Fault, "#GP", errorCode) {
+    }
+}


### PR DESCRIPTION
This introduces opcode prefix 67 (address size) support, including the decoding of the SIB byte.

This supersedes PR #262 

To keep the PR small I have not yet identified and adjusted all the places where this should be used. I want to get a stable implementation base in first.
