### PR TITLE
Video memory access crash prevention

### DIFF
--- a/src/Spice86.Core/Emulator/Devices/Video/AeonCard.cs
+++ b/src/Spice86.Core/Emulator/Devices/Video/AeonCard.cs
@@ -752,7 +752,7 @@ public class AeonCard : DefaultIOPortHandler, IVideoCard, IAeonVgaCard, IDisposa
 
         _loggerService.Information("Video mode changed to {@Mode}", mode.GetType().Name);
         _presenter = GetPresenter();
-        VideoModeChanged?.Invoke(this, new VideoModeChangedEventArgs(true));
+        _gui?.SetResolution(CurrentMode.PixelWidth, CurrentMode.PixelHeight, MemoryUtils.ToPhysicalAddress(MemoryMap.GraphicVideoMemorySegment, 0));
     }
 
     public Presenter GetPresenter() {
@@ -797,7 +797,8 @@ public class AeonCard : DefaultIOPortHandler, IVideoCard, IAeonVgaCard, IDisposa
         var mode = new Unchained256(320, 200, this);
         CrtController.Offset = 320 / 8;
         CurrentMode = mode;
-        VideoModeChanged?.Invoke(this, new VideoModeChangedEventArgs(false));
+        _presenter = GetPresenter();
+        _gui?.SetResolution(CurrentMode.PixelWidth, CurrentMode.PixelHeight, MemoryUtils.ToPhysicalAddress(MemoryMap.GraphicVideoMemorySegment, 0));
     }
 
 }

--- a/src/Spice86/ViewModels/VideoBufferViewModel.cs
+++ b/src/Spice86/ViewModels/VideoBufferViewModel.cs
@@ -54,6 +54,7 @@ public sealed partial class VideoBufferViewModel : ObservableObject, IVideoBuffe
         Scale = scale;
         MainWindow.AppClosing += MainWindow_AppClosing;
         _frameRenderTimeWatch = new Stopwatch();
+        _bitmap = new WriteableBitmap(new PixelSize(width, height), new Vector(96, 96), PixelFormat.Bgra8888, AlphaFormat.Opaque);
     }
 
     private void DrawThreadMethod() {
@@ -103,7 +104,7 @@ public sealed partial class VideoBufferViewModel : ObservableObject, IVideoBuffe
     /// that's why it's used to bind the Source property of the Image control in VideoBufferView.xaml<br/>
     /// </summary>
     [ObservableProperty]
-    private WriteableBitmap? _bitmap = new(new PixelSize(320, 200), new Vector(96, 96), PixelFormat.Bgra8888, AlphaFormat.Opaque);
+    private WriteableBitmap? _bitmap;
 
     private bool _showCursor = true;
 


### PR DESCRIPTION
Make sure we have the right bitmap, memory and presenter. This should avoid a number of illegal memory access crashes.
