### PR TITLE
Fix/performance

### DIFF
--- a/src/Spice86.Aeon/Emulator/Video/Rendering/GraphicsPresenter2.cs
+++ b/src/Spice86.Aeon/Emulator/Video/Rendering/GraphicsPresenter2.cs
@@ -5,7 +5,6 @@ namespace Spice86.Aeon.Emulator.Video.Rendering
         /// <summary>
         /// Initializes a new instance of the <see cref="GraphicsPresenter2"/> class.
         /// </summary>
-        /// <param name="dest">Pointer to destination bitmap.</param>
         /// <param name="videoMode">VideoMode instance describing the video mode.</param>
         public GraphicsPresenter2(VideoMode videoMode) : base(videoMode)
         {

--- a/src/Spice86.Core/CLI/CommandLineParser.cs
+++ b/src/Spice86.Core/CLI/CommandLineParser.cs
@@ -7,8 +7,9 @@ using Serilog.Events;
 
 using Spice86.Core.Emulator.Errors;
 using Spice86.Core.Emulator.Function;
-using Spice86.Core.Utils;
 using Spice86.Logging;
+using Spice86.Shared.Emulator.Errors;
+using Spice86.Shared.Utils;
 
 using System;
 using System.Diagnostics;

--- a/src/Spice86.Core/Emulator/CPU/CPU.cs
+++ b/src/Spice86.Core/Emulator/CPU/CPU.cs
@@ -1,4 +1,6 @@
-﻿using Serilog.Events;
+﻿namespace Spice86.Core.Emulator.CPU;
+
+using Serilog.Events;
 
 using Spice86.Core.Emulator.Callback;
 using Spice86.Core.Emulator.CPU.Exceptions;
@@ -10,10 +12,6 @@ using Spice86.Core.Emulator.Memory;
 using Spice86.Core.Emulator.VM;
 using Spice86.Core.Utils;
 using Spice86.Shared.Interfaces;
-
-namespace Spice86.Core.Emulator.CPU;
-
-using Serilog.Context;
 
 /// <summary>
 /// Implementation of a 8086 CPU. <br /> It has some 80186, 80286 and 80386 instructions as some
@@ -34,7 +32,7 @@ public class Cpu {
         { 0xA4, 0xA5, 0xA6, 0xA7, 0xAA, 0xAB, 0xAC, 0xAD, 0xAE, 0xAF, 0x6C, 0x6D, 0x6E, 0x6F };
 
     private readonly Machine _machine;
-    private readonly Memory.Memory _memory;
+    private readonly Memory _memory;
     private readonly ModRM _modRM;
     private readonly Instructions8 _instructions8;
     private readonly Instructions16 _instructions16;

--- a/src/Spice86.Core/Emulator/CPU/CPU.cs
+++ b/src/Spice86.Core/Emulator/CPU/CPU.cs
@@ -81,6 +81,10 @@ public class Cpu {
 
     public void ExecuteNextInstruction() {
         _internalIp = State.IP;
+        
+        _loggerService.LoggerPropertyBag.CodeSegment = State.CS;
+        _loggerService.LoggerPropertyBag.InstructionPointer = State.IP;
+
         ExecutionFlowRecorder.RegisterExecutedInstruction(State.CS, _internalIp);
         byte opcode = ProcessPrefixes();
         if (State.ContinueZeroFlagValue != null && IsStringOpcode(opcode)) {
@@ -102,13 +106,6 @@ public class Cpu {
         State.IncCycles();
         HandleExternalInterrupt();
         State.IP = _internalIp;
-        
-        // Keep reporting last seen user-mode address when we're in BIOS code.
-        if (State.CS >= 0xF000) {
-            return;
-        }
-        _loggerService.LoggerPropertyBag.CodeSegment = State.CS;
-        _loggerService.LoggerPropertyBag.InstructionPointer = State.IP;
     }
 
     public void ExternalInterrupt(byte vectorNumber) {

--- a/src/Spice86.Core/Emulator/CPU/CPU.cs
+++ b/src/Spice86.Core/Emulator/CPU/CPU.cs
@@ -10,8 +10,9 @@ using Spice86.Core.Emulator.Function;
 using Spice86.Core.Emulator.IOPorts;
 using Spice86.Core.Emulator.Memory;
 using Spice86.Core.Emulator.VM;
-using Spice86.Core.Utils;
+using Spice86.Shared;
 using Spice86.Shared.Interfaces;
+using Spice86.Shared.Utils;
 
 /// <summary>
 /// Implementation of a 8086 CPU. <br /> It has some 80186, 80286 and 80386 instructions as some
@@ -81,9 +82,9 @@ public class Cpu {
 
     public void ExecuteNextInstruction() {
         _internalIp = State.IP;
-        
-        _loggerService.LoggerPropertyBag.CodeSegment = State.CS;
-        _loggerService.LoggerPropertyBag.InstructionPointer = State.IP;
+
+        _loggerService.LoggerPropertyBag.CsIp.Segment = State.CS;
+        _loggerService.LoggerPropertyBag.CsIp.Offset = State.IP;
 
         ExecutionFlowRecorder.RegisterExecutedInstruction(State.CS, _internalIp);
         byte opcode = ProcessPrefixes();

--- a/src/Spice86.Core/Emulator/CPU/InstructionsImpl/Instructions.cs
+++ b/src/Spice86.Core/Emulator/CPU/InstructionsImpl/Instructions.cs
@@ -4,6 +4,8 @@ using Spice86.Core.Emulator.VM;
 
 namespace Spice86.Core.Emulator.CPU.InstructionsImpl;
 
+using Spice86.Shared.Utils;
+
 public abstract class Instructions {
     protected readonly Machine Machine;
     protected readonly Alu Alu;

--- a/src/Spice86.Core/Emulator/CPU/InvalidGroupIndexException.cs
+++ b/src/Spice86.Core/Emulator/CPU/InvalidGroupIndexException.cs
@@ -2,7 +2,7 @@
 
 using Spice86.Core.Emulator.Errors;
 using Spice86.Core.Emulator.VM;
-using Spice86.Core.Utils;
+using Spice86.Shared.Utils;
 
 using System;
 

--- a/src/Spice86.Core/Emulator/CPU/InvalidModeException.cs
+++ b/src/Spice86.Core/Emulator/CPU/InvalidModeException.cs
@@ -2,7 +2,7 @@
 
 using Spice86.Core.Emulator.Errors;
 using Spice86.Core.Emulator.VM;
-using Spice86.Core.Utils;
+using Spice86.Shared.Utils;
 
 using System;
 

--- a/src/Spice86.Core/Emulator/CPU/InvalidOpCodeException.cs
+++ b/src/Spice86.Core/Emulator/CPU/InvalidOpCodeException.cs
@@ -2,7 +2,7 @@
 
 using Spice86.Core.Emulator.Errors;
 using Spice86.Core.Emulator.VM;
-using Spice86.Core.Utils;
+using Spice86.Shared.Utils;
 
 using System;
 

--- a/src/Spice86.Core/Emulator/CPU/ModRM.cs
+++ b/src/Spice86.Core/Emulator/CPU/ModRM.cs
@@ -4,6 +4,8 @@ using Spice86.Core.Emulator.VM;
 
 namespace Spice86.Core.Emulator.CPU;
 
+using Spice86.Shared.Utils;
+
 public class ModRM {
     private readonly Cpu _cpu;
     private readonly Machine _machine;

--- a/src/Spice86.Core/Emulator/CPU/RegistersHolder.cs
+++ b/src/Spice86.Core/Emulator/CPU/RegistersHolder.cs
@@ -1,6 +1,6 @@
 ﻿namespace Spice86.Core.Emulator.CPU;
 
-using Spice86.Core.Utils;
+using Spice86.Shared.Utils;
 
 using System;
 using System.Collections.Generic;

--- a/src/Spice86.Core/Emulator/CPU/State.cs
+++ b/src/Spice86.Core/Emulator/CPU/State.cs
@@ -1,9 +1,10 @@
 ﻿using Spice86.Core.Emulator.Memory;
-using Spice86.Core.Utils;
 
 using System.Text;
 
 namespace Spice86.Core.Emulator.CPU;
+
+using Spice86.Shared.Utils;
 
 public class State {
     // Accumulator

--- a/src/Spice86.Core/Emulator/Callback/CallbackHandler.cs
+++ b/src/Spice86.Core/Emulator/Callback/CallbackHandler.cs
@@ -6,6 +6,9 @@ using System.Collections.Generic;
 using Spice86.Core.Emulator.Errors;
 using Spice86.Core.Emulator.Memory;
 using Spice86.Core.Emulator.VM;
+using Spice86.Shared;
+using Spice86.Shared.Interfaces;
+using Spice86.Shared.Utils;
 
 public class CallbackHandler : IndexBasedDispatcher {
     private const ushort CallbackSize = 4;
@@ -23,7 +26,7 @@ public class CallbackHandler : IndexBasedDispatcher {
 
     private readonly Memory _memory;
 
-    public CallbackHandler(Machine machine, ushort interruptHandlerSegment) {
+    public CallbackHandler(Machine machine, ILoggerService loggerService, ushort interruptHandlerSegment) : base(machine, loggerService) {
         _machine = machine;
         _memory = machine.Memory;
         _callbackHandlerSegment = interruptHandlerSegment;

--- a/src/Spice86.Core/Emulator/Devices/ExternalInput/DualPic.cs
+++ b/src/Spice86.Core/Emulator/Devices/ExternalInput/DualPic.cs
@@ -5,6 +5,7 @@ namespace Spice86.Core.Emulator.Devices.ExternalInput;
 using Spice86.Core.Emulator.Errors;
 using Spice86.Core.Emulator.IOPorts;
 using Spice86.Core.Emulator.VM;
+using Spice86.Shared.Emulator.Errors;
 
 public class DualPic : DefaultIOPortHandler {
     private const int MasterCommand = 0x20;

--- a/src/Spice86.Core/Emulator/Devices/ExternalInput/Pic.cs
+++ b/src/Spice86.Core/Emulator/Devices/ExternalInput/Pic.cs
@@ -7,7 +7,8 @@ using Serilog;
 
 using Spice86.Core.Emulator.Errors;
 using Spice86.Core.Emulator.VM;
-using Spice86.Core.Utils;
+using Spice86.Shared.Emulator.Errors;
+using Spice86.Shared.Utils;
 
 /// <summary>
 /// Emulates a PIC8259 Programmable Interrupt Controller.<br/>

--- a/src/Spice86.Core/Emulator/Devices/Input/Keyboard/Keyboard.cs
+++ b/src/Spice86.Core/Emulator/Devices/Input/Keyboard/Keyboard.cs
@@ -7,6 +7,7 @@ using Serilog;
 using Spice86.Core.Emulator.IOPorts;
 using Spice86.Core.Emulator.VM;
 using Spice86.Shared;
+using Spice86.Shared.Emulator.Keyboard;
 using Spice86.Shared.Interfaces;
 
 /// <summary>

--- a/src/Spice86.Core/Emulator/Devices/Sound/PcSpeaker.cs
+++ b/src/Spice86.Core/Emulator/Devices/Sound/PcSpeaker.cs
@@ -8,7 +8,7 @@ using Serilog;
 using Spice86.Core.Emulator.IOPorts;
 using Spice86.Core.Emulator.Sound.PCSpeaker;
 using Spice86.Core.Emulator.VM;
-using Spice86.Core.Utils;
+using Spice86.Shared.Utils;
 
 /// <summary>
 /// PC speaker implementation.

--- a/src/Spice86.Core/Emulator/Devices/Timer/Counter.cs
+++ b/src/Spice86.Core/Emulator/Devices/Timer/Counter.cs
@@ -7,7 +7,7 @@ using Serilog;
 
 using Spice86.Core.Emulator.Errors;
 using Spice86.Core.Emulator.VM;
-using Spice86.Core.Utils;
+using Spice86.Shared.Utils;
 
 public class Counter {
     public const long HardwareFrequency = 1193182;

--- a/src/Spice86.Core/Emulator/Devices/Video/AeonCard.cs
+++ b/src/Spice86.Core/Emulator/Devices/Video/AeonCard.cs
@@ -16,7 +16,9 @@ using Spice86.Core.Emulator.Devices.Video.Fonts;
 using Spice86.Core.Emulator.IOPorts;
 using Spice86.Core.Emulator.Memory;
 using Spice86.Core.Emulator.VM;
+using Spice86.Shared;
 using Spice86.Shared.Interfaces;
+using Spice86.Shared.Utils;
 
 using System.Linq;
 using System.Runtime.InteropServices;

--- a/src/Spice86.Core/Emulator/Function/Dump/ExecutionFlowDumper.cs
+++ b/src/Spice86.Core/Emulator/Function/Dump/ExecutionFlowDumper.cs
@@ -11,6 +11,7 @@ using Serilog.Events;
 
 using Spice86.Core.Emulator.Function;
 using Spice86.Logging;
+using Spice86.Shared.Emulator.Errors;
 
 using System;
 using System.Diagnostics;

--- a/src/Spice86.Core/Emulator/Function/Dump/GhidraSymbolsDumper.cs
+++ b/src/Spice86.Core/Emulator/Function/Dump/GhidraSymbolsDumper.cs
@@ -6,8 +6,9 @@ using Serilog.Events;
 
 using Spice86.Core.Emulator.Function;
 using Spice86.Core.Emulator.VM;
-using Spice86.Core.Utils;
+using Spice86.Shared;
 using Spice86.Shared.Interfaces;
+using Spice86.Shared.Utils;
 
 using System;
 using System.Collections.Generic;

--- a/src/Spice86.Core/Emulator/Function/Dump/RecordedDataReader.cs
+++ b/src/Spice86.Core/Emulator/Function/Dump/RecordedDataReader.cs
@@ -4,6 +4,7 @@ using Spice86.Shared.Interfaces;
 using Memory;
 
 using Spice86.Core.Emulator.Function;
+using Spice86.Shared;
 
 public class RecordedDataReader : RecordedDataIoHandler {
     private readonly ILoggerService _loggerService;

--- a/src/Spice86.Core/Emulator/Function/ExecutionFlowRecorder.cs
+++ b/src/Spice86.Core/Emulator/Function/ExecutionFlowRecorder.cs
@@ -8,6 +8,9 @@ namespace Spice86.Core.Emulator.Function;
 
 using Memory;
 
+using Spice86.Shared;
+using Spice86.Shared.Utils;
+
 using System.Collections.Generic;
 
 public class ExecutionFlowRecorder {

--- a/src/Spice86.Core/Emulator/Function/FunctionCall.cs
+++ b/src/Spice86.Core/Emulator/Function/FunctionCall.cs
@@ -1,6 +1,7 @@
 ﻿namespace Spice86.Core.Emulator.Function;
 
 using Spice86.Core.Emulator.Memory;
+using Spice86.Shared;
 
 public class FunctionCall {
     private readonly CallType _callType;

--- a/src/Spice86.Core/Emulator/Function/FunctionHandler.cs
+++ b/src/Spice86.Core/Emulator/Function/FunctionHandler.cs
@@ -10,8 +10,9 @@ using Spice86.Core.Emulator.CPU;
 
 using Spice86.Core.Emulator.Memory;
 using Spice86.Core.Emulator.VM;
-using Spice86.Core.Utils;
 using Spice86.Logging;
+using Spice86.Shared;
+using Spice86.Shared.Utils;
 
 using System;
 using System.Collections.Generic;

--- a/src/Spice86.Core/Emulator/Function/FunctionInformation.cs
+++ b/src/Spice86.Core/Emulator/Function/FunctionInformation.cs
@@ -1,6 +1,7 @@
 ﻿namespace Spice86.Core.Emulator.Function;
 using Spice86.Core.Emulator.Memory;
-using Spice86.Core.Utils;
+using Spice86.Shared;
+using Spice86.Shared.Utils;
 
 using System;
 using System.Collections.Generic;

--- a/src/Spice86.Core/Emulator/Function/FunctionReturn.cs
+++ b/src/Spice86.Core/Emulator/Function/FunctionReturn.cs
@@ -1,6 +1,7 @@
 ﻿namespace Spice86.Core.Emulator.Function;
 
 using Spice86.Core.Emulator.Memory;
+using Spice86.Shared;
 
 using System;
 

--- a/src/Spice86.Core/Emulator/Function/IOverrideSupplier.cs
+++ b/src/Spice86.Core/Emulator/Function/IOverrideSupplier.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 
 using Spice86.Core.Emulator.Memory;
 using Spice86.Core.Emulator.VM;
+using Spice86.Shared;
 
 public interface IOverrideSupplier {
     public Dictionary<SegmentedAddress, FunctionInformation> GenerateFunctionInformations(

--- a/src/Spice86.Core/Emulator/Gdb/GdbCommandBreakPointHandler.cs
+++ b/src/Spice86.Core/Emulator/Gdb/GdbCommandBreakPointHandler.cs
@@ -3,13 +3,14 @@ using Serilog.Events;
 
 using Spice86.Core.Emulator.VM;
 using Spice86.Core.Emulator.VM.Breakpoint;
-using Spice86.Core.Utils;
 using Spice86.Logging;
 using Spice86.Shared.Interfaces;
 
 using System.Diagnostics;
 
 namespace Spice86.Core.Emulator.Gdb;
+
+using Spice86.Shared.Utils;
 
 public class GdbCommandBreakpointHandler {
     private readonly ILoggerService _loggerService;

--- a/src/Spice86.Core/Emulator/Gdb/GdbCommandMemoryHandler.cs
+++ b/src/Spice86.Core/Emulator/Gdb/GdbCommandMemoryHandler.cs
@@ -7,7 +7,7 @@ using Serilog;
 
 using Spice86.Core.Emulator.Memory;
 using Spice86.Core.Emulator.VM;
-using Spice86.Core.Utils;
+using Spice86.Shared.Utils;
 
 using System;
 using System.Collections.Generic;

--- a/src/Spice86.Core/Emulator/Gdb/GdbCommandRegisterHandler.cs
+++ b/src/Spice86.Core/Emulator/Gdb/GdbCommandRegisterHandler.cs
@@ -7,7 +7,7 @@ using Serilog;
 
 using Spice86.Core.Emulator.CPU;
 using Spice86.Core.Emulator.VM;
-using Spice86.Core.Utils;
+using Spice86.Shared.Utils;
 
 using System;
 using System.Diagnostics;

--- a/src/Spice86.Core/Emulator/Gdb/GdbCustomCommandsHandler.cs
+++ b/src/Spice86.Core/Emulator/Gdb/GdbCustomCommandsHandler.cs
@@ -8,11 +8,13 @@ using Spice86.Core.Emulator.Function.Dump;
 using Spice86.Core.Emulator.Memory;
 using Spice86.Core.Emulator.VM;
 using Spice86.Core.Emulator.VM.Breakpoint;
-using Spice86.Core.Utils;
 using Spice86.Logging;
 using Spice86.Shared.Interfaces;
 
 using Serilog.Events;
+
+using Spice86.Shared.Utils;
+
 using System;
 using System.Diagnostics;
 using System.IO;

--- a/src/Spice86.Core/Emulator/Gdb/GdbFormatter.cs
+++ b/src/Spice86.Core/Emulator/Gdb/GdbFormatter.cs
@@ -1,6 +1,6 @@
 ﻿namespace Spice86.Core.Emulator.Gdb;
 
-using Spice86.Core.Utils;
+using Spice86.Shared.Utils;
 
 public class GdbFormatter {
     public string FormatValueAsHex32(uint value) {

--- a/src/Spice86.Core/Emulator/Gdb/GdbIo.cs
+++ b/src/Spice86.Core/Emulator/Gdb/GdbIo.cs
@@ -6,7 +6,7 @@ namespace Spice86.Core.Emulator.Gdb;
 using Serilog;
 using Serilog.Events;
 
-using Spice86.Core.Utils;
+using Spice86.Shared.Utils;
 
 using System;
 using System.Collections.Generic;

--- a/src/Spice86.Core/Emulator/IOPorts/UnhandledIOPortException.cs
+++ b/src/Spice86.Core/Emulator/IOPorts/UnhandledIOPortException.cs
@@ -4,7 +4,7 @@ using System;
 
 using Spice86.Core.Emulator.Errors;
 using Spice86.Core.Emulator.VM;
-using Spice86.Core.Utils;
+using Spice86.Shared.Utils;
 
 /// <summary> Thrown when an unhandled IO Port is accessed. </summary>
 [Serializable]

--- a/src/Spice86.Core/Emulator/InterruptHandlers/Bios/BiosEquipmentDeterminationInt11Handler.cs
+++ b/src/Spice86.Core/Emulator/InterruptHandlers/Bios/BiosEquipmentDeterminationInt11Handler.cs
@@ -2,12 +2,13 @@
 
 using Spice86.Core.Emulator.InterruptHandlers;
 using Spice86.Core.Emulator.VM;
+using Spice86.Shared.Interfaces;
 
 /// <summary>
 /// Very basic implementation of int 11 that basically does nothing.
 /// </summary>
 public class BiosEquipmentDeterminationInt11Handler : InterruptHandler {
-    public BiosEquipmentDeterminationInt11Handler(Machine machine) : base(machine) {
+    public BiosEquipmentDeterminationInt11Handler(Machine machine, ILoggerService loggerService) : base(machine, loggerService) {
     }
 
     public override byte Index => 0x11;

--- a/src/Spice86.Core/Emulator/InterruptHandlers/Bios/SystemBiosInt15Handler.cs
+++ b/src/Spice86.Core/Emulator/InterruptHandlers/Bios/SystemBiosInt15Handler.cs
@@ -3,15 +3,10 @@
 using Spice86.Core.Emulator.InterruptHandlers;
 using Spice86.Core.Emulator.VM;
 using Spice86.Core.Emulator.Callback;
-using Spice86.Core.Emulator.Function;
-using Spice86.Core.Emulator.Memory;
 using Spice86.Shared.Interfaces;
 
 public class SystemBiosInt15Handler : InterruptHandler {
-    private readonly ILoggerService _loggerService;
-    
-    public SystemBiosInt15Handler(Machine machine, ILoggerService loggerService) : base(machine) {
-        _loggerService = loggerService;
+    public SystemBiosInt15Handler(Machine machine, ILoggerService loggerService) : base(machine, loggerService) {
         FillDispatchTable();
     }
 
@@ -26,11 +21,6 @@ public class SystemBiosInt15Handler : InterruptHandler {
     public override byte Index => 0x15;
 
     public override void Run() {
-        SegmentedAddress? csIp = _machine.Cpu.FunctionHandlerInUse.PeekReturnAddressOnMachineStack(CallType.INTERRUPT);
-        if (csIp is not null) {
-            _loggerService.LoggerPropertyBag.CodeSegment = csIp.Segment;
-            _loggerService.LoggerPropertyBag.InstructionPointer = csIp.Offset;
-        }
         byte operation = _state.AH;
         Run(operation);
     }

--- a/src/Spice86.Core/Emulator/InterruptHandlers/Dos/DosInt20Handler.cs
+++ b/src/Spice86.Core/Emulator/InterruptHandlers/Dos/DosInt20Handler.cs
@@ -15,7 +15,7 @@ using Spice86.Logging;
 public class DosInt20Handler : InterruptHandler {
     private readonly ILoggerService _loggerService;
 
-    public DosInt20Handler(Machine machine, ILoggerService loggerService) : base(machine) {
+    public DosInt20Handler(Machine machine, ILoggerService loggerService) : base(machine, loggerService) {
         _loggerService = loggerService;
     }
 

--- a/src/Spice86.Core/Emulator/InterruptHandlers/Dos/DosInt21Handler.cs
+++ b/src/Spice86.Core/Emulator/InterruptHandlers/Dos/DosInt21Handler.cs
@@ -10,8 +10,8 @@ using Spice86.Core.Emulator.Memory;
 using Spice86.Core.Emulator.OperatingSystem.Devices;
 using Spice86.Core.Emulator.OperatingSystem.Structures;
 using Spice86.Core.Emulator.VM;
-using Spice86.Core.Utils;
 using Spice86.Shared.Interfaces;
+using Spice86.Shared.Utils;
 
 using System;
 using System.IO;
@@ -36,7 +36,7 @@ public class DosInt21Handler : InterruptHandler {
     private readonly DosFileManager _dosFileManager;
     private readonly List<IVirtualDevice> _devices;
 
-    public DosInt21Handler(Machine machine, ILoggerService loggerService, Dos dos) : base(machine) {
+    public DosInt21Handler(Machine machine, ILoggerService loggerService, Dos dos) : base(machine, loggerService) {
         _loggerService = loggerService;
         Encoding.RegisterProvider(CodePagesEncodingProvider.Instance);
         _cp850CharSet = Encoding.GetEncoding("ibm850");

--- a/src/Spice86.Core/Emulator/InterruptHandlers/Dos/DosInt2fHandler.cs
+++ b/src/Spice86.Core/Emulator/InterruptHandlers/Dos/DosInt2fHandler.cs
@@ -11,6 +11,7 @@ using Spice86.Core.Emulator.Callback;
 using Spice86.Core.Emulator.InterruptHandlers;
 using Spice86.Core.Emulator.Memory;
 using Spice86.Core.Emulator.VM;
+using Spice86.Shared.Utils;
 
 /// <summary>
 /// Reimplementation of int2f
@@ -18,7 +19,7 @@ using Spice86.Core.Emulator.VM;
 public class DosInt2fHandler : InterruptHandler {
     private readonly ILoggerService _loggerService;
 
-    public DosInt2fHandler(Machine machine, ILoggerService loggerService) : base(machine) {
+    public DosInt2fHandler(Machine machine, ILoggerService loggerService) : base(machine, loggerService) {
         _loggerService = loggerService;
         FillDispatchTable();
     }

--- a/src/Spice86.Core/Emulator/InterruptHandlers/Input/Keyboard/BiosKeyboardInt9Handler.cs
+++ b/src/Spice86.Core/Emulator/InterruptHandlers/Input/Keyboard/BiosKeyboardInt9Handler.cs
@@ -18,7 +18,7 @@ public class BiosKeyboardInt9Handler : InterruptHandler {
     private readonly Keyboard _keyboard;
     private readonly IKeyScanCodeConverter? _keyScanCodeConverter;
 
-    public BiosKeyboardInt9Handler(Machine machine, ILoggerService loggerService, IKeyScanCodeConverter? keyScanCodeConverter) : base(machine) {
+    public BiosKeyboardInt9Handler(Machine machine, ILoggerService loggerService, IKeyScanCodeConverter? keyScanCodeConverter) : base(machine, loggerService) {
         _loggerService = loggerService;
         _keyboard = machine.Keyboard;
         _keyScanCodeConverter = keyScanCodeConverter;

--- a/src/Spice86.Core/Emulator/InterruptHandlers/Input/Keyboard/KeyboardInt16Handler.cs
+++ b/src/Spice86.Core/Emulator/InterruptHandlers/Input/Keyboard/KeyboardInt16Handler.cs
@@ -13,7 +13,7 @@ public class KeyboardInt16Handler : InterruptHandler {
     private readonly ILoggerService _loggerService;
     private readonly BiosKeyboardBuffer _biosKeyboardBuffer;
 
-    public KeyboardInt16Handler(Machine machine, ILoggerService loggerService, BiosKeyboardBuffer biosKeyboardBuffer) : base(machine) {
+    public KeyboardInt16Handler(Machine machine, ILoggerService loggerService, BiosKeyboardBuffer biosKeyboardBuffer) : base(machine, loggerService) {
         _loggerService = loggerService;
         _biosKeyboardBuffer = biosKeyboardBuffer;
         _dispatchTable.Add(0x00, new Callback(0x00, () => GetKeystroke()));

--- a/src/Spice86.Core/Emulator/InterruptHandlers/Input/Mouse/MouseInt33Handler.cs
+++ b/src/Spice86.Core/Emulator/InterruptHandlers/Input/Mouse/MouseInt33Handler.cs
@@ -23,7 +23,7 @@ public class MouseInt33Handler : InterruptHandler {
     private ushort _userCallbackOffset;
     private ushort _userCallbackSegment;
 
-    public MouseInt33Handler(Machine machine, ILoggerService loggerService, IGui? gui) : base(machine) {
+    public MouseInt33Handler(Machine machine, ILoggerService loggerService, IGui? gui) : base(machine, loggerService) {
         _loggerService = loggerService;
         _gui = gui;
         _dispatchTable.Add(0x00, new Callback(0x00, MouseInstalledFlag));

--- a/src/Spice86.Core/Emulator/InterruptHandlers/InterruptHandler.cs
+++ b/src/Spice86.Core/Emulator/InterruptHandlers/InterruptHandler.cs
@@ -5,6 +5,7 @@ using Spice86.Core.Emulator.CPU;
 using Spice86.Core.Emulator.Errors;
 using Spice86.Core.Emulator.Memory;
 using Spice86.Core.Emulator.VM;
+using Spice86.Shared.Interfaces;
 
 public abstract class InterruptHandler : IndexBasedDispatcher, ICallback {
     protected State _state;
@@ -18,7 +19,7 @@ public abstract class InterruptHandler : IndexBasedDispatcher, ICallback {
 
     private bool _interruptStackPresent = true;
 
-    protected InterruptHandler(Machine machine) {
+    protected InterruptHandler(Machine machine, ILoggerService loggerService) : base(machine, loggerService) {
         _machine = machine;
         _memory = machine.Memory;
         _cpu = machine.Cpu;

--- a/src/Spice86.Core/Emulator/InterruptHandlers/SystemClock/SystemClockInt1AHandler.cs
+++ b/src/Spice86.Core/Emulator/InterruptHandlers/SystemClock/SystemClockInt1AHandler.cs
@@ -17,7 +17,7 @@ public class SystemClockInt1AHandler : InterruptHandler {
     private readonly ILoggerService _loggerService;
     private readonly TimerInt8Handler _timerHandler;
 
-    public SystemClockInt1AHandler(Machine machine, ILoggerService loggerService, TimerInt8Handler timerHandler) : base(machine) {
+    public SystemClockInt1AHandler(Machine machine, ILoggerService loggerService, TimerInt8Handler timerHandler) : base(machine, loggerService) {
         _loggerService = loggerService;
         _timerHandler = timerHandler;
         _dispatchTable.Add(0x00, new Callback(0x00, SetSystemClockCounter));

--- a/src/Spice86.Core/Emulator/InterruptHandlers/Timer/TimerInt8Handler.cs
+++ b/src/Spice86.Core/Emulator/InterruptHandlers/Timer/TimerInt8Handler.cs
@@ -5,6 +5,7 @@ using Spice86.Core.Emulator.Devices.Timer;
 using Spice86.Core.Emulator.InterruptHandlers;
 using Spice86.Core.Emulator.Memory;
 using Spice86.Core.Emulator.VM;
+using Spice86.Shared.Interfaces;
 
 /// <summary>
 /// Implementation of int8 that just updates a value in the bios data area.
@@ -13,7 +14,7 @@ public class TimerInt8Handler : InterruptHandler {
     private readonly DualPic _dualPic;
     private readonly Timer _timer;
 
-    public TimerInt8Handler(Machine machine) : base(machine) {
+    public TimerInt8Handler(Machine machine, ILoggerService loggerService) : base(machine, loggerService) {
         _timer = machine.Timer;
         _memory = machine.Memory;
         _dualPic = machine.DualPic;

--- a/src/Spice86.Core/Emulator/InterruptHandlers/VGA/VideoBiosInt10Handler.cs
+++ b/src/Spice86.Core/Emulator/InterruptHandlers/VGA/VideoBiosInt10Handler.cs
@@ -3,11 +3,12 @@ namespace Spice86.Core.Emulator.InterruptHandlers.VGA;
 using Spice86.Core.Emulator.Callback;
 using Spice86.Core.Emulator.Devices.Video;
 using Spice86.Core.Emulator.VM;
+using Spice86.Shared.Interfaces;
 
 public class VideoBiosInt10Handler : InterruptHandler {
     private readonly IVgaInterrupts _vgaCard;
 
-    public VideoBiosInt10Handler(Machine machine, IVgaInterrupts vgaCard) : base(machine) {
+    public VideoBiosInt10Handler(Machine machine, ILoggerService loggerService, IVgaInterrupts vgaCard) : base(machine, loggerService) {
         _vgaCard = vgaCard;
         FillDispatchTable();
     }

--- a/src/Spice86.Core/Emulator/LoadableFile/Bios/BiosLoader.cs
+++ b/src/Spice86.Core/Emulator/LoadableFile/Bios/BiosLoader.cs
@@ -5,6 +5,7 @@ using Spice86.Shared.Interfaces;
 using Spice86.Core.Emulator.LoadableFile;
 using Spice86.Core.Emulator.Memory;
 using Spice86.Core.Emulator.VM;
+using Spice86.Shared.Utils;
 
 /// <summary>
 /// Loader for bios files.<br/>

--- a/src/Spice86.Core/Emulator/LoadableFile/Dos/Com/ComLoader.cs
+++ b/src/Spice86.Core/Emulator/LoadableFile/Dos/Com/ComLoader.cs
@@ -5,6 +5,8 @@ using Spice86.Shared.Interfaces;
 
 namespace Spice86.Core.Emulator.LoadableFile.Dos.Com;
 
+using Spice86.Shared.Utils;
+
 public class ComLoader : DosFileLoader {
     private const ushort ComOffset = 0x100;
     private readonly ushort _startSegment;

--- a/src/Spice86.Core/Emulator/LoadableFile/Dos/Exe/ExeFile.cs
+++ b/src/Spice86.Core/Emulator/LoadableFile/Dos/Exe/ExeFile.cs
@@ -1,6 +1,8 @@
 ﻿namespace Spice86.Core.Emulator.LoadableFile.Dos.Exe;
 
 using Spice86.Core.Emulator.Memory;
+using Spice86.Shared;
+using Spice86.Shared.Utils;
 
 using System;
 using System.Collections.Generic;

--- a/src/Spice86.Core/Emulator/LoadableFile/Dos/Exe/ExeLoader.cs
+++ b/src/Spice86.Core/Emulator/LoadableFile/Dos/Exe/ExeLoader.cs
@@ -9,6 +9,9 @@ using Spice86.Shared.Interfaces;
 
 namespace Spice86.Core.Emulator.LoadableFile.Dos.Exe;
 
+using Spice86.Shared;
+using Spice86.Shared.Utils;
+
 /// <summary>
 /// Loads a DOS 16 bits EXE file in memory.
 /// </summary>

--- a/src/Spice86.Core/Emulator/LoadableFile/Dos/PspGenerator.cs
+++ b/src/Spice86.Core/Emulator/LoadableFile/Dos/PspGenerator.cs
@@ -4,6 +4,7 @@ using System.Text;
 using Spice86.Core.Emulator.Memory;
 using Spice86.Core.Emulator.InterruptHandlers.Dos;
 using Spice86.Core.Emulator.VM;
+using Spice86.Shared.Utils;
 
 public class PspGenerator {
     private const ushort DTA_OR_COMMAND_LINE_OFFSET = 0x80;

--- a/src/Spice86.Core/Emulator/LoadableFile/ExecutableFileLoader.cs
+++ b/src/Spice86.Core/Emulator/LoadableFile/ExecutableFileLoader.cs
@@ -7,9 +7,9 @@ using Serilog;
 using System.IO;
 using Spice86.Logging;
 using Spice86.Core.Emulator.Memory;
-using Spice86.Core.Utils;
 using Spice86.Core.Emulator.CPU;
 using Spice86.Core.Emulator.VM;
+using Spice86.Shared.Utils;
 
 /// <summary>
 /// Base class for loading executable files in the VM like exe, bios, ...

--- a/src/Spice86.Core/Emulator/Memory/MemoryRange.cs
+++ b/src/Spice86.Core/Emulator/Memory/MemoryRange.cs
@@ -1,5 +1,7 @@
 ﻿namespace Spice86.Core.Emulator.Memory;
 
+using Spice86.Shared.Utils;
+
 using System.Text.Json;
 
 /// <summary> Represents a range in memory. </summary>

--- a/src/Spice86.Core/Emulator/Memory/UInt16Indexer.cs
+++ b/src/Spice86.Core/Emulator/Memory/UInt16Indexer.cs
@@ -1,5 +1,7 @@
 ﻿namespace Spice86.Core.Emulator.Memory;
 
+using Spice86.Shared.Utils;
+
 public class UInt16Indexer {
     private readonly Memory _memory;
 

--- a/src/Spice86.Core/Emulator/Memory/UInt32Indexer.cs
+++ b/src/Spice86.Core/Emulator/Memory/UInt32Indexer.cs
@@ -1,5 +1,7 @@
 ﻿namespace Spice86.Core.Emulator.Memory;
 
+using Spice86.Shared.Utils;
+
 public class UInt32Indexer {
     private readonly Memory _memory;
 

--- a/src/Spice86.Core/Emulator/Memory/UInt8Indexer.cs
+++ b/src/Spice86.Core/Emulator/Memory/UInt8Indexer.cs
@@ -1,5 +1,7 @@
 ﻿namespace Spice86.Core.Emulator.Memory;
 
+using Spice86.Shared.Utils;
+
 public class UInt8Indexer {
     private readonly Memory _memory;
 

--- a/src/Spice86.Core/Emulator/OperatingSystem/Dos.cs
+++ b/src/Spice86.Core/Emulator/OperatingSystem/Dos.cs
@@ -12,6 +12,7 @@ using Spice86.Core.Emulator.OperatingSystem.Devices;
 using Spice86.Core.Emulator.OperatingSystem.Enums;
 using Spice86.Core.Emulator.OperatingSystem.Structures;
 using Spice86.Shared.Interfaces;
+using Spice86.Shared.Utils;
 
 public class Dos {
     private const int DeviceDriverHeaderLength = 18;

--- a/src/Spice86.Core/Emulator/OperatingSystem/DosFileManager.cs
+++ b/src/Spice86.Core/Emulator/OperatingSystem/DosFileManager.cs
@@ -6,12 +6,12 @@ namespace Spice86.Core.Emulator.OperatingSystem;
 using Serilog;
 
 using Spice86.Core.Emulator.Memory;
-using Spice86.Core.Utils;
-
 using Spice86.Core.Emulator.Errors;
 using Spice86.Core.Emulator.OperatingSystem.Devices;
 using Spice86.Core.Emulator.OperatingSystem.Enums;
 using Spice86.Core.Emulator.OperatingSystem.Structures;
+using Spice86.Shared.Emulator.Errors;
+using Spice86.Shared.Utils;
 
 using System;
 using System.Collections.Generic;

--- a/src/Spice86.Core/Emulator/OperatingSystem/DosMemoryManager.cs
+++ b/src/Spice86.Core/Emulator/OperatingSystem/DosMemoryManager.cs
@@ -3,6 +3,7 @@
 using Spice86.Core.Emulator.Memory;
 using Spice86.Core.Emulator.OperatingSystem.Structures;
 using Spice86.Shared.Interfaces;
+using Spice86.Shared.Utils;
 
 public class DosMemoryManager {
     private readonly ILoggerService _loggerService;

--- a/src/Spice86.Core/Emulator/OperatingSystem/Structures/DosMemoryControlBlock.cs
+++ b/src/Spice86.Core/Emulator/OperatingSystem/Structures/DosMemoryControlBlock.cs
@@ -2,6 +2,7 @@
 
 using Spice86.Core.Emulator.Memory;
 using Spice86.Core.Emulator.ReverseEngineer;
+using Spice86.Shared.Utils;
 
 using System.Text;
 

--- a/src/Spice86.Core/Emulator/ProgramExecutor.cs
+++ b/src/Spice86.Core/Emulator/ProgramExecutor.cs
@@ -12,7 +12,6 @@ using Spice86.Core.Emulator.Gdb;
 using Spice86.Core.Emulator.LoadableFile;
 using Spice86.Core.Emulator.Memory;
 using Spice86.Core.Emulator.VM;
-using Spice86.Core.Utils;
 using Spice86.Core.Emulator.Devices.Timer;
 using Spice86.Core.Emulator.Errors;
 using Spice86.Core.Emulator.LoadableFile.Bios;
@@ -27,6 +26,9 @@ using System.Security.Cryptography;
 using System.Diagnostics;
 
 using Spice86.Core.CLI;
+using Spice86.Shared;
+using Spice86.Shared.Emulator.Errors;
+using Spice86.Shared.Utils;
 
 /// <summary>
 /// Loads and executes a program following the given configuration in the emulator.<br/>

--- a/src/Spice86.Core/Emulator/ReverseEngineer/CSharpOverrideHelper.cs
+++ b/src/Spice86.Core/Emulator/ReverseEngineer/CSharpOverrideHelper.cs
@@ -8,12 +8,15 @@ using Spice86.Core.Emulator.Function.Dump;
 using Spice86.Core.Emulator.Memory;
 using Spice86.Core.Emulator.VM;
 using Spice86.Core.Emulator.VM.Breakpoint;
-using Spice86.Core.Utils;
 using Spice86.Shared.Interfaces;
 
 using System.Linq;
 
 namespace Spice86.Core.Emulator.ReverseEngineer;
+
+using Spice86.Shared;
+using Spice86.Shared.Emulator.Errors;
+using Spice86.Shared.Utils;
 
 public class CSharpOverrideHelper {
     protected readonly ILoggerService _loggerService;

--- a/src/Spice86.Core/Emulator/ReverseEngineer/MemoryBasedDataStructureWithBaseAddressProvider.cs
+++ b/src/Spice86.Core/Emulator/ReverseEngineer/MemoryBasedDataStructureWithBaseAddressProvider.cs
@@ -3,6 +3,7 @@
 using Spice86.Core.Emulator.Memory;
 
 using Spice86.Core.Emulator.Errors;
+using Spice86.Shared.Emulator.Errors;
 
 using System.Text;
 

--- a/src/Spice86.Core/Emulator/VM/Machine.cs
+++ b/src/Spice86.Core/Emulator/VM/Machine.cs
@@ -170,7 +170,7 @@ public class Machine : IDisposable {
         Register(VideoBiosInt10Handler);
         BiosEquipmentDeterminationInt11Handler = new BiosEquipmentDeterminationInt11Handler(this);
         Register(BiosEquipmentDeterminationInt11Handler);
-        SystemBiosInt15Handler = new SystemBiosInt15Handler(this);
+        SystemBiosInt15Handler = new SystemBiosInt15Handler(this, loggerService);
         Register(SystemBiosInt15Handler);
         KeyboardInt16Handler = new KeyboardInt16Handler(
             this,

--- a/src/Spice86.Core/Emulator/VM/Machine.cs
+++ b/src/Spice86.Core/Emulator/VM/Machine.cs
@@ -22,8 +22,8 @@ using Spice86.Core.Emulator.InterruptHandlers.VGA;
 using Spice86.Core.Emulator.IOPorts;
 using Spice86.Core.Emulator.Memory;
 using Spice86.Core.Emulator.OperatingSystem;
-using Spice86.Core.Emulator.OperatingSystem.Enums;
 using Spice86.Core.Emulator.OperatingSystem.Structures;
+using Spice86.Shared;
 using Spice86.Shared.Interfaces;
 
 using System;
@@ -38,8 +38,8 @@ public class Machine : IDisposable {
     private readonly ProgramExecutor _programExecutor;
     private readonly List<DmaChannel> _dmaDeviceChannels = new();
     private readonly Thread _dmaThread;
-    private bool _exitDmaLoop = false;
-    private bool _dmaThreadStarted = false;
+    private bool _exitDmaLoop;
+    private bool _dmaThreadStarted;
     private readonly ManualResetEvent _dmaResetEvent = new(true);
 
     private bool _disposed;
@@ -158,17 +158,17 @@ public class Machine : IDisposable {
         Register(Midi);
 
         // Services
-        CallbackHandler = new CallbackHandler(this, MemoryMap.InterruptHandlersSegment);
+        CallbackHandler = new CallbackHandler(this, loggerService, MemoryMap.InterruptHandlersSegment);
         Cpu.CallbackHandler = CallbackHandler;
-        TimerInt8Handler = new TimerInt8Handler(this);
+        TimerInt8Handler = new TimerInt8Handler(this, loggerService);
         Register(TimerInt8Handler);
         BiosKeyboardInt9Handler = new BiosKeyboardInt9Handler(this,
             loggerService,
             keyScanCodeConverter);
         Register(BiosKeyboardInt9Handler);
-        VideoBiosInt10Handler = new VideoBiosInt10Handler(this, (IVgaInterrupts)VgaCard);
+        VideoBiosInt10Handler = new VideoBiosInt10Handler(this, loggerService, (IVgaInterrupts)VgaCard);
         Register(VideoBiosInt10Handler);
-        BiosEquipmentDeterminationInt11Handler = new BiosEquipmentDeterminationInt11Handler(this);
+        BiosEquipmentDeterminationInt11Handler = new BiosEquipmentDeterminationInt11Handler(this, loggerService);
         Register(BiosEquipmentDeterminationInt11Handler);
         SystemBiosInt15Handler = new SystemBiosInt15Handler(this, loggerService);
         Register(SystemBiosInt15Handler);

--- a/src/Spice86.Core/Emulator/VM/PauseHandler.cs
+++ b/src/Spice86.Core/Emulator/VM/PauseHandler.cs
@@ -5,6 +5,7 @@ namespace Spice86.Core.Emulator.VM;
 using Serilog;
 
 using Spice86.Core.Emulator.Errors;
+using Spice86.Shared.Emulator.Errors;
 using Spice86.Shared.Interfaces;
 
 using System.Diagnostics;

--- a/src/Spice86.Core/Spice86.Core.csproj
+++ b/src/Spice86.Core/Spice86.Core.csproj
@@ -73,4 +73,7 @@
 		<ProjectReference Include="..\Spice86.Logging\Spice86.Logging.csproj" />
 		<ProjectReference Include="..\Spice86.Shared\Spice86.Shared.csproj" />
 	</ItemGroup>
+	<ItemGroup>
+	  <Folder Include="Utils\" />
+	</ItemGroup>
 </Project>

--- a/src/Spice86.Logging/LoggerPropertyBag.cs
+++ b/src/Spice86.Logging/LoggerPropertyBag.cs
@@ -1,0 +1,9 @@
+namespace Spice86.Logging;
+
+using Spice86.Shared.Interfaces;
+
+/// <inheritdoc/>
+public class LoggerPropertyBag : ILoggerPropertyBag {
+    public ushort CodeSegment { get; set; }
+    public ushort InstructionPointer { get; set; }
+}

--- a/src/Spice86.Logging/LoggerPropertyBag.cs
+++ b/src/Spice86.Logging/LoggerPropertyBag.cs
@@ -1,9 +1,9 @@
 namespace Spice86.Logging;
 
+using Spice86.Shared;
 using Spice86.Shared.Interfaces;
 
 /// <inheritdoc/>
 public class LoggerPropertyBag : ILoggerPropertyBag {
-    public ushort CodeSegment { get; set; }
-    public ushort InstructionPointer { get; set; }
+    public SegmentedAddress CsIp { get; set; } = new(0,0);
 }

--- a/src/Spice86.Logging/LoggerService.cs
+++ b/src/Spice86.Logging/LoggerService.cs
@@ -15,7 +15,10 @@ public class LoggerService : ILoggerService {
 
     private LoggerConfiguration _loggerConfiguration;
 
-    public LoggerService() {
+    public ILoggerPropertyBag LoggerPropertyBag { get; }
+
+    public LoggerService(ILoggerPropertyBag loggerPropertyBag) {
+        LoggerPropertyBag = loggerPropertyBag;
         _loggerConfiguration = CreateLoggerConfiguration();
         _loggerConfiguration
             .MinimumLevel.ControlledBy(LogLevelSwitch);
@@ -27,7 +30,11 @@ public class LoggerService : ILoggerService {
     /// <returns>The ILogger instance.</returns>
     private ILogger GetLogger() {
         _logger ??= _loggerConfiguration.CreateLogger();
-        return _logger;
+        return AddProperties(_logger);
+    }
+
+    private ILogger AddProperties(ILogger logger) {
+        return logger.ForContext("IP", $"{LoggerPropertyBag.CodeSegment:X4}:{LoggerPropertyBag.InstructionPointer:X4}");
     }
     
     public LoggerConfiguration CreateLoggerConfiguration() {

--- a/src/Spice86.Logging/LoggerService.cs
+++ b/src/Spice86.Logging/LoggerService.cs
@@ -34,7 +34,7 @@ public class LoggerService : ILoggerService {
     }
 
     private ILogger AddProperties(ILogger logger) {
-        return logger.ForContext("IP", $"{LoggerPropertyBag.CodeSegment:X4}:{LoggerPropertyBag.InstructionPointer:X4}");
+        return logger.ForContext("IP", $"{LoggerPropertyBag.CsIp}");
     }
     
     public LoggerConfiguration CreateLoggerConfiguration() {

--- a/src/Spice86.Shared/Emulator/Errors/UnrecoverableException.cs
+++ b/src/Spice86.Shared/Emulator/Errors/UnrecoverableException.cs
@@ -1,4 +1,4 @@
-﻿namespace Spice86.Core.Emulator.Errors;
+﻿namespace Spice86.Shared.Emulator.Errors;
 
 using System;
 

--- a/src/Spice86.Shared/Emulator/Keyboard/KeyboardInput.cs
+++ b/src/Spice86.Shared/Emulator/Keyboard/KeyboardInput.cs
@@ -1,2 +1,2 @@
-﻿namespace Spice86.Shared;
+﻿namespace Spice86.Shared.Emulator.Keyboard;
 public readonly record struct KeyboardInput(EventArgs EventArgs, bool IsPressed);

--- a/src/Spice86.Shared/Emulator/Memory/SegmentedAddress.cs
+++ b/src/Spice86.Shared/Emulator/Memory/SegmentedAddress.cs
@@ -1,6 +1,6 @@
-﻿namespace Spice86.Core.Emulator.Memory;
+﻿namespace Spice86.Shared;
 
-using Spice86.Core.Utils;
+using Spice86.Shared.Utils;
 
 using System;
 
@@ -42,9 +42,9 @@ public class SegmentedAddress : IComparable<SegmentedAddress> {
         return (int)ToPhysical();
     }
 
-    public ushort Offset { get; private set; }
+    public ushort Offset { get; set; }
 
-    public ushort Segment { get; private set; }
+    public ushort Segment { get; set; }
 
     public uint ToPhysical() {
         return MemoryUtils.ToPhysicalAddress(Segment, Offset);

--- a/src/Spice86.Shared/Emulator/Video/Rgb.cs
+++ b/src/Spice86.Shared/Emulator/Video/Rgb.cs
@@ -1,4 +1,4 @@
-﻿namespace Spice86.Shared;
+﻿namespace Spice86.Shared.Emulator.Video;
 
 /// <summary>
 /// RGB representation of a color.

--- a/src/Spice86.Shared/Interfaces/IKeyScanCodeConverter.cs
+++ b/src/Spice86.Shared/Interfaces/IKeyScanCodeConverter.cs
@@ -1,4 +1,7 @@
 ﻿namespace Spice86.Shared.Interfaces;
+
+using Spice86.Shared.Emulator.Keyboard;
+
 public interface IKeyScanCodeConverter {
     public byte? GetAsciiCode(byte scancode);
 

--- a/src/Spice86.Shared/Interfaces/ILoggerPropertyBag.cs
+++ b/src/Spice86.Shared/Interfaces/ILoggerPropertyBag.cs
@@ -1,4 +1,4 @@
-namespace Spice86.Shared.Interfaces; 
+namespace Spice86.Shared.Interfaces;
 
 /// <summary>
 /// Contains properties used internally by the <see cref="ILoggerService"/> to enrich logs. <br/>
@@ -6,12 +6,7 @@ namespace Spice86.Shared.Interfaces;
 /// </summary>
 public interface ILoggerPropertyBag {
     /// <summary>
-    /// From Cpu.State.CS
+    /// From Cpu.State.CS and Cpu.State.IP
     /// </summary>
-    ushort CodeSegment { get; set; }
-    
-    /// <summary>
-    /// From Cpu.State.IP
-    /// </summary>
-    ushort InstructionPointer { get; set; }
+    SegmentedAddress CsIp { get; set; }
 }

--- a/src/Spice86.Shared/Interfaces/ILoggerPropertyBag.cs
+++ b/src/Spice86.Shared/Interfaces/ILoggerPropertyBag.cs
@@ -1,0 +1,17 @@
+namespace Spice86.Shared.Interfaces; 
+
+/// <summary>
+/// Contains properties used internally by the <see cref="ILoggerService"/> to enrich logs. <br/>
+/// Each property is updated during execution by the appropriate emulator class.
+/// </summary>
+public interface ILoggerPropertyBag {
+    /// <summary>
+    /// From Cpu.State.CS
+    /// </summary>
+    ushort CodeSegment { get; set; }
+    
+    /// <summary>
+    /// From Cpu.State.IP
+    /// </summary>
+    ushort InstructionPointer { get; set; }
+}

--- a/src/Spice86.Shared/Interfaces/ILoggerService.cs
+++ b/src/Spice86.Shared/Interfaces/ILoggerService.cs
@@ -15,6 +15,8 @@ public interface ILoggerService : ILogger {
     /// </summary>
     LoggingLevelSwitch LogLevelSwitch { get; set; }
     
+    ILoggerPropertyBag LoggerPropertyBag { get; }
+    
     /// <summary>
     /// Whether logs are ignored.
     /// </summary>

--- a/src/Spice86.Shared/Utils/ConvertUtils.cs
+++ b/src/Spice86.Shared/Utils/ConvertUtils.cs
@@ -1,8 +1,6 @@
-﻿namespace Spice86.Core.Utils;
-using Spice86.Core.Emulator.CPU;
-using Spice86.Core.Emulator.Function;
+﻿namespace Spice86.Shared.Utils;
 
-using Spice86.Core.Emulator.Memory;
+using Spice86.Shared;
 
 using System.Globalization;
 using System.Text;

--- a/src/Spice86.Shared/Utils/DictionaryUtils.cs
+++ b/src/Spice86.Shared/Utils/DictionaryUtils.cs
@@ -1,4 +1,4 @@
-namespace Spice86.Core.Utils;
+namespace Spice86.Shared.Utils;
 
 using System.Collections.Generic;
 

--- a/src/Spice86.Shared/Utils/MemoryUtils.cs
+++ b/src/Spice86.Shared/Utils/MemoryUtils.cs
@@ -1,6 +1,6 @@
-﻿namespace Spice86.Core.Emulator.Memory;
+﻿namespace Spice86.Shared.Utils;
 
-using Spice86.Core.Emulator.Errors;
+using Spice86.Shared.Emulator.Errors;
 
 using System.Text;
 

--- a/src/Spice86.Tests/CSharpOverrideHelperTest.cs
+++ b/src/Spice86.Tests/CSharpOverrideHelperTest.cs
@@ -13,6 +13,8 @@ using System.Collections.Generic;
 using Xunit;
 using Moq;
 
+using Spice86.Shared;
+
 public class CSharpOverrideHelperTest {
     private readonly Mock<ILoggerService> _loggerServiceMock = new();
     

--- a/src/Spice86.Tests/MachineCreator.cs
+++ b/src/Spice86.Tests/MachineCreator.cs
@@ -10,6 +10,8 @@ using System;
 
 using Moq;
 
+using Spice86.Logging;
+
 public class MachineCreator {
     public ProgramExecutor CreateProgramExecutorFromBinName(string binName) {
         return CreateProgramExecutorForBin($"Resources/cpuTests/{binName}.bin");
@@ -25,8 +27,9 @@ public class MachineCreator {
             InitializeDOS = false
         };
 
+        ILoggerService loggerService = new Mock<LoggerService>(new Mock<ILoggerPropertyBag>().Object).Object;
         ProgramExecutor programExecutor = new ProgramExecutor(
-            new Mock<ILoggerService>().Object,
+            loggerService,
             null, null, configuration);
         Machine machine = programExecutor.Machine;
         Cpu cpu = machine.Cpu;

--- a/src/Spice86.Tests/MachineCreator.cs
+++ b/src/Spice86.Tests/MachineCreator.cs
@@ -27,7 +27,7 @@ public class MachineCreator {
             InitializeDOS = false
         };
 
-        ILoggerService loggerService = new Mock<LoggerService>(new Mock<ILoggerPropertyBag>().Object).Object;
+        ILoggerService loggerService = new Mock<LoggerService>(new LoggerPropertyBag()).Object;
         ProgramExecutor programExecutor = new ProgramExecutor(
             loggerService,
             null, null, configuration);

--- a/src/Spice86.Tests/MachineTest.cs
+++ b/src/Spice86.Tests/MachineTest.cs
@@ -11,11 +11,11 @@ using System.IO;
 
 using Xunit;
 using Spice86.Core.Emulator.Memory;
-using Spice86.Core.Utils;
 using Spice86.Core.Emulator.CPU;
 using Spice86.Core.Emulator.VM.Breakpoint;
 using Spice86.Core.Emulator;
 using Spice86.Core.Emulator.VM;
+using Spice86.Shared.Utils;
 
 public class MachineTest {
     static MachineTest() {

--- a/src/Spice86/DependencyInjection/LoggerServiceInjectionExtensions.cs
+++ b/src/Spice86/DependencyInjection/LoggerServiceInjectionExtensions.cs
@@ -8,6 +8,7 @@ namespace Spice86.DependencyInjection;
 
 public static class LoggerServiceInjectionExtensions {
     public static IServiceCollection AddLogging(this IServiceCollection services) {
+        services.TryAddSingleton<ILoggerPropertyBag, LoggerPropertyBag>();
         services.TryAddSingleton<ILoggerService, LoggerService>();
         return services;
     }

--- a/src/Spice86/Keyboard/AvaloniaKeyScanCodeConverter.cs
+++ b/src/Spice86/Keyboard/AvaloniaKeyScanCodeConverter.cs
@@ -3,6 +3,7 @@
 using Avalonia.Input;
 
 using Spice86.Shared;
+using Spice86.Shared.Emulator.Keyboard;
 using Spice86.Shared.Interfaces;
 
 using System.Collections.Generic;

--- a/src/Spice86/UserControls/PaletteUserControl.axaml.cs
+++ b/src/Spice86/UserControls/PaletteUserControl.axaml.cs
@@ -8,6 +8,7 @@ using Avalonia.Collections;
 using Avalonia.Controls.Shapes;
 
 using Spice86.Shared;
+using Spice86.Shared.Emulator.Video;
 
 public partial class PaletteUserControl : UserControl {
     public PaletteUserControl() {

--- a/src/Spice86/ViewModels/PaletteViewModel.cs
+++ b/src/Spice86/ViewModels/PaletteViewModel.cs
@@ -11,6 +11,7 @@ using CommunityToolkit.Mvvm.ComponentModel;
 using Spice86.Core.Emulator.Devices.Video;
 using Spice86.Core.Emulator.VM;
 using Spice86.Shared;
+using Spice86.Shared.Emulator.Video;
 
 public partial class PaletteViewModel : ObservableObject {
     private readonly Machine? _machine;


### PR DESCRIPTION
Tested with Dune.

Example of output in the console (same as master, but fast):


```

[2023-04-10 19:16:05.910 +02:00] [EROR] [5635:0461] Unhandled port write: 12, 0 in WriteByte
[2023-04-10 19:16:06.286 +02:00] [EROR] [5635:0461] Unhandled port write: 12, 0 in WriteByte
[2023-04-10 19:16:06.697 +02:00] [EROR] [5635:0461] Unhandled port write: 12, 0 in WriteByte
[2023-04-10 19:16:07.075 +02:00] [EROR] [5635:0461] Unhandled port write: 12, 0 in WriteByte
[2023-04-10 19:16:07.475 +02:00] [EROR] [5635:0461] Unhandled port write: 12, 0 in WriteByte
[2023-04-10 19:16:07.855 +02:00] [EROR] [5635:0461] Unhandled port write: 12, 0 in WriteByte
[2023-04-10 19:16:08.237 +02:00] [EROR] [5635:0461] Unhandled port write: 12, 0 in WriteByte
[2023-04-10 19:16:08.634 +02:00] [EROR] [5635:0461] Unhandled port write: 12, 0 in WriteByte
[2023-04-10 19:16:09.062 +02:00] [EROR] [5635:0461] Unhandled port write: 12, 0 in WriteByte
[2023-04-10 19:16:09.441 +02:00] [EROR] [5635:0461] Unhandled port write: 12, 0 in WriteByte
[2023-04-10 19:16:09.823 +02:00] [EROR] [5635:0461] Unhandled port write: 12, 0 in WriteByte


```

There no usage of IDisposable at all.
This is the less invasive fix I could find.
There is no need to disable the CS:IP reporting, as it does not hurt performance anymore.
The property bag can be extended in the future.