### PR TITLE
Allow per-class loglevel overrides.

### DIFF
--- a/src/Spice86.Logging/LoggerService.cs
+++ b/src/Spice86.Logging/LoggerService.cs
@@ -44,10 +44,11 @@ public class LoggerService : ILoggerService {
             .WriteTo.Console(outputTemplate: LogFormat)
             .WriteTo.Debug(outputTemplate: LogFormat);
     }
-    
-    public LoggerConfiguration Override(string source, LogEventLevel minimumLevel) {
-        _loggerConfiguration.MinimumLevel.Override(source, new LoggingLevelSwitch(minimumLevel));
-        return _loggerConfiguration;
+
+    public ILoggerService WithLogLevel(LogEventLevel minimumLevel) {
+        var logger = new LoggerService(LoggerPropertyBag) {LogLevelSwitch = new LoggingLevelSwitch(minimumLevel)};
+        logger._loggerConfiguration.MinimumLevel.ControlledBy(new LoggingLevelSwitch(minimumLevel));
+        return logger;
     }
 
 #pragma warning disable Serilog004

--- a/src/Spice86.Shared/Interfaces/ILoggerService.cs
+++ b/src/Spice86.Shared/Interfaces/ILoggerService.cs
@@ -3,7 +3,6 @@ using Serilog.Core;
 namespace Spice86.Shared.Interfaces;
 
 using Serilog;
-using Serilog.Configuration;
 using Serilog.Events;
 
 using System.Diagnostics;
@@ -35,14 +34,7 @@ public interface ILoggerService : ILogger {
     LoggerConfiguration CreateLoggerConfiguration();
 
     /// <summary>
-    /// Override the minimum level for events from a specific namespace or type name.
-    /// This API is not supported for configuring sub-loggers (created through <see cref="Logger"/>). Use <see cref="LoggerConfiguration.Filter"/> or <see cref="LoggerSinkConfiguration.Conditional(Func{LogEvent, bool}, Action{LoggerSinkConfiguration})"/> instead.
-    /// You also might consider using https://github.com/serilog/serilog-filters-expressions.
-    /// </summary>
-    /// <param name="source">The (partial) namespace or type name to set the override for.</param>
-    /// <param name="minimumLevel">The minimum level applied to loggers for matching sources.</param>
-    /// <returns>Configuration object allowing method chaining.</returns>
-    /// <exception cref="ArgumentNullException">When <paramref name="source"/> is <code>null</code></exception>
-    LoggerConfiguration Override(string source, LogEventLevel minimumLevel);
-
+    /// Returns a new <see cref="ILoggerService"/> with the specified minimum log level.
+    /// </summary> 
+    ILoggerService WithLogLevel(LogEventLevel minimumLevel);
 }


### PR DESCRIPTION
The `Override()` method only worked if no logger had been created yet. 
The new `WithLogLevel()` method can be used in any class by doing something like
```csharp
_loggerService = loggerService.WithLogLevel(LogEventLevel.Verbose);
```

Very useful when working on a specific class. 
You can set the overall loglevel to Error or Fatal and your class to Verbose or Debug.

