### PR TITLE
Move memory string reading and writing

### DIFF
--- a/src/Spice86.Core/Emulator/Devices/Video/AeonCard.cs
+++ b/src/Spice86.Core/Emulator/Devices/Video/AeonCard.cs
@@ -343,7 +343,7 @@ public class AeonCard : DefaultIOPortHandler, IVideoCard, IAeonVgaCard, IDisposa
     public void WriteString() {
         if (_loggerService.IsEnabled(LogEventLevel.Debug)) {
             uint address = MemoryUtils.ToPhysicalAddress(_state.ES, _state.BP);
-            string str = MemoryUtils.GetZeroTerminatedString(_memory.Ram, address, _memory.Ram.Length - (int)address);
+            string str = _memory.GetZeroTerminatedString(address, _memory.Ram.Length - (int)address);
             _loggerService.Debug("WRITE STRING: {WrittenString}", str);
         }
     }

--- a/src/Spice86.Core/Emulator/ReverseEngineer/MemoryBasedDataStructureWithBaseAddressProvider.cs
+++ b/src/Spice86.Core/Emulator/ReverseEngineer/MemoryBasedDataStructureWithBaseAddressProvider.cs
@@ -34,18 +34,11 @@ public abstract class MemoryBasedDataStructureWithBaseAddressProvider : MemoryBa
     }
 
     public string GetZeroTerminatedString(int start, int maxLength) {
-        StringBuilder res = new();
-        uint physicalStart = (uint)(BaseAddress + start);
-        for (int i = 0; i < maxLength; i++) {
-            byte characterByte = GetUint8(physicalStart, i);
-            if (characterByte == 0) {
-                break;
-            }
-            char character = Convert.ToChar(characterByte);
-            res.Append(character);
-        }
+        return Memory.GetZeroTerminatedString((uint)(BaseAddress + start), maxLength);
+    }
 
-        return res.ToString();
+    public void SetZeroTerminatedString(int start, string value, int maxLength) {
+        Memory.SetZeroTerminatedString((uint)(BaseAddress + start), value, maxLength);
     }
 
     public void SetUint16(int offset, ushort value) {
@@ -60,19 +53,4 @@ public abstract class MemoryBasedDataStructureWithBaseAddressProvider : MemoryBa
         SetUint8(BaseAddress, offset, value);
     }
 
-    public void SetZeroTerminatedString(int start, string value, int maxLength) {
-        if (value.Length + 1 > maxLength) {
-            throw new UnrecoverableException($"String {value} is more than {maxLength} cannot write it at offset {start}");
-        }
-
-        uint physicalStart = (uint)(BaseAddress + start);
-        int i = 0;
-        for (; i < value.Length; i++) {
-            char character = value[i];
-            byte charFirstByte = Encoding.ASCII.GetBytes(character.ToString())[0];
-            SetUint8(physicalStart, i, charFirstByte);
-        }
-
-        SetUint8(physicalStart, i, 0);
-    }
 }

--- a/src/Spice86.Shared/Utils/MemoryUtils.cs
+++ b/src/Spice86.Shared/Utils/MemoryUtils.cs
@@ -44,33 +44,4 @@ public static class MemoryUtils {
     public static ushort ToSegment(uint physicalAddress) {
         return (ushort)(physicalAddress >> 4);
     }
-    
-    public static string GetZeroTerminatedString(byte[] memory, uint address, int maxLength) {
-        StringBuilder res = new();
-        for (int i = 0; i < maxLength; i++) {
-            byte characterByte = GetUint8(memory, (uint)(address + i));
-            if (characterByte == 0) {
-                break;
-            }
-            char character = Convert.ToChar(characterByte);
-            res.Append(character);
-        }
-
-        return res.ToString();
-    }
-
-    public static void SetZeroTerminatedString(byte[] memory, uint address, string value, int maxLength) {
-        if (value.Length + 1 > maxLength) {
-            throw new UnrecoverableException($"String {value} is more than {maxLength} cannot write it at offset {address}");
-        }
-
-        int i = 0;
-        for (; i < value.Length; i++) {
-            char character = value[i];
-            byte charFirstByte = Encoding.ASCII.GetBytes(character.ToString())[0];
-            SetUint8(memory, (uint)(address + i), charFirstByte);
-        }
-
-        SetUint8(memory, (uint)(address + i), 0);
-    }
 }


### PR DESCRIPTION
Move the string get/set methods from MemoryUtils and MemoryBasedDataStructureWithBaseAddressProvider classes to Memory manager class.

This provides direct access rather than access to a copy of memory. Also reduces code duplication.
