### PR TITLE
More/performance

### DIFF
--- a/src/Spice86.Core/Emulator/Function/ExecutionFlowRecorder.cs
+++ b/src/Spice86.Core/Emulator/Function/ExecutionFlowRecorder.cs
@@ -13,6 +13,11 @@ using Spice86.Shared.Utils;
 /// </summary>
 public class ExecutionFlowRecorder {
     /// <summary>
+    /// A set of pre-allocated breakpoints from physical address 0x0 to <see cref="Memory.Memory.MemoryBusSize"/>
+    /// </summary>
+    private Dictionary<uint, AddressBreakPoint> _addressBreakPoints = new();
+
+    /// <summary>
     /// Gets or sets whether we register calls, jumps, returns, and unaligned returns.
     /// </summary>
     public bool RecordData { set; get; }
@@ -72,6 +77,24 @@ public class ExecutionFlowRecorder {
         UnalignedRetsFromTo = new Dictionary<uint, ISet<SegmentedAddress>>();
         ExecutedInstructions = new HashSet<SegmentedAddress>();
         ExecutableAddressWrittenBy = new Dictionary<uint, IDictionary<uint, ISet<ByteModificationRecord>>>();
+    }
+
+    /// <summary>
+    /// Avoids allocation and deallocation of closures before the emulation starts.
+    /// Speeds up the emulator quite a bit.
+    /// </summary>
+    /// <param name="machine">The emulator machine.</param>
+    internal void PreAllocatePossibleExecutionFlowBreakPoints(Machine machine) {
+        //Avoid re-entry.
+        if (_addressBreakPoints.Count != 0) {
+            return;
+        }
+        // This is fast *because* the memory bus size is around 1 MB.
+        // Beyond that, this code would have to be deleted,
+        // as the allocation would take way too much time.
+        for (uint i = 0; i < Memory.Memory.MemoryBusSize; i++) {
+            _addressBreakPoints.Add(i, GenerateBreakPoint(machine, i));
+        }
     }
 
     /// <summary>
@@ -172,6 +195,15 @@ public class ExecutionFlowRecorder {
             return;
         }
 
+        AddressBreakPoint? breakPoint;
+        if (!_addressBreakPoints.TryGetValue(physicalAddress, out breakPoint)) {
+            breakPoint = GenerateBreakPoint(machine, physicalAddress);
+        }
+        
+        machine.MachineBreakpoints.ToggleBreakPoint(breakPoint, true);
+    }
+
+    private AddressBreakPoint GenerateBreakPoint(Machine machine, uint physicalAddress) {
         AddressBreakPoint breakPoint = new(BreakPointType.WRITE, physicalAddress, _ => {
             if (!IsRegisterExecutableCodeModificationEnabled) {
                 return;
@@ -185,7 +217,7 @@ public class ExecutionFlowRecorder {
                     new SegmentedAddress(state.CS, state.IP), physicalAddress, oldValue, newValue);
             }
         }, false);
-        machine.MachineBreakpoints.ToggleBreakPoint(breakPoint, true);
+        return breakPoint;
     }
 
     private void RegisterExecutableByteModification(SegmentedAddress instructionAddress, uint modifiedAddress, byte oldValue, byte newValue) {

--- a/src/Spice86.Core/Emulator/ProgramExecutor.cs
+++ b/src/Spice86.Core/Emulator/ProgramExecutor.cs
@@ -146,6 +146,7 @@ public sealed class ProgramExecutor : IDisposable {
 
         InitializeFunctionHandlers(_configuration, reader.ReadGhidraSymbolsFromFileOrCreate());
         LoadFileToRun(_configuration, loader);
+        executionFlowRecorder.PreAllocatePossibleExecutionFlowBreakPoints(Machine);
         return Machine;
     }
 


### PR DESCRIPTION
This improves performance compared to master by avoiding the creation of closures for execution flow breakpoints from physical address 0 to around 1 MB.

The deallocation of closures by the GC does not happen anymore, resulting in a noticeable speed boost.