### PR TITLE
fix: improve performance by not creating a full logger only to check its enabled status

### DIFF
--- a/src/Spice86.Logging/LoggerService.cs
+++ b/src/Spice86.Logging/LoggerService.cs
@@ -156,6 +156,7 @@ public class LoggerService : ILoggerService {
 
     /// <inheritdoc/>
     public bool IsEnabled(LogEventLevel level) {
-        return GetLogger().IsEnabled(level);
+        _logger ??= _loggerConfiguration.CreateLogger();
+        return _logger.IsEnabled(level);
     }
 }


### PR DESCRIPTION
Did a few tests using my current example (Detroit's intro). With this change, and at least in debug, I got from 30 seconds to render up to the first "pixel fade" to only 20, with logging disabled.

With logging enabled more improvements can probably be made (because the hotspots will now be the different `Write`s). The main culprit is `AddProperties` on `GetLogger`, and inside that one the main issue is `String` concatenation while creating the segmented address. I'm sure this can be cached instead of recreated for every single logging event.
