### PR TITLE
Migration/avalonia v11

### DIFF
--- a/src/Spice86/App.axaml
+++ b/src/Spice86/App.axaml
@@ -4,9 +4,6 @@
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:local="using:Spice86">
     <Application.Styles>
-        <FluentTheme Mode="Light" />
-        <FluentTheme Mode="Dark" />
-        <!-- Add the line below to get OxyPlot UI theme applied. -->
-        <StyleInclude Source="resm:OxyPlot.Avalonia.Themes.Default.xaml?assembly=OxyPlot.Avalonia"/>
+        <FluentTheme />
     </Application.Styles>
 </Application>

--- a/src/Spice86/App.axaml.cs
+++ b/src/Spice86/App.axaml.cs
@@ -30,7 +30,7 @@ internal partial class App : Application {
     /// Called when the framework initialization is completed.
     /// </summary>
     public override void OnFrameworkInitializationCompleted() {
-        if (!IsInDarkMode()) {
+        if (!IsInDarkMode() && Styles.Count > 1) {
             Styles.RemoveAt(1);
         }
 
@@ -38,7 +38,7 @@ internal partial class App : Application {
             throw new PlatformNotSupportedException("Spice86 needs the desktop Linux/Mac/Windows platform in order to run.");
         }
 
-        ServiceProvider serviceProvider = Startup.StartupInjectedServices(desktop.Args);
+        ServiceProvider serviceProvider = Startup.StartupInjectedServices(desktop.Args ?? Array.Empty<string>());
 
         ILoggerService? loggerService = serviceProvider.GetService<ILoggerService>();
         if (loggerService is null) {
@@ -48,8 +48,8 @@ internal partial class App : Application {
         desktop.MainWindow = new MainWindow();
         MainWindowViewModel mainViewModel = new(loggerService);
         desktop.MainWindow.DataContext = mainViewModel;
-        mainViewModel.SetConfiguration(desktop.Args);
-        desktop.MainWindow.Closed += (s, e) => mainViewModel.Dispose();
+        mainViewModel.SetConfiguration(desktop.Args ?? Array.Empty<string>());
+        desktop.MainWindow.Closed += (_, _) => mainViewModel.Dispose();
         desktop.MainWindow.Opened += mainViewModel.OnMainWindowOpened;
         base.OnFrameworkInitializationCompleted();
     }

--- a/src/Spice86/Program.cs
+++ b/src/Spice86/Program.cs
@@ -1,5 +1,4 @@
 ﻿using Avalonia;
-using OxyPlot.Avalonia;
 using Microsoft.Extensions.DependencyInjection;
 using Spice86.Core.CLI;
 using Spice86.Core.Emulator;
@@ -10,8 +9,7 @@ namespace Spice86;
 /// <summary>
 /// Entry point for Spice86 application.
 /// </summary>
-public class Program
-{
+public class Program {
     /// <summary>
     /// Alternate entry point to use when injecting a class that defines C# overrides of the x86 assembly code found in the target DOS program.
     /// </summary>
@@ -19,8 +17,7 @@ public class Program
     /// <param name="args">The command-line arguments.</param>
     /// <param name="expectedChecksum">The expected checksum of the target DOS program.</param>
     [STAThread]
-    public static void RunWithOverrides<T>(string[] args, string expectedChecksum) where T : class, new()
-    {
+    public static void RunWithOverrides<T>(string[] args, string expectedChecksum) where T : class, new() {
         List<string> argsList = args.ToList();
 
         // Inject override
@@ -34,21 +31,16 @@ public class Program
     /// </summary>
     /// <param name="args">The command-line arguments.</param>
     [STAThread]
-    public static void Main(string[] args)
-    {
+    public static void Main(string[] args) {
         Configuration configuration = CommandLineParser.ParseCommandLine(args);
 
-        if (!configuration.HeadlessMode)
-        {
-            OxyPlotModule.EnsureLoaded();
+        if (!configuration.HeadlessMode) {
             BuildAvaloniaApp().StartWithClassicDesktopLifetime(args, Avalonia.Controls.ShutdownMode.OnMainWindowClose);
         }
-        else
-        {
+        else {
             ServiceProvider serviceProvider = Startup.StartupInjectedServices(args);
             ILoggerService? loggerService = serviceProvider.GetService<ILoggerService>();
-            if (loggerService is null)
-            {
+            if (loggerService is null) {
                 throw new InvalidOperationException("Could not get logging service from DI !");
             }
 
@@ -61,8 +53,7 @@ public class Program
     /// Configures and builds an Avalonia application instance.
     /// </summary>
     /// <returns>The built <see cref="AppBuilder"/> instance.</returns>
-    public static AppBuilder BuildAvaloniaApp()
-    {
+    public static AppBuilder BuildAvaloniaApp() {
         return AppBuilder.Configure<App>()
             .UsePlatformDetect()
             .LogToTrace();

--- a/src/Spice86/Spice86.csproj
+++ b/src/Spice86/Spice86.csproj
@@ -39,22 +39,22 @@
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>
-		<PackageReference Include="OxyPlot.Avalonia" Version="2.1.0" />
 	</ItemGroup>
 
 	<ItemGroup>
 		<PackageReference Include="Ben.Demystifier" Version="0.4.1" />
-		<PackageReference Include="MessageBox.Avalonia" Version="1.7.1" />
+		<PackageReference Include="MessageBox.Avalonia" Version="2.2.0" />
 		<PackageReference Include="CommunityToolkit.Mvvm" Version="8.2.0" />
 		<PackageReference Include="ErrorProne.NET.CoreAnalyzers" Version="0.1.2">
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>
 		<PackageReference Include="Microsoft.Win32.Registry" Version="5.0.0" />
-		<PackageReference Include="Avalonia" Version="0.10.21" />
-		<PackageReference Include="Avalonia.Desktop" Version="0.10.21" />
+		<PackageReference Include="Avalonia" Version="11.0.0-rc1.1" />
+		<PackageReference Include="Avalonia.Themes.Fluent" Version="11.0.0-rc1.1" />
+		<PackageReference Include="Avalonia.Desktop" Version="11.0.0-rc1.1" />
 		<!--Condition below is needed to remove Avalonia.Diagnostics package from build output in Release configuration.-->
-		<PackageReference Condition="'$(Configuration)' == 'Debug'" Include="Avalonia.Diagnostics" Version="0.10.21" />
+		<PackageReference Condition="'$(Configuration)' == 'Debug'" Include="Avalonia.Diagnostics" Version="11.0.0-rc1.1" />
 	</ItemGroup>
 	<ItemGroup>
 		<AvaloniaResource Include="Icon\Spice86.ico" />

--- a/src/Spice86/Startup.cs
+++ b/src/Spice86/Startup.cs
@@ -17,8 +17,7 @@ internal static class Startup {
     /// </summary>
     /// <param name="commandLineArgs">The command line arguments.</param>
     /// <returns>A <see cref="ServiceProvider"/> instance that can be used to retrieve registered services.</returns>
-    public static ServiceProvider StartupInjectedServices(string[] commandLineArgs)
-    {
+    public static ServiceProvider StartupInjectedServices(string[] commandLineArgs) {
         ServiceCollection services = new ServiceCollection();
         services.AddLogging();
         ServiceProvider serviceProvider = services.BuildServiceProvider();

--- a/src/Spice86/UserControls/PaletteUserControl.axaml
+++ b/src/Spice86/UserControls/PaletteUserControl.axaml
@@ -5,7 +5,7 @@
             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
             mc:Ignorable="d" d:DesignWidth="800" d:DesignHeight="450"
             x:Class="Spice86.UserControls.PaletteUserControl">
-    <ItemsControl Items="{Binding Palette}">
+    <ItemsControl ItemsSource="{Binding Palette}">
         <ItemsControl.ItemsPanel>
             <ItemsPanelTemplate>
                 <UniformGrid Rows="16" Columns="16" />

--- a/src/Spice86/ViewModels/MainWindowViewModel.cs
+++ b/src/Spice86/ViewModels/MainWindowViewModel.cs
@@ -459,8 +459,15 @@ public sealed partial class MainWindowViewModel : ObservableObject, IGui, IDispo
     [ObservableProperty]
     private string _currentLogLevel = "";
 
-    [RelayCommand]
-    public void SetLogLevel(string logLevel) {
+    [RelayCommand] public void SetLogLevelToSilent() => SetLogLevel("Silent");
+    [RelayCommand] public void SetLogLevelToVerbose() => SetLogLevel("Verbose");
+    [RelayCommand] public void SetLogLevelToDebug() => SetLogLevel("Debug");
+    [RelayCommand] public void SetLogLevelToInformation() => SetLogLevel("Information");
+    [RelayCommand] public void SetLogLevelToWarning() => SetLogLevel("Warning");
+    [RelayCommand] public void SetLogLevelToError() => SetLogLevel("Error");
+    [RelayCommand] public void SetLogLevelToFatal() => SetLogLevel("Fatal");
+
+    private void SetLogLevel(string logLevel) {
         if (logLevel == "Silent") {
             CurrentLogLevel = logLevel;
             _loggerService.AreLogsSilenced = true;

--- a/src/Spice86/ViewModels/MainWindowViewModel.cs
+++ b/src/Spice86/ViewModels/MainWindowViewModel.cs
@@ -232,13 +232,12 @@ public sealed partial class MainWindowViewModel : ObservableObject, IGui, IDispo
 
             IReadOnlyList<IStorageFile> files = await storageProvider.OpenFilePickerAsync(options);
 
-            if (string.IsNullOrWhiteSpace(filePath)) {
-                if (!File.Exists(filePath) && desktop.MainWindow is not null) {
-                    if (files.Any()) {
+            if (string.IsNullOrWhiteSpace(filePath) || !File.Exists(filePath)) {
+                if (files.Any()) {
                         filePath = files[0].Path.AbsolutePath;
                         await RestartEmulatorWithNewProgram(filePath);
                     }
-                }
+                
             } else {
                 await RestartEmulatorWithNewProgram(filePath);
             }

--- a/src/Spice86/ViewModels/VideoBufferViewModel.cs
+++ b/src/Spice86/ViewModels/VideoBufferViewModel.cs
@@ -25,8 +25,6 @@ public sealed partial class VideoBufferViewModel : ObservableObject, IVideoBuffe
 
     private bool _exitDrawThread;
 
-    private readonly ManualResetEvent _manualResetEvent = new(false);
-
     /// <summary>
     /// For AvaloniaUI Designer
     /// </summary>
@@ -53,9 +51,6 @@ public sealed partial class VideoBufferViewModel : ObservableObject, IVideoBuffe
     private void DrawThreadMethod() {
         while (!_exitDrawThread) {
             _drawAction?.Invoke();
-            if (!_exitDrawThread) {
-                _manualResetEvent.WaitOne();
-            }
         }
     }
 
@@ -173,10 +168,6 @@ public sealed partial class VideoBufferViewModel : ObservableObject, IVideoBuffe
                 LastFrameRenderTimeMs = _frameRenderTimeWatch.ElapsedMilliseconds;
             }
         };
-        if (!_exitDrawThread) {
-            _manualResetEvent.Set();
-            _manualResetEvent.Reset();
-        }
     }
 
     [ObservableProperty]
@@ -188,11 +179,9 @@ public sealed partial class VideoBufferViewModel : ObservableObject, IVideoBuffe
         if (!_disposedValue) {
             if (disposing) {
                 _exitDrawThread = true;
-                _manualResetEvent.Set();
                 if (_drawThread?.IsAlive == true) {
                     _drawThread.Join();
                 }
-                _manualResetEvent.Dispose();
                 Dispatcher.UIThread.Post(() => {
                     Bitmap?.Dispose();
                     Bitmap = null;

--- a/src/Spice86/ViewModels/VideoBufferViewModel.cs
+++ b/src/Spice86/ViewModels/VideoBufferViewModel.cs
@@ -13,17 +13,22 @@ using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 
 using Spice86.Views;
+using Spice86.Shared;
 using Spice86.Shared.Interfaces;
 
+using System;
 using System.Diagnostics;
+using System.Threading.Tasks;
 
 /// <inheritdoc cref="Spice86.Shared.Interfaces.IVideoBufferViewModel" />
-public sealed partial class VideoBufferViewModel : ObservableObject, IVideoBufferViewModel {
+public sealed partial class VideoBufferViewModel : ObservableObject, IVideoBufferViewModel, IComparable<VideoBufferViewModel> {
     private bool _disposedValue;
 
     private Thread? _drawThread;
 
     private bool _exitDrawThread;
+
+    private readonly ManualResetEvent _manualResetEvent = new(false);
 
     /// <summary>
     /// For AvaloniaUI Designer
@@ -34,14 +39,19 @@ public sealed partial class VideoBufferViewModel : ObservableObject, IVideoBuffe
         }
         Width = 320;
         Height = 200;
+        Address = 1;
+        _index = 1;
         Scale = 1;
         _frameRenderTimeWatch = new Stopwatch();
     }
 
-    public VideoBufferViewModel(IVideoCard videoCard, double scale, int width, int height) {
+    public VideoBufferViewModel(IVideoCard videoCard, double scale, int width, int height, uint address, int index, bool isPrimaryDisplay) {
         _videoCard = videoCard;
+        _isPrimaryDisplay = isPrimaryDisplay;
         Width = width;
         Height = height;
+        Address = address;
+        _index = index;
         Scale = scale;
         MainWindow.AppClosing += MainWindow_AppClosing;
         _frameRenderTimeWatch = new Stopwatch();
@@ -51,6 +61,9 @@ public sealed partial class VideoBufferViewModel : ObservableObject, IVideoBuffe
     private void DrawThreadMethod() {
         while (!_exitDrawThread) {
             _drawAction?.Invoke();
+            if (!_exitDrawThread) {
+                _manualResetEvent.WaitOne();
+            }
         }
     }
 
@@ -82,6 +95,8 @@ public sealed partial class VideoBufferViewModel : ObservableObject, IVideoBuffe
     private void MainWindow_AppClosing(object? sender, System.ComponentModel.CancelEventArgs e) {
         _appClosing = true;
     }
+
+    public uint Address { get; private set; }
 
     /// <summary>
     /// TODO : Get current DPI from Avalonia or Skia.
@@ -126,12 +141,27 @@ public sealed partial class VideoBufferViewModel : ObservableObject, IVideoBuffe
     private int _height = 200;
 
     [ObservableProperty]
+    private bool _isPrimaryDisplay;
+
+    [ObservableProperty]
     private int _width = 320;
 
     [ObservableProperty]
     private long _framesRendered;
 
     private bool _appClosing;
+
+    private readonly int _index;
+
+    public int CompareTo(VideoBufferViewModel? other) {
+        if (_index < other?._index) {
+            return -1;
+        }
+        if (_index == other?._index) {
+            return 0;
+        }
+        return 1;
+    }
 
     public void Dispose() {
         // Do not change this code. Put cleanup code in 'Dispose(bool disposing)' method
@@ -154,20 +184,21 @@ public sealed partial class VideoBufferViewModel : ObservableObject, IVideoBuffe
             _drawThread.Start();
         }
         _drawAction ??= () => {
-            unsafe {
-                _frameRenderTimeWatch.Restart();
-                using ILockedFramebuffer pixels = Bitmap.Lock();
-                var buffer = new Span<uint>((void*)pixels.Address, pixels.RowBytes * pixels.Size.Height / 4);
-                _videoCard?.Render(buffer);
+            _frameRenderTimeWatch.Restart();
+            using ILockedFramebuffer pixels = Bitmap.Lock();
+            _videoCard?.Render(Address, Width, Height, pixels.Address);
 
-                Dispatcher.UIThread.Post(() => {
-                    UIUpdateMethod?.Invoke();
-                    FramesRendered++;
-                }, DispatcherPriority.Render);
-                _frameRenderTimeWatch.Stop();
-                LastFrameRenderTimeMs = _frameRenderTimeWatch.ElapsedMilliseconds;
-            }
+            Dispatcher.UIThread.Post(() => {
+                UIUpdateMethod?.Invoke();
+                FramesRendered++;
+            }, DispatcherPriority.Render);
+            _frameRenderTimeWatch.Stop();
+            LastFrameRenderTimeMs = _frameRenderTimeWatch.ElapsedMilliseconds;
         };
+        if (!_exitDrawThread) {
+            _manualResetEvent.Set();
+            _manualResetEvent.Reset();
+        }
     }
 
     [ObservableProperty]
@@ -175,13 +206,23 @@ public sealed partial class VideoBufferViewModel : ObservableObject, IVideoBuffe
 
     private readonly IVideoCard? _videoCard;
 
+    public override bool Equals(object? obj) {
+        return this == obj || ((obj is VideoBufferViewModel other) && _index == other._index);
+    }
+
+    public override int GetHashCode() {
+        return _index;
+    }
+
     private void Dispose(bool disposing) {
         if (!_disposedValue) {
             if (disposing) {
                 _exitDrawThread = true;
+                _manualResetEvent.Set();
                 if (_drawThread?.IsAlive == true) {
                     _drawThread.Join();
                 }
+                _manualResetEvent.Dispose();
                 Dispatcher.UIThread.Post(() => {
                     Bitmap?.Dispose();
                     Bitmap = null;

--- a/src/Spice86/Views/DebugWindow.axaml.cs
+++ b/src/Spice86/Views/DebugWindow.axaml.cs
@@ -11,9 +11,6 @@ using Spice86.ViewModels;
 public partial class DebugWindow : Window {
     public DebugWindow() {
         InitializeComponent();
-#if DEBUG
-        this.AttachDevTools();
-#endif
         if (!Design.IsDesignMode &&
             Application.Current?.ApplicationLifetime is IClassicDesktopStyleApplicationLifetime desktop) {
             Owner = desktop.MainWindow;
@@ -22,18 +19,11 @@ public partial class DebugWindow : Window {
     
     public DebugWindow(Machine machine) {
         InitializeComponent();
-#if DEBUG
-        this.AttachDevTools();
-#endif
         if (!Design.IsDesignMode &&
             Application.Current?.ApplicationLifetime is IClassicDesktopStyleApplicationLifetime desktop) {
             Owner = desktop.MainWindow;
         }
 
         DataContext = new DebugViewModel(machine);
-    }
-    
-    private void InitializeComponent() {
-        AvaloniaXamlLoader.Load(this);
     }
 }

--- a/src/Spice86/Views/MainWindow.axaml
+++ b/src/Spice86/Views/MainWindow.axaml
@@ -35,13 +35,13 @@
 					<MenuItem Header="Color Palette" IsEnabled="{Binding IsMachineRunning}" Command="{Binding ShowColorPaletteCommand}" />
 					<MenuItem Header="Performance" IsEnabled="{Binding IsMachineRunning}" Command="{Binding ShowPerformanceCommand}" />
 					<MenuItem Header="{Binding CurrentLogLevel, StringFormat='Log Level ({0})'}">
-						<MenuItem Header="Silent" Command="{Binding SetLogLevel}" CommandParameter="Silent"></MenuItem>
-						<MenuItem Header="Verbose" Command="{Binding SetLogLevel}" CommandParameter="Verbose"></MenuItem>
-						<MenuItem Header="Debug" Command="{Binding SetLogLevel}" CommandParameter="Debug"></MenuItem>
-						<MenuItem Header="Information" Command="{Binding SetLogLevel}" CommandParameter="Information"></MenuItem>
-						<MenuItem Header="Warning" Command="{Binding SetLogLevel}" CommandParameter="Warning"></MenuItem>
-						<MenuItem Header="Error" Command="{Binding SetLogLevel}" CommandParameter="Error"></MenuItem>
-						<MenuItem Header="Fatal" Command="{Binding SetLogLevel}" CommandParameter="Fatal"></MenuItem>
+						<MenuItem Header="Silent" Command="{Binding SetLogLevelToSilent}" />
+						<MenuItem Header="Verbose" Command="{Binding SetLogLevelToVerbose}" />
+						<MenuItem Header="Debug" Command="{Binding SetLogLevelToDebug}" />
+						<MenuItem Header="Information" Command="{Binding SetLogLevelToInformation}" />
+						<MenuItem Header="Warning" Command="{Binding SetLogLevelToWarning}" />
+						<MenuItem Header="Error" Command="{Binding SetLogLevelToError}" />
+						<MenuItem Header="Fatal" Command="{Binding SetLogLevelToFatal}" />
 					</MenuItem>
 					<MenuItem Header="Dump emulator state to directory..." IsEnabled="{Binding IsMachineRunning}" Command="{Binding DumpEmulatorStateToFileCommand}" />
 				</MenuItem>

--- a/src/Spice86/Views/MainWindow.axaml.cs
+++ b/src/Spice86/Views/MainWindow.axaml.cs
@@ -4,6 +4,9 @@ using Avalonia;
 using Avalonia.Controls;
 using Avalonia.Input;
 using Avalonia.Markup.Xaml;
+
+using Spice86.ViewModels;
+
 using System.ComponentModel;
 
 internal partial class MainWindow : Window {
@@ -31,10 +34,12 @@ internal partial class MainWindow : Window {
 
     protected override void OnKeyUp(KeyEventArgs e) {
         FocusOnVideoBuffer();
+        (DataContext as MainWindowViewModel)?.OnKeyUp(e);
     }
 
     protected override void OnKeyDown(KeyEventArgs e) {
         FocusOnVideoBuffer();
+        (DataContext as MainWindowViewModel)?.OnKeyDown(e);
     }
 
     public static event EventHandler<CancelEventArgs>? AppClosing;

--- a/src/Spice86/Views/MainWindow.axaml.cs
+++ b/src/Spice86/Views/MainWindow.axaml.cs
@@ -10,9 +10,6 @@ internal partial class MainWindow : Window {
     public MainWindow() {
         InitializeComponent();
         Closing += MainWindow_Closing;
-#if DEBUG
-        this.AttachDevTools();
-#endif
     }
 
     private Image? _videoBufferImage;
@@ -27,7 +24,7 @@ internal partial class MainWindow : Window {
     private void FocusOnVideoBuffer() {
         if (_videoBufferImage is not null) {
             _videoBufferImage.IsEnabled = false;
-            FocusManager.Instance?.Focus(_videoBufferImage);
+            _videoBufferImage.Focus();
             _videoBufferImage.IsEnabled = true;
         }
     }
@@ -44,9 +41,5 @@ internal partial class MainWindow : Window {
 
     private void MainWindow_Closing(object? sender, CancelEventArgs e) {
         AppClosing?.Invoke(sender, e);
-    }
-
-    private void InitializeComponent() {
-        AvaloniaXamlLoader.Load(this);
     }
 }

--- a/src/Spice86/Views/PaletteWindow.axaml.cs
+++ b/src/Spice86/Views/PaletteWindow.axaml.cs
@@ -11,13 +11,6 @@ internal partial class PaletteWindow : Window {
 
     public PaletteWindow() {
         InitializeComponent();
-#if DEBUG
-        this.AttachDevTools();
-#endif
-    }
-
-    private void InitializeComponent() {
-        AvaloniaXamlLoader.Load(this);
     }
 
     public PaletteWindow(PaletteViewModel paletteViewModel) {

--- a/src/Spice86/Views/PerformanceWindow.axaml
+++ b/src/Spice86/Views/PerformanceWindow.axaml
@@ -41,24 +41,5 @@
 					StringFormat={}{0:N0} ms}"/>
 			</WrapPanel>
 		</TabItem>
-		<TabItem Header="History">
-			<WrapPanel>
-				<StackPanel Orientation="Vertical">
-					<oxy:Plot Title="CPU" Subtitle="Last 10 minutes"
-					  Width="{Binding $parent[StackPanel].Bounds.Width}"
-					  Height="{Binding $parent[StackPanel].Bounds.Height}"
-					  MinWidth="600"
-					  MinHeight="300"
-			          PlotMargins="50 0 0 0"
-			          PlotAreaBorderColor="#999999">
-						<oxy:AreaSeries 
-							DataFieldX="Number"
-							DataFieldY="Value"
-							Items="{Binding CpuHistoryDataPoints}"
-							Color="#fd6d00" />
-					</oxy:Plot>
-				</StackPanel>
-			</WrapPanel>
-		</TabItem>
 	</TabControl>
 </Window>

--- a/src/Spice86/Views/PerformanceWindow.axaml.cs
+++ b/src/Spice86/Views/PerformanceWindow.axaml.cs
@@ -7,16 +7,9 @@ using Avalonia.Markup.Xaml;
 internal partial class PerformanceWindow : Window {
     public PerformanceWindow() {
         InitializeComponent();
-#if DEBUG
-        this.AttachDevTools();
-#endif
         if (!Design.IsDesignMode &&
             Application.Current?.ApplicationLifetime is IClassicDesktopStyleApplicationLifetime desktop) {
             Owner = desktop.MainWindow;
         }
-    }
-
-    private void InitializeComponent() {
-        AvaloniaXamlLoader.Load(this);
     }
 }

--- a/src/Spice86/Views/VideoBufferView.axaml
+++ b/src/Spice86/Views/VideoBufferView.axaml
@@ -17,7 +17,7 @@
 		</LayoutTransformControl.RenderTransform>
 		<Viewbox>
 			<Image x:Name="Image"
-				RenderOptions.BitmapInterpolationMode="Default"
+				RenderOptions.BitmapInterpolationMode="None"
 				Cursor="{Binding Cursor}"
 				Source="{Binding Bitmap}" />
 		</Viewbox>

--- a/src/Spice86/Views/VideoBufferView.axaml.cs
+++ b/src/Spice86/Views/VideoBufferView.axaml.cs
@@ -13,10 +13,6 @@ using System;
 internal partial class VideoBufferView : UserControl {
     public VideoBufferView() {
         InitializeComponent();
-    }
-
-    private void InitializeComponent() {
-        AvaloniaXamlLoader.Load(this);
         DataContextChanged += VideoBufferView_DataContextChanged;
         MainWindow.AppClosing += MainWindow_AppClosing;
     }
@@ -24,8 +20,6 @@ internal partial class VideoBufferView : UserControl {
     private void MainWindow_AppClosing(object? sender, System.ComponentModel.CancelEventArgs e) {
         _appClosing = true;
     }
-    
-    private Image? _image;
     private bool _appClosing;
     private MainWindowViewModel? _mainVm;
 
@@ -45,21 +39,22 @@ internal partial class VideoBufferView : UserControl {
             return;
         }
 
-        _image = this.FindControl<Image>(nameof(Image));
-        if (_image is not null && desktop.MainWindow is MainWindow mainWindow && desktop.MainWindow.DataContext is MainWindowViewModel mainVm) {
-            mainWindow.SetPrimaryDisplayControl(_image);
-            _mainVm = mainVm;
-            _image.PointerMoved += (_, e) => _mainVm?.OnMouseMoved(e, _image);
-            _image.PointerPressed += (_, e) => _mainVm?.OnMouseButtonDown(e, _image);
-            _image.PointerReleased += (_, e) => _mainVm?.OnMouseButtonUp(e, _image);
+        if (Image is not null && desktop.MainWindow is MainWindow mainWindow && desktop.MainWindow.DataContext is MainWindowViewModel mainVm) {
+            mainWindow.SetPrimaryDisplayControl(Image);
+            Image.PointerMoved -= (s, e) => mainVm.OnMouseMoved(e, Image);
+            Image.PointerPressed -= (s, e) => mainVm.OnMouseButtonDown(e, Image);
+            Image.PointerReleased -= (s, e) => mainVm.OnMouseButtonUp(e, Image);
+            Image.PointerMoved += (s, e) => mainVm.OnMouseMoved(e, Image);
+            Image.PointerPressed += (s, e) => mainVm.OnMouseButtonDown(e, Image);
+            Image.PointerReleased += (s, e) => mainVm.OnMouseButtonUp(e, Image);
         }
         vm.SetUIUpdateMethod(InvalidateImage);
     }
 
     private void InvalidateImage() {
-        if (_appClosing || _image is null) {
+        if (_appClosing || Image is null) {
             return;
         }
-        _image.InvalidateVisual();
+        Image.InvalidateVisual();
     }
 }

--- a/src/Spice86/Views/VideoBufferView.axaml.cs
+++ b/src/Spice86/Views/VideoBufferView.axaml.cs
@@ -17,11 +17,12 @@ internal partial class VideoBufferView : UserControl {
         MainWindow.AppClosing += MainWindow_AppClosing;
     }
 
+    private MainWindowViewModel? _mainVm;
+
     private void MainWindow_AppClosing(object? sender, System.ComponentModel.CancelEventArgs e) {
         _appClosing = true;
     }
     private bool _appClosing;
-    private MainWindowViewModel? _mainVm;
 
     protected override void OnKeyUp(KeyEventArgs e) {
         _mainVm?.OnKeyUp(e);
@@ -40,6 +41,7 @@ internal partial class VideoBufferView : UserControl {
         }
 
         if (Image is not null && desktop.MainWindow is MainWindow mainWindow && desktop.MainWindow.DataContext is MainWindowViewModel mainVm) {
+            _mainVm = mainVm;
             mainWindow.SetPrimaryDisplayControl(Image);
             Image.PointerMoved -= (s, e) => mainVm.OnMouseMoved(e, Image);
             Image.PointerPressed -= (s, e) => mainVm.OnMouseButtonDown(e, Image);

--- a/src/Spice86/Views/VideoBufferView.axaml.cs
+++ b/src/Spice86/Views/VideoBufferView.axaml.cs
@@ -3,8 +3,6 @@ namespace Spice86.Views;
 using Avalonia;
 using Avalonia.Controls;
 using Avalonia.Controls.ApplicationLifetimes;
-using Avalonia.Input;
-using Avalonia.Markup.Xaml;
 
 using Spice86.ViewModels;
 
@@ -17,22 +15,10 @@ internal partial class VideoBufferView : UserControl {
         MainWindow.AppClosing += MainWindow_AppClosing;
     }
 
-    private MainWindowViewModel? _mainVm;
-
     private void MainWindow_AppClosing(object? sender, System.ComponentModel.CancelEventArgs e) {
         _appClosing = true;
     }
     private bool _appClosing;
-
-    protected override void OnKeyUp(KeyEventArgs e) {
-        _mainVm?.OnKeyUp(e);
-        base.OnKeyUp(e);
-    }
-
-    protected override void OnKeyDown(KeyEventArgs e) {
-        _mainVm?.OnKeyDown(e);
-        base.OnKeyDown(e);
-    }
 
     private void VideoBufferView_DataContextChanged(object? sender, EventArgs @event) {
         if (DataContext is not VideoBufferViewModel vm ||
@@ -41,7 +27,6 @@ internal partial class VideoBufferView : UserControl {
         }
 
         if (Image is not null && desktop.MainWindow is MainWindow mainWindow && desktop.MainWindow.DataContext is MainWindowViewModel mainVm) {
-            _mainVm = mainVm;
             mainWindow.SetPrimaryDisplayControl(Image);
             Image.PointerMoved -= (s, e) => mainVm.OnMouseMoved(e, Image);
             Image.PointerPressed -= (s, e) => mainVm.OnMouseButtonDown(e, Image);


### PR DESCRIPTION
### Description of Changes

Migration to the latest version of the UI framework, which was published a few hours ago.

### Rationale behind Changes

Eventually, the v0.10.x version will not be supported anymore.

Plus, the performance regressions found in AvaloniaUI v11-rc1 were fixed.

### Suggested Testing Steps

Test this while looking at the average number of instructions per second, compared with the master branch.

I already did so on too very different machines, and the numbers were very close.
