### PR TITLE
Rework Memory class

### DIFF
--- a/src/Spice86.Core/Emulator/CPU/CPU.cs
+++ b/src/Spice86.Core/Emulator/CPU/CPU.cs
@@ -158,7 +158,7 @@ public class Cpu {
     }
 
     public uint NextUint32() {
-        uint res = _memory.GetUint32(InternalIpPhysicalAddress);
+        uint res = _memory.UInt32[InternalIpPhysicalAddress];
         ExecutionFlowRecorder.RegisterExecutableByte(_machine, State.CS, _internalIp);
         ExecutionFlowRecorder.RegisterExecutableByte(_machine, State.CS, (ushort) (_internalIp+1));
         ExecutionFlowRecorder.RegisterExecutableByte(_machine, State.CS, (ushort) (_internalIp+2));
@@ -168,7 +168,7 @@ public class Cpu {
     }
 
     public ushort NextUint16() {
-        ushort res = _memory.GetUint16(InternalIpPhysicalAddress);
+        ushort res = _memory.UInt16[InternalIpPhysicalAddress];
         ExecutionFlowRecorder.RegisterExecutableByte(_machine, State.CS, _internalIp);
         ExecutionFlowRecorder.RegisterExecutableByte(_machine, State.CS, (ushort) (_internalIp+1));
         _internalIp += 2;
@@ -176,7 +176,7 @@ public class Cpu {
     }
 
     public byte NextUint8() {
-        byte res = _memory.GetUint8(InternalIpPhysicalAddress);
+        byte res = _memory.UInt8[InternalIpPhysicalAddress];
         ExecutionFlowRecorder.RegisterExecutableByte(_machine, State.CS, _internalIp);
         _internalIp++;
         return res;
@@ -184,14 +184,14 @@ public class Cpu {
 
     public void SetFlagOnInterruptStack(int flagMask, bool flagValue) {
         uint flagsAddress = MemoryUtils.ToPhysicalAddress(State.SS, (ushort)(State.SP + 4));
-        int value = _memory.GetUint16(flagsAddress);
+        int value = _memory.UInt16[flagsAddress];
         if (flagValue) {
             value |= flagMask;
         } else {
             value &= ~flagMask;
         }
 
-        _memory.SetUint16(flagsAddress, (ushort)value);
+        _memory.UInt16[flagsAddress] = (ushort)value;
     }
 
     private void HandleCpuException(CpuException cpuException) {
@@ -1217,8 +1217,8 @@ public class Cpu {
             return;
         }
 
-        ushort targetIP = _memory.GetUint16((ushort)(4 * vectorNumber.Value));
-        ushort targetCS = _memory.GetUint16((ushort)((4 * vectorNumber.Value) + 2));
+        ushort targetIP = _memory.UInt16[(ushort)(4 * vectorNumber.Value)];
+        ushort targetCS = _memory.UInt16[(ushort)((4 * vectorNumber.Value) + 2)];
         if (ErrorOnUninitializedInterruptHandler && targetCS == 0 && targetIP == 0) {
             throw new UnhandledOperationException(_machine,
                 $"Int was called but vector was not initialized for vectorNumber={ConvertUtils.ToHex(vectorNumber.Value)}");

--- a/src/Spice86.Core/Emulator/CPU/InstructionsImpl/Instructions16.cs
+++ b/src/Spice86.Core/Emulator/CPU/InstructionsImpl/Instructions16.cs
@@ -235,14 +235,14 @@ public class Instructions16 : Instructions16Or32 {
     }
 
     public override void Movs() {
-        ushort value = Memory.GetUint16(MemoryAddressOverridableDsSi);
-        Memory.SetUint16(MemoryAddressEsDi, value);
+        ushort value = Memory.UInt16[MemoryAddressOverridableDsSi];
+        Memory.UInt16[MemoryAddressEsDi] = value;
         AdvanceSIDI();
     }
 
     public override void Cmps() {
-        ushort value = Memory.GetUint16(MemoryAddressOverridableDsSi);
-        Alu.Sub16(value, Memory.GetUint16(MemoryAddressEsDi));
+        ushort value = Memory.UInt16[MemoryAddressOverridableDsSi];
+        Alu.Sub16(value, Memory.UInt16[MemoryAddressEsDi]);
         AdvanceSIDI();
     }
 
@@ -258,30 +258,30 @@ public class Instructions16 : Instructions16Or32 {
     }
 
     public override void Stos() {
-        Memory.SetUint16(MemoryAddressEsDi, State.AX);
+        Memory.UInt16[MemoryAddressEsDi] = State.AX;
         AdvanceDI();
     }
 
     public override void Lods() {
-        State.AX = Memory.GetUint16(MemoryAddressOverridableDsSi);
+        State.AX = Memory.UInt16[MemoryAddressOverridableDsSi];
         AdvanceSI();
     }
 
     public override void Scas() {
-        Alu.Sub16(State.AX, Memory.GetUint16(MemoryAddressEsDi));
+        Alu.Sub16(State.AX, Memory.UInt16[MemoryAddressEsDi]);
         AdvanceDI();
     }
 
     public override void Ins() {
         ushort port = State.DX;
         ushort value = Cpu.In16(port);
-        Memory.SetUint16(MemoryAddressEsDi, value);
+        Memory.UInt16[MemoryAddressEsDi] = value;
         AdvanceDI();
     }
 
     public override void Outs() {
         ushort port = State.DX;
-        ushort value = Memory.GetUint16(MemoryAddressOverridableDsSi);
+        ushort value = Memory.UInt16[MemoryAddressOverridableDsSi];
         Cpu.Out16(port, value);
         AdvanceSI();
     }
@@ -428,12 +428,12 @@ public class Instructions16 : Instructions16Or32 {
 
     public override void MovAccMoffs() {
         // MOV AX moffs16
-        State.AX = Memory.GetUint16(DsNextUint16Address);
+        State.AX = Memory.UInt16[DsNextUint16Address];
     }
 
     public override void MovMoffsAcc() {
         // MOV moffs16 AX
-        Memory.SetUint16(DsNextUint16Address, State.AX);
+        Memory.UInt16[DsNextUint16Address] = State.AX;
     }
     
     public override void MovRmImm() {
@@ -495,8 +495,8 @@ public class Instructions16 : Instructions16Or32 {
 
     protected override ushort DoLxsAndReturnSegmentValue() {
         uint memoryAddress = ReadLxsMemoryAddress();
-        ModRM.R16 = Memory.GetUint16(memoryAddress);
-        return Memory.GetUint16(memoryAddress + 2);
+        ModRM.R16 = Memory.UInt16[memoryAddress];
+        return Memory.UInt16[memoryAddress + 2];
     }
     
     public override void InImm8() {

--- a/src/Spice86.Core/Emulator/CPU/InstructionsImpl/Instructions16Or32.cs
+++ b/src/Spice86.Core/Emulator/CPU/InstructionsImpl/Instructions16Or32.cs
@@ -110,8 +110,8 @@ public abstract class Instructions16Or32 : Instructions {
             return;
         }
 
-        ushort ip = Memory.GetUint16(ipAddress.Value);
-        ushort cs = Memory.GetUint16(ipAddress.Value + 2);
+        ushort ip = Memory.UInt16[ipAddress.Value];
+        ushort cs = Memory.UInt16[ipAddress.Value + 2];
         Cpu.FarCallWithReturnIpNextInstruction(cs, ip);
     }
 
@@ -126,8 +126,8 @@ public abstract class Instructions16Or32 : Instructions {
             return;
         }
 
-        ushort ip = Memory.GetUint16(ipAddress.Value);
-        ushort cs = Memory.GetUint16(ipAddress.Value + 2);
+        ushort ip = Memory.UInt16[ipAddress.Value];
+        ushort cs = Memory.UInt16[ipAddress.Value + 2];
         Cpu.JumpFar(cs, ip);
     }
 

--- a/src/Spice86.Core/Emulator/CPU/InstructionsImpl/Instructions32.cs
+++ b/src/Spice86.Core/Emulator/CPU/InstructionsImpl/Instructions32.cs
@@ -233,14 +233,14 @@ public class Instructions32 : Instructions16Or32 {
     }
 
     public override void Movs() {
-        uint value = Memory.GetUint32(MemoryAddressOverridableDsSi);
-        Memory.SetUint32(MemoryAddressEsDi, value);
+        uint value = Memory.UInt32[MemoryAddressOverridableDsSi];
+        Memory.UInt32[MemoryAddressEsDi] = value;
         AdvanceSIDI();
     }
     
     public override void Cmps() {
-        uint value = Memory.GetUint32(MemoryAddressOverridableDsSi);
-        Alu.Sub32(value, Memory.GetUint32(MemoryAddressEsDi));
+        uint value = Memory.UInt32[MemoryAddressOverridableDsSi];
+        Alu.Sub32(value, Memory.UInt32[MemoryAddressEsDi]);
         AdvanceSIDI();
     }
 
@@ -256,30 +256,30 @@ public class Instructions32 : Instructions16Or32 {
     }
     
     public override void Stos() {
-        Memory.SetUint32(MemoryAddressEsDi, State.EAX);
+        Memory.UInt32[MemoryAddressEsDi] = State.EAX;
         AdvanceDI();
     }
     
     public override void Lods() {
-        State.EAX = Memory.GetUint32(MemoryAddressOverridableDsSi);
+        State.EAX = Memory.UInt32[MemoryAddressOverridableDsSi];
         AdvanceSI();
     }
     
     public override void Scas() {
-        Alu.Sub32(State.EAX, Memory.GetUint32(MemoryAddressEsDi));
+        Alu.Sub32(State.EAX, Memory.UInt32[MemoryAddressEsDi]);
         AdvanceDI();
     }
     
     public override void Ins() {
         ushort port = State.DX;
         uint value = Cpu.In32(port);
-        Memory.SetUint32(MemoryAddressEsDi, value);
+        Memory.UInt32[MemoryAddressEsDi] = value;
         AdvanceDI();
     }
 
     public override void Outs() {
         ushort port = State.DX;
-        uint value = Memory.GetUint32(MemoryAddressOverridableDsSi);
+        uint value = Memory.UInt32[MemoryAddressOverridableDsSi];
         Cpu.Out32(port, value);
         AdvanceSI();
     }
@@ -424,12 +424,12 @@ public class Instructions32 : Instructions16Or32 {
     
     public override void MovAccMoffs() {
         // MOV EAX moffs32
-        State.EAX = Memory.GetUint32(DsNextUint16Address);
+        State.EAX = Memory.UInt32[DsNextUint16Address];
     }
     
     public override void MovMoffsAcc() {
         // MOV moffs32 EAX
-        Memory.SetUint32(DsNextUint16Address, State.EAX);
+        Memory.UInt32[DsNextUint16Address] = State.EAX;
     }
     
     public override void MovRmImm() {
@@ -481,8 +481,8 @@ public class Instructions32 : Instructions16Or32 {
     
     protected override ushort DoLxsAndReturnSegmentValue() {
         uint memoryAddress = ReadLxsMemoryAddress();
-        ModRM.R32 = Memory.GetUint32(memoryAddress);
-        return Memory.GetUint16(memoryAddress + 4);
+        ModRM.R32 = Memory.UInt32[memoryAddress];
+        return Memory.UInt16[memoryAddress + 4];
     }
     
     public override void InImm8() {

--- a/src/Spice86.Core/Emulator/CPU/InstructionsImpl/Instructions8.cs
+++ b/src/Spice86.Core/Emulator/CPU/InstructionsImpl/Instructions8.cs
@@ -153,14 +153,14 @@ public class Instructions8 : Instructions {
     }
 
     public override void Movs() {
-        byte value = Memory.GetUint8(MemoryAddressOverridableDsSi);
-        Memory.SetUint8(MemoryAddressEsDi, value);
+        byte value = Memory.UInt8[MemoryAddressOverridableDsSi];
+        Memory.UInt8[MemoryAddressEsDi] = value;
         AdvanceSIDI();
     }
 
     public override void Cmps() {
-        byte value = Memory.GetUint8(MemoryAddressOverridableDsSi);
-        Alu.Sub8(value, Memory.GetUint8(MemoryAddressEsDi));
+        byte value = Memory.UInt8[MemoryAddressOverridableDsSi];
+        Alu.Sub8(value, Memory.UInt8[MemoryAddressEsDi]);
         AdvanceSIDI();
     }
 
@@ -176,30 +176,30 @@ public class Instructions8 : Instructions {
     }
 
     public override void Stos() {
-        Memory.SetUint8(MemoryAddressEsDi, State.AL);
+        Memory.UInt8[MemoryAddressEsDi] = State.AL;
         AdvanceDI();
     }
 
     public override void Lods() {
-        State.AL = Memory.GetUint8(MemoryAddressOverridableDsSi);
+        State.AL = Memory.UInt8[MemoryAddressOverridableDsSi];
         AdvanceSI();
     }
 
     public override void Scas() {
-        Alu.Sub8(State.AL, Memory.GetUint8(MemoryAddressEsDi));
+        Alu.Sub8(State.AL, Memory.UInt8[MemoryAddressEsDi]);
         AdvanceDI();
     }
 
     public override void Ins() {
         ushort port = State.DX;
         byte value = Cpu.In8(port);
-        Memory.SetUint8(MemoryAddressEsDi, value);
+        Memory.UInt8[MemoryAddressEsDi] = value;
         AdvanceDI();
     }
 
     public override void Outs() {
         ushort port = State.DX;
-        byte value = Memory.GetUint8(MemoryAddressOverridableDsSi);
+        byte value = Memory.UInt8[MemoryAddressOverridableDsSi];
         Cpu.Out8(port, value);
         AdvanceSI();
     }
@@ -349,12 +349,12 @@ public class Instructions8 : Instructions {
 
     public override void MovAccMoffs() {
         // MOV AL moffs8
-        State.AL = Memory.GetUint8(DsNextUint16Address);
+        State.AL = Memory.UInt8[DsNextUint16Address];
     }
 
     public override void MovMoffsAcc() {
         // MOV moffs8 AL
-        Memory.SetUint8(DsNextUint16Address, State.AL);
+        Memory.UInt8[DsNextUint16Address] = State.AL;
     }
 
     public override void MovRmImm() {
@@ -391,7 +391,7 @@ public class Instructions8 : Instructions {
     public void Xlat() {
         // XLAT
         uint address = ModRM.GetAddress(SegmentRegisters.DsIndex, State.BX) + State.AL;
-        State.AL = Memory.GetUint8(address);
+        State.AL = Memory.UInt8[address];
     }
 
 

--- a/src/Spice86.Core/Emulator/CPU/ModRM.cs
+++ b/src/Spice86.Core/Emulator/CPU/ModRM.cs
@@ -44,21 +44,21 @@ public class ModRM {
         if (MemoryAddress == null) {
             return _state.Registers.GetRegister32(_registerMemoryIndex);
         }
-        return _memory.GetUint32((uint)MemoryAddress);
+        return _memory.UInt32[(uint)MemoryAddress];
     }
 
     public ushort GetRm16() {
         if (MemoryAddress == null) {
             return _state.Registers.GetRegister16(_registerMemoryIndex);
         }
-        return _memory.GetUint16((uint)MemoryAddress);
+        return _memory.UInt16[(uint)MemoryAddress];
     }
 
     public byte GetRm8() {
         if (MemoryAddress == null) {
             return _state.Registers.GetRegisterFromHighLowIndex8(_registerMemoryIndex);
         }
-        return _memory.GetUint8((uint)MemoryAddress);
+        return _memory.UInt8[(uint)MemoryAddress];
     }
 
     public ushort SegmentRegister { get => _state.SegmentRegisters.GetRegister16(RegisterIndex); set => _state.SegmentRegisters.SetRegister16(RegisterIndex, value); }
@@ -110,7 +110,7 @@ public class ModRM {
         if (MemoryAddress == null) {
             _state.Registers.SetRegister32(_registerMemoryIndex, value);
         } else {
-            _memory.SetUint32((uint)MemoryAddress, value);
+            _memory.UInt32[(uint)MemoryAddress] = value;
         }
     }
 
@@ -118,7 +118,7 @@ public class ModRM {
         if (MemoryAddress == null) {
             _state.Registers.SetRegister16(_registerMemoryIndex, value);
         } else {
-            _memory.SetUint16((uint)MemoryAddress, value);
+            _memory.UInt16[(uint)MemoryAddress] = value;
         }
     }
 
@@ -126,7 +126,7 @@ public class ModRM {
         if (MemoryAddress == null) {
             _state.Registers.SetRegisterFromHighLowIndex8(_registerMemoryIndex, value);
         } else {
-            _memory.SetUint8((uint)MemoryAddress, value);
+            _memory.UInt8[(uint)MemoryAddress] = value;
         }
     }
 

--- a/src/Spice86.Core/Emulator/CPU/Stack.cs
+++ b/src/Spice86.Core/Emulator/CPU/Stack.cs
@@ -14,40 +14,40 @@ public class Stack {
     }
 
     public ushort Peek16(int index) {
-        return memory.GetUint16((uint)(PhysicalAddress + index));
+        return memory.UInt16[(uint)(PhysicalAddress + index)];
     }
 
     public void Poke16(int index, ushort value) {
-        memory.SetUint16((uint)(PhysicalAddress + index), value);
+        memory.UInt16[(uint)(PhysicalAddress + index)] = value;
     }
 
     public ushort Pop16() {
-        ushort res = memory.GetUint16(state.StackPhysicalAddress);
+        ushort res = memory.UInt16[state.StackPhysicalAddress];
         state.SP = (ushort)(state.SP + 2);
         return res;
     }
 
     public void Push16(ushort value) {
         state.SP = (ushort)(state.SP - 2);
-        memory.SetUint16(state.StackPhysicalAddress, value);
+        memory.UInt16[state.StackPhysicalAddress] = value;
     }
     
     public uint Peek32(int index) {
-        return memory.GetUint32((uint)(PhysicalAddress + index));
+        return memory.UInt32[(uint)(PhysicalAddress + index)];
     }
 
     public void Poke32(int index, uint value) {
-        memory.SetUint32((uint)(PhysicalAddress + index), value);
+        memory.UInt32[(uint)(PhysicalAddress + index)] = value;
     }
 
     public uint Pop32() {
-        uint res = memory.GetUint32(state.StackPhysicalAddress);
+        uint res = memory.UInt32[state.StackPhysicalAddress];
         state.SP = (ushort)(state.SP + 4);
         return res;
     }
 
     public void Push32(uint value) {
         state.SP = (ushort)(state.SP - 4);
-        memory.SetUint32(state.StackPhysicalAddress, value);
+        memory.UInt32[state.StackPhysicalAddress] = value;
     }
 }

--- a/src/Spice86.Core/Emulator/Callback/CallbackHandler.cs
+++ b/src/Spice86.Core/Emulator/Callback/CallbackHandler.cs
@@ -124,8 +124,8 @@ public class CallbackHandler : IndexBasedDispatcher {
     /// <param name="offset">The offset address of the vector.</param>
     private void InstallVectorInTable(byte vectorNumber, ushort segment, ushort offset) {
         // install the vector in the vector table
-        _memory.SetUint16((ushort)((4 * vectorNumber) + 2), segment);
-        _memory.SetUint16((ushort)(4 * vectorNumber), offset);
+        _memory.UInt16[(ushort)((4 * vectorNumber) + 2)] = segment;
+        _memory.UInt16[(ushort)(4 * vectorNumber)] = offset;
     }
 
     /// <summary>
@@ -140,14 +140,14 @@ public class CallbackHandler : IndexBasedDispatcher {
         uint address = MemoryUtils.ToPhysicalAddress(segment, offset);
 
         // CALLBACK opcode (custom instruction, FE38 + 16 bits callback number)
-        _memory.SetUint8(address, 0xFE);
-        _memory.SetUint8(address + 1, 0x38);
+        _memory.UInt8[address] = 0xFE;
+        _memory.UInt8[address + 1] = 0x38;
 
         // vector to call
-        _memory.SetUint8(address + 2, vectorNumber);
+        _memory.UInt8[address + 2] = vectorNumber;
 
         // IRET
-        _memory.SetUint8(address + 3, 0xCF);
+        _memory.UInt8[address + 3] = 0xCF;
 
         // 4 bytes used
         return CallbackSize;

--- a/src/Spice86.Core/Emulator/Function/FunctionHandler.cs
+++ b/src/Spice86.Core/Emulator/Function/FunctionHandler.cs
@@ -155,10 +155,10 @@ public class FunctionHandler {
         Memory memory = _machine.Memory;
         State state = _machine.Cpu.State;
         return returnCallType switch {
-            CallType.NEAR => new SegmentedAddress(state.CS, memory.GetUint16(stackPhysicalAddress)),
+            CallType.NEAR => new SegmentedAddress(state.CS, memory.UInt16[stackPhysicalAddress]),
             CallType.FAR or CallType.INTERRUPT => new SegmentedAddress(
-                memory.GetUint16(stackPhysicalAddress + 2),
-                memory.GetUint16(stackPhysicalAddress)),
+                memory.UInt16[stackPhysicalAddress + 2],
+                memory.UInt16[stackPhysicalAddress]),
             CallType.MACHINE => null,
             _ => null
         };

--- a/src/Spice86.Core/Emulator/Gdb/GdbCommandMemoryHandler.cs
+++ b/src/Spice86.Core/Emulator/Gdb/GdbCommandMemoryHandler.cs
@@ -55,7 +55,7 @@ public class GdbCommandMemoryHandler {
                     break;
                 }
 
-                byte b = memory.GetUint8((uint)readAddress);
+                byte b = memory.UInt8[(uint)readAddress];
                 string value = _gdbFormatter.FormatValueAsHex8(b);
                 response.Append(value);
             }

--- a/src/Spice86.Core/Emulator/InterruptHandlers/Dos/DosInt21Handler.cs
+++ b/src/Spice86.Core/Emulator/InterruptHandlers/Dos/DosInt21Handler.cs
@@ -332,8 +332,8 @@ public class DosInt21Handler : InterruptHandler {
     /// </summary>
     public void GetInterruptVector() {
         byte vectorNumber = _state.AL;
-        ushort segment = _memory.GetUint16((uint)((4 * vectorNumber) + 2));
-        ushort offset = _memory.GetUint16((uint)(4 * vectorNumber));
+        ushort segment = _memory.UInt16[(uint)((4 * vectorNumber) + 2)];
+        ushort offset = _memory.UInt16[(uint)(4 * vectorNumber)];
         if (_loggerService.IsEnabled(LogEventLevel.Verbose)) {
             _loggerService.Verbose("GET INTERRUPT VECTOR INT {VectorInt}, got {SegmentedAddress}", ConvertUtils.ToHex8(vectorNumber),
                 ConvertUtils.ToSegmentedAddressRepresentation(segment, offset));
@@ -487,8 +487,8 @@ public class DosInt21Handler : InterruptHandler {
     }
 
     public void SetInterruptVector(byte vectorNumber, ushort segment, ushort offset) {
-        _memory.SetUint16((ushort)((4 * vectorNumber) + 2), segment);
-        _memory.SetUint16((ushort)(4 * vectorNumber), offset);
+        _memory.UInt16[(ushort)((4 * vectorNumber) + 2)] = segment;
+        _memory.UInt16[(ushort)(4 * vectorNumber)] = offset;
     }
 
     public void WriteFileUsingHandle(bool calledFromVm) {
@@ -521,15 +521,15 @@ public class DosInt21Handler : InterruptHandler {
         }
         uint responseAddress = MemoryUtils.ToPhysicalAddress(_state.DS, _state.SI);
         // Fake that we are always at the root of the drive (empty String)
-        _memory.SetUint8(responseAddress, 0);
+        _memory.UInt8[responseAddress] = 0;
     }
 
     private string GetDosString(Memory memory, ushort segment, ushort offset, char end) {
         uint stringStart = MemoryUtils.ToPhysicalAddress(segment, offset);
         StringBuilder stringBuilder = new();
         List<byte> sourceArray = new();
-        while (memory.GetUint8(stringStart) != end) {
-            sourceArray.Add(memory.GetUint8(stringStart++));
+        while (memory.UInt8[stringStart] != end) {
+            sourceArray.Add(memory.UInt8[stringStart++]);
         }
         string convertedString = ConvertDosChars(sourceArray);
         stringBuilder.Append(convertedString);

--- a/src/Spice86.Core/Emulator/InterruptHandlers/Dos/Ems/ExpandedMemoryManager.cs
+++ b/src/Spice86.Core/Emulator/InterruptHandlers/Dos/Ems/ExpandedMemoryManager.cs
@@ -499,9 +499,9 @@ public sealed class ExpandedMemoryManager : InterruptHandler {
     
     public byte GetAllHandlePages(uint tableAddress) {
         foreach(KeyValuePair<int, EmmHandle> allocatedHandle in EmmHandles) {
-            _memory.SetUint16(tableAddress, allocatedHandle.Value.HandleNumber);
+            _memory.UInt16[tableAddress] = allocatedHandle.Value.HandleNumber;
             tableAddress += 2;
-            _memory.SetUint16(tableAddress, (ushort)allocatedHandle.Value.LogicalPages.Count);
+            _memory.UInt16[tableAddress] = (ushort)allocatedHandle.Value.LogicalPages.Count;
             tableAddress += 2;
         }
         return EmmStatus.EmmNoError;
@@ -529,9 +529,9 @@ public sealed class ExpandedMemoryManager : InterruptHandler {
         switch (operation) {
             case EmmSubFunctions.UsePhysicalPageNumbers:
                 for (int i = 0; i < numberOfPages; i++) {
-                    ushort logicalPage = _memory.GetUint16(mapAddress);
+                    ushort logicalPage = _memory.UInt16[mapAddress];
                     mapAddress += 2;
-                    ushort physicalPage = _memory.GetUint16(mapAddress);
+                    ushort physicalPage = _memory.UInt16[mapAddress];
                     mapAddress += 2;
                     MapUnmapHandlePage(logicalPage, physicalPage, handleId);
                     if (_state.AH != EmmStatus.EmmNoError) {
@@ -541,9 +541,9 @@ public sealed class ExpandedMemoryManager : InterruptHandler {
                 break;
             case EmmSubFunctions.UseSegmentedAddress:
                 for (int i = 0; i < numberOfPages; i++) {
-                    ushort logicalPage = _memory.GetUint16(mapAddress);
+                    ushort logicalPage = _memory.UInt16[mapAddress];
                     mapAddress += 2;
-                    ushort segment = _memory.GetUint16(mapAddress);
+                    ushort segment = _memory.UInt16[mapAddress];
                     mapAddress += 2;
                     MapSegment(logicalPage, segment, handleId);
                     if (_state.AH != EmmStatus.EmmNoError) {
@@ -668,19 +668,19 @@ public sealed class ExpandedMemoryManager : InterruptHandler {
             case EmmSubFunctions.GetHardwareConfigurationArray:
                 uint data = MemoryUtils.ToPhysicalAddress(_state.ES, _state.DI);
                 // 1 page is 1K paragraphs (16KB)
-                _memory.SetUint16(data,0x0400);
+                _memory.UInt16[data] =0x0400;
                 data+=2;
                 // No alternate register sets
-                _memory.SetUint16(data,0x0000);
+                _memory.UInt16[data] = 0x0000;
                 data+=2;
                 // Context save area size
-                _memory.SetUint16(data, (ushort)EmmHandles.SelectMany(static x => x.Value.LogicalPages).Count());
+                _memory.UInt16[data] = (ushort)EmmHandles.SelectMany(static x => x.Value.LogicalPages).Count();
                 data+=2;
                 // No DMA channels
-                _memory.SetUint16(data,0x0000);
+                _memory.UInt16[data] = 0x0000;
                 data+=2;
                 // Always 0 for LIM standard
-                _memory.SetUint16(data,0x0000);
+                _memory.UInt16[data] = 0x0000;
                 break;
             case EmmSubFunctions.GetUnallocatedRawPages:
                 // Return number of pages available in BX.

--- a/src/Spice86.Core/Emulator/InterruptHandlers/Input/Mouse/MouseDriver.cs
+++ b/src/Spice86.Core/Emulator/InterruptHandlers/Input/Mouse/MouseDriver.cs
@@ -215,8 +215,8 @@ public class MouseDriver : IMouseDriver {
 
         // We're going to call the user specific subroutine, and then return to a special callback that will restore the registers.
         const int int90HandlerVector = 0x90;
-        ushort callAddressSegment = _memory.GetUint16(4 * int90HandlerVector + 2);
-        ushort callAddressOffset = _memory.GetUint16(4 * int90HandlerVector);
+        ushort callAddressSegment = _memory.UInt16[4 * int90HandlerVector + 2];
+        ushort callAddressOffset = _memory.UInt16[4 * int90HandlerVector];
 
         _cpu.FarCall(callAddressSegment, callAddressOffset, _userCallback.Segment, _userCallback.Offset);
     }

--- a/src/Spice86.Core/Emulator/InterruptHandlers/VGA/VgaFunctionality.cs
+++ b/src/Spice86.Core/Emulator/InterruptHandlers/VGA/VgaFunctionality.cs
@@ -1394,7 +1394,7 @@ public class VgaFunctionality : IVgaFunctionality {
         uint address = MemoryUtils.ToPhysicalAddress(segment, offset);
         _memory.Memset16(address, value, (uint)amount);
         for (int i = 0; i < amount; i += 2) {
-            _memory.SetUint16((uint)(address + i), value);
+            _memory.UInt16[(uint)(address + i)] = value;
         }
     }
 

--- a/src/Spice86.Core/Emulator/LoadableFile/Dos/Exe/ExeLoader.cs
+++ b/src/Spice86.Core/Emulator/LoadableFile/Dos/Exe/ExeLoader.cs
@@ -79,9 +79,9 @@ public class ExeLoader : DosFileLoader {
             SegmentedAddress address = exeFile.RelocationTable[i];
             // Read value from memory, add the start segment offset and write back
             uint addressToEdit = MemoryUtils.ToPhysicalAddress(address.Segment, address.Offset) + physicalStartAddress;
-            int segmentToRelocate = _memory.GetUint16(addressToEdit);
+            int segmentToRelocate = _memory.UInt16[addressToEdit];
             segmentToRelocate += startSegment;
-            _memory.SetUint16(addressToEdit, (ushort)segmentToRelocate);
+            _memory.UInt16[addressToEdit] = (ushort)segmentToRelocate;
         }
     }
 

--- a/src/Spice86.Core/Emulator/LoadableFile/Dos/PspGenerator.cs
+++ b/src/Spice86.Core/Emulator/LoadableFile/Dos/PspGenerator.cs
@@ -41,11 +41,11 @@ public class PspGenerator {
         uint pspAddress = MemoryUtils.ToPhysicalAddress(pspSegment, 0);
 
         // Set the PSP's first 2 bytes to INT 20h.
-        _memory.SetUint16(pspAddress, 0xCD20);
+        _memory.UInt16[pspAddress] = 0xCD20;
 
         // Set the PSP's last free segment value.
         const ushort lastFreeSegment = MemoryMap.GraphicVideoMemorySegment - 1;
-        _memory.SetUint16(pspAddress + LAST_FREE_SEGMENT_OFFSET, lastFreeSegment);
+        _memory.UInt16[pspAddress + LAST_FREE_SEGMENT_OFFSET] = lastFreeSegment;
 
         // Load the command-line arguments into the PSP.
         _memory.LoadData(pspAddress + DTA_OR_COMMAND_LINE_OFFSET, ArgumentsToDosBytes(arguments));

--- a/src/Spice86.Core/Emulator/Memory/IByteReaderWriter.cs
+++ b/src/Spice86.Core/Emulator/Memory/IByteReaderWriter.cs
@@ -1,0 +1,19 @@
+namespace Spice86.Core.Emulator.Memory;
+
+/// <summary>
+/// Interface for objects that allow to read and write bytes at specific addresses
+/// </summary>
+public interface IByteReaderWriter {
+    /// <summary>
+    /// Provides read / write access for bytes at address
+    /// </summary>
+    /// <param name="address">Address where to perform the operation</param>
+    public byte this[uint address] { get; set; }
+
+    /// <summary>
+    /// Length of the address space
+    /// </summary>
+    public uint Length {
+        get;
+    }
+}

--- a/src/Spice86.Core/Emulator/Memory/Indexer/IIndexed.cs
+++ b/src/Spice86.Core/Emulator/Memory/Indexer/IIndexed.cs
@@ -1,0 +1,27 @@
+namespace Spice86.Core.Emulator.Memory; 
+
+/// <summary>
+/// Interface for objects that allow access to their data as byte, ushort, or uint
+/// </summary>
+public interface IIndexed {
+    /// <summary>
+    ///     Allows indexed byte access to the memory map.
+    /// </summary>
+    public UInt8Indexer UInt8 {
+        get;
+    }
+
+    /// <summary>
+    ///     Allows indexed word access to the memory map.
+    /// </summary>
+    public UInt16Indexer UInt16 {
+        get;
+    }
+
+    /// <summary>
+    ///     Allows indexed double word access to the memory map.
+    /// </summary>
+    public UInt32Indexer UInt32 {
+        get;
+    }
+}

--- a/src/Spice86.Core/Emulator/Memory/Indexer/UInt16Indexer.cs
+++ b/src/Spice86.Core/Emulator/Memory/Indexer/UInt16Indexer.cs
@@ -6,14 +6,14 @@ using Spice86.Shared.Utils;
 /// Provides indexed unsigned 16-byte access over memory.
 /// </summary>
 public class UInt16Indexer {
-    private readonly Memory _memory;
+    private readonly IByteReaderWriter _byteReaderWriter;
 
     /// <summary>
     /// Creates a new instance of the <see cref="UInt16Indexer"/> class
-    /// with the specified <see cref="Memory"/> instance.
+    /// with the specified <see cref="IByteReaderWriter"/> instance.
     /// </summary>
-    /// <param name="memory">The memory bus.</param>
-    public UInt16Indexer(Memory memory) => _memory = memory;
+    /// <param name="byteReaderWriter">The object where to read / write bytes.</param>
+    public UInt16Indexer(IByteReaderWriter byteReaderWriter) => _byteReaderWriter = byteReaderWriter;
 
     /// <summary>
     /// Gets or sets the unsigned 16-bit integer at the specified physical address.
@@ -21,8 +21,11 @@ public class UInt16Indexer {
     /// <param name="address">The physical address of the value to get or set.</param>
     /// <returns>The unsigned 16-bit integer at the specified physical address.</returns>
     public ushort this[uint address] {
-        get => _memory.GetUint16(address);
-        set => _memory.SetUint16(address, value);
+        get => (ushort)(_byteReaderWriter[address] | _byteReaderWriter[address + 1] << 8);
+        set {
+            _byteReaderWriter[address] = (byte)value;
+            _byteReaderWriter[address + 1] = (byte)(value >> 8);
+        }
     }
 
     /// <summary>

--- a/src/Spice86.Core/Emulator/Memory/Indexer/UInt32Indexer.cs
+++ b/src/Spice86.Core/Emulator/Memory/Indexer/UInt32Indexer.cs
@@ -6,13 +6,13 @@ using Spice86.Shared.Utils;
 /// Provides indexed unsigned 32-bit access over memory.
 /// </summary>
 public class UInt32Indexer {
-    private readonly Memory _memory;
+    private readonly IByteReaderWriter _byteReaderWriter;
 
     /// <summary>
-    /// Initializes a new instance of the UInt32Indexer class with a specified memory bus.
+    /// Initializes a new instance of the <see cref="UInt32Indexer"/> class with the specified byteReadeWriter.
     /// </summary>
-    /// <param name="memory">The memory bus.</param>
-    public UInt32Indexer(Memory memory) => _memory = memory;
+    /// <param name="byteReaderWriter">The object where to read / write bytes.</param>
+    public UInt32Indexer(IByteReaderWriter byteReaderWriter) => _byteReaderWriter = byteReaderWriter;
 
     /// <summary>
     /// Gets or sets the unsigned 32-bit value at the specified memory address.
@@ -20,8 +20,14 @@ public class UInt32Indexer {
     /// <param name="address">The memory address to access.</param>
     /// <returns>The unsigned 32-bit value at the specified memory address.</returns>
     public uint this[uint address] {
-        get => _memory.GetUint32(address);
-        set => _memory.SetUint32(address, value);
+        get => (uint)(_byteReaderWriter[address] | _byteReaderWriter[address + 1] << 8 |
+                      _byteReaderWriter[address + 2] << 16 | _byteReaderWriter[address + 3] << 24);
+        set {
+            _byteReaderWriter[address] = (byte)value;
+            _byteReaderWriter[address + 1] = (byte)(value >> 8);
+            _byteReaderWriter[address + 2] = (byte)(value >> 16);
+            _byteReaderWriter[address + 3] = (byte)(value >> 24);
+        }
     }
 
     /// <summary>

--- a/src/Spice86.Core/Emulator/Memory/Indexer/UInt8Indexer.cs
+++ b/src/Spice86.Core/Emulator/Memory/Indexer/UInt8Indexer.cs
@@ -6,13 +6,13 @@ using Spice86.Shared.Utils;
 /// Provides indexed byte access over memory.
 /// </summary>
 public class UInt8Indexer {
-    private readonly Memory _memory;
+    private readonly IByteReaderWriter _byteReaderWriter;
 
     /// <summary>
-    /// Initializes a new instance of the <see cref="UInt8Indexer"/> class with the specified memory.
+    /// Initializes a new instance of the <see cref="UInt8Indexer"/> class with the specified byteReadeWriter.
     /// </summary>
-    /// <param name="memory">The memory bus.</param>
-    public UInt8Indexer(Memory memory) => _memory = memory;
+    /// <param name="byteReaderWriter">The object where to read / write bytes.</param>
+    public UInt8Indexer(IByteReaderWriter byteReaderWriter) => _byteReaderWriter = byteReaderWriter;
 
     /// <summary>
     /// Gets or sets the 8-bit unsigned integer at the specified index in the memory.
@@ -20,8 +20,8 @@ public class UInt8Indexer {
     /// <param name="i">The index of the element to get or set.</param>
     /// <returns>The 8-bit unsigned integer at the specified index in the memory.</returns>
     public byte this[uint i] {
-        get => _memory.GetUint8(i);
-        set => _memory.SetUint8(i, value);
+        get => _byteReaderWriter[i];
+        set => _byteReaderWriter[i] = value;
     }
 
     /// <summary>

--- a/src/Spice86.Core/Emulator/ReverseEngineer/CSharpOverrideHelper.cs
+++ b/src/Spice86.Core/Emulator/ReverseEngineer/CSharpOverrideHelper.cs
@@ -477,8 +477,8 @@ public class CSharpOverrideHelper {
     /// <param name="vectorNumber">The vector number to call for the interrupt.</param>
     /// <exception cref="UnrecoverableException">If the interrupt vector number is not recognized.</exception>
     public void InterruptCall(ushort expectedReturnCs, ushort expectedReturnIp, int vectorNumber) {
-        ushort targetIP = Memory.GetUint16((ushort)(4 * vectorNumber));
-        ushort targetCS = Memory.GetUint16((ushort)((4 * vectorNumber) + 2));
+        ushort targetIP = Memory.UInt16[(ushort)(4 * vectorNumber)];
+        ushort targetCS = Memory.UInt16[(ushort)((4 * vectorNumber) + 2)];
         SegmentedAddress target = new SegmentedAddress(targetCS, targetIP);
         Func<int, Action>? function = SearchFunctionOverride(target);
         if (function is null) {
@@ -619,8 +619,8 @@ public class CSharpOverrideHelper {
         ushort expectedSegment,
         ushort expectedOffset) {
         uint address = MemoryUtils.ToPhysicalAddress(State.SegmentRegisters.GetRegister16(segmentRegisterIndex), offset);
-        ushort foundOffset = Memory.GetUint16(address);
-        ushort foundSegment = Memory.GetUint16(address + 2);
+        ushort foundOffset = Memory.UInt16[address];
+        ushort foundSegment = Memory.UInt16[address + 2];
         if (foundOffset != expectedOffset || foundSegment != expectedSegment) {
             throw FailAsUntested(
                 $"Call table value changed, we would not call the method the game is calling. Expected: {new SegmentedAddress(expectedSegment, expectedOffset)} found: {new SegmentedAddress(foundSegment, foundOffset)}");

--- a/src/Spice86.Core/Emulator/ReverseEngineer/MemoryBasedDataStructure.cs
+++ b/src/Spice86.Core/Emulator/ReverseEngineer/MemoryBasedDataStructure.cs
@@ -25,7 +25,7 @@ public class MemoryBasedDataStructure {
     /// <param name="baseAddress">The base address of the structure.</param>
     /// <param name="offset">The offset added to the address.</param>
     public ushort GetUint16(uint baseAddress, int offset) {
-        return Memory.GetUint16((uint)(baseAddress + offset));
+        return Memory.UInt16[(uint)(baseAddress + offset)];
     }
 
     /// <summary>
@@ -44,7 +44,7 @@ public class MemoryBasedDataStructure {
     /// <param name="baseAddress">The base address of the structure.</param>
     /// <param name="offset">The offset added to the address.</param>
     public uint GetUint32(uint baseAddress, int offset) {
-        return Memory.GetUint32((uint)(baseAddress + offset));
+        return Memory.UInt32[(uint)(baseAddress + offset)];
     }
 
     /// <summary>
@@ -53,7 +53,7 @@ public class MemoryBasedDataStructure {
     /// <param name="baseAddress">The base address of the structure.</param>
     /// <param name="offset">The offset added to the address.</param>
     public byte GetUint8(uint baseAddress, int offset) {
-        return Memory.GetUint8((uint)(baseAddress + offset));
+        return Memory.UInt8[(uint)(baseAddress + offset)];
     }
 
     /// <summary>
@@ -73,7 +73,7 @@ public class MemoryBasedDataStructure {
     /// <param name="offset">The offset added to the address.</param>
     /// <param name="value">The value to write</param>
     public void SetUint16(uint baseAddress, int offset, ushort value) {
-        Memory.SetUint16((uint)(baseAddress + offset), value);
+        Memory.UInt16[(uint)(baseAddress + offset)] = value;
     }
 
     /// <summary>
@@ -83,7 +83,7 @@ public class MemoryBasedDataStructure {
     /// <param name="offset">The offset added to the address.</param>
     /// <param name="value">The value to write</param>
     public void SetUint32(uint baseAddress, int offset, uint value) {
-        Memory.SetUint32((uint)(baseAddress + offset), value);
+        Memory.UInt32[(uint)(baseAddress + offset)] = value;
     }
 
     /// <summary>
@@ -93,6 +93,6 @@ public class MemoryBasedDataStructure {
     /// <param name="offset">The offset added to the address.</param>
     /// <param name="value">The value to write</param>
     public void SetUint8(uint baseAddress, int offset, byte value) {
-        Memory.SetUint8((uint)(baseAddress + offset), value);
+        Memory.UInt8[(uint)(baseAddress + offset)] = value;
     }
 }

--- a/src/Spice86.Tests/MachineTest.cs
+++ b/src/Spice86.Tests/MachineTest.cs
@@ -61,24 +61,24 @@ public class MachineTest {
         // simple read
         // 2 reads, but breakpoint is removed after first
         AssertAddressMemoryBreakPoint(machineBreakpoints, BreakPointType.READ, 0, 1, true, () => {
-            memory.GetUint8(0);
-            memory.GetUint8(0);
+            _ = memory.UInt8[0];
+            _ = memory.UInt8[0];
         });
 
         // simple write
         AssertAddressMemoryBreakPoint(machineBreakpoints, BreakPointType.WRITE, 0, 1, true, () => {
-            memory.SetUint8(0, 0);
+            memory.UInt8[0] = 0;
         });
 
         // read / write with remove
         int readWrite0Triggered = 0;
         AddressBreakPoint readWrite0 = new AddressBreakPoint(BreakPointType.ACCESS, 0, breakpoint => { readWrite0Triggered++; }, false);
         machineBreakpoints.ToggleBreakPoint(readWrite0, true);
-        memory.GetUint8(0);
-        memory.SetUint8(0, 0);
+        _ =  memory.UInt8[0];
+        memory.UInt8[0] = 0;
         machineBreakpoints.ToggleBreakPoint(readWrite0, false);
         // Should not trigger
-        memory.GetUint8(0);
+        _ =  memory.UInt8[0];
         Assert.Equal(2, readWrite0Triggered);
 
         // Memset
@@ -133,14 +133,14 @@ public class MachineTest {
 
         // Long reads
         AssertAddressMemoryBreakPoint(machineBreakpoints, BreakPointType.READ, 1, 2, false, () => {
-            memory.GetUint16(0);
-            memory.GetUint32(0);
+            _ = memory.UInt16[0];
+            _ = memory.UInt32[0];
         });
 
         // Long writes
         AssertAddressMemoryBreakPoint(machineBreakpoints, BreakPointType.WRITE, 1, 2, false, () => {
-            memory.SetUint16(0, 0);
-            memory.SetUint32(0, 0);
+            memory.UInt16[0] = 0;
+            memory.UInt32[0] = 0;
         });
     }
     

--- a/src/Spice86.Tests/MainMemoryTest.cs
+++ b/src/Spice86.Tests/MainMemoryTest.cs
@@ -39,7 +39,7 @@ public class MainMemoryTest {
         _memory.UInt8[0x1234] = 0x12;
 
         // Act
-        byte actual = _memory.GetUint8(0x1234);
+        byte actual = _memory.UInt8[0x1234];
 
         // Assert
         Assert.Equal(0x12, actual);
@@ -52,7 +52,7 @@ public class MainMemoryTest {
         _memory.UInt8[0x1235] = 0x12;
 
         // Act
-        ushort actual = _memory.GetUint16(0x1234);
+        ushort actual = _memory.UInt16[0x1234];
 
         // Assert
         Assert.Equal(0x1234, actual);
@@ -67,7 +67,7 @@ public class MainMemoryTest {
         _memory.UInt8[0x1237] = 0x56;
 
         // Act
-        uint actual = _memory.GetUint32(0x1234);
+        uint actual = _memory.UInt32[0x1234];
 
         // Assert
         Assert.Equal(0x56781234u, actual);
@@ -79,7 +79,7 @@ public class MainMemoryTest {
         _memory.UInt8[0x1234] = 0x00;
 
         // Act
-        _memory.SetUint8(0x1234, 0x12);
+        _memory.UInt8[0x1234] = 0x12;
 
         // Assert
         Assert.Equal(0x12, _memory.UInt8[0x1234]);
@@ -92,7 +92,7 @@ public class MainMemoryTest {
         _memory.UInt8[0x1235] = 0x00;
 
         // Act
-        _memory.SetUint16(0x1234, 0x1234);
+        _memory.UInt16[0x1234] = 0x1234;
 
         // Assert
         Assert.Equal(0x34, _memory.UInt8[0x1234]);
@@ -108,7 +108,7 @@ public class MainMemoryTest {
         _memory.UInt8[0x1237] = 0x00;
 
         // Act
-        _memory.SetUint32(0x1234, 0x56781234u);
+        _memory.UInt32[0x1234] = 0x56781234u;
 
         // Assert
         Assert.Equal(0x34, _memory.UInt8[0x1234]);
@@ -127,7 +127,7 @@ public class MainMemoryTest {
         _memory.RegisterMapping(0x1234, 4, newMem);
 
         // Act
-        byte actual = _memory.GetUint8(0x1234);
+        byte actual = _memory.UInt8[0x1234];
 
         // Assert
         Assert.Equal(0xDE, actual);
@@ -158,7 +158,7 @@ public class MainMemoryTest {
         _memory.RegisterMapping(0x1234, 4, newMem);
 
         // Act
-        uint actual = _memory.GetUint16(testAddress);
+        uint actual = _memory.UInt16[testAddress];
 
         // Assert
         Assert.Equal(expected, actual);
@@ -195,7 +195,7 @@ public class MainMemoryTest {
         _memory.RegisterMapping(0x1238, 4, newMem);
 
         // Act
-        uint actual = _memory.GetUint32(testAddress);
+        uint actual = _memory.UInt32[testAddress];
 
         // Assert
         Assert.Equal(expected, actual);
@@ -210,7 +210,7 @@ public class MainMemoryTest {
         _memory.RegisterMapping(0x1234, 4, newMem);
 
         // Act
-        _memory.SetUint8(0x1234, 0x12);
+        _memory.UInt8[0x1234] = 0x12;
 
         // Assert
         Assert.Equal(0x12, newMem.Read(0x1234));
@@ -240,7 +240,7 @@ public class MainMemoryTest {
         _memory.RegisterMapping(0x1234, 4, newMem);
 
         // Act
-        _memory.SetUint16(testAddress, 0xBEEF);
+        _memory.UInt16[testAddress] = 0xBEEF;
 
         // Assert
         Assert.Equal(expected1, newMem.Read(0x1234));
@@ -264,7 +264,7 @@ public class MainMemoryTest {
         _memory.RegisterMapping(0x1234, 4, newMem);
     
         // Act
-        _memory.SetUint32(0x1234, 0x12345678);
+        _memory.UInt32[0x1234] = 0x12345678;
     
         // Assert
         Assert.Equal(0x78, newMem.Read(0x1234));
@@ -294,7 +294,7 @@ public class MainMemoryTest {
         _memory.RegisterMapping(0x1234, 4, newMem);
     
         // Act
-        _memory.SetUint32(0x1233, 0x12345678);
+        _memory.UInt32[0x1233] = 0x12345678;
     
         // Assert
         Assert.Equal(0x00, newMem.Read(0x1233));
@@ -325,7 +325,7 @@ public class MainMemoryTest {
         _memory.RegisterMapping(0x1234, 4, newMem);
     
         // Act
-        _memory.SetUint32(0x1235, 0x12345678);
+        _memory.UInt32[0x1235] = 0x12345678;
     
         // Assert
         Assert.Equal(0xDE, newMem.Read(0x1234));

--- a/src/Spice86/Views/PerformanceWindow.axaml
+++ b/src/Spice86/Views/PerformanceWindow.axaml
@@ -2,7 +2,6 @@
 		xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
 		xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
 		xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-		xmlns:oxy="clr-namespace:OxyPlot.Avalonia;assembly=OxyPlot.Avalonia"
 		xmlns:vm="using:Spice86.ViewModels"
 		xmlns:converters="using:Spice86.Converters"
 		mc:Ignorable="d" d:DesignWidth="800" d:DesignHeight="450"


### PR DESCRIPTION
Remove Get / Set methods, use indexers everywhere.
Make indexers depend on IByteReaderWriter instead of Memory.
Create a new IIndexed interface to represent Indexer 8 / 16 / 32 holders.

Motivation: to be able to use a byte array as IIndexed for memory dumps.