### PR TITLE
BDA rework and tests on Memory structs

### DIFF
--- a/src/Spice86.Core/Emulator/InterruptHandlers/Input/Keyboard/BiosKeyboardBuffer.cs
+++ b/src/Spice86.Core/Emulator/InterruptHandlers/Input/Keyboard/BiosKeyboardBuffer.cs
@@ -8,11 +8,11 @@ using Spice86.Core.Emulator.Memory.Indexable;
 /// Data about buffer start, end and positions are stored in the Bios Data Area.
 /// </summary>
 public class BiosKeyboardBuffer {
-    private readonly Indexable _indexable;
+    private readonly Indexable _memory;
     private readonly BiosDataArea _biosDataArea;
 
-    public BiosKeyboardBuffer(Indexable indexable, BiosDataArea biosDataArea) {
-        _indexable = indexable;
+    public BiosKeyboardBuffer(Indexable memory, BiosDataArea biosDataArea) {
+        _memory = memory;
         _biosDataArea = biosDataArea;
     }
 
@@ -61,14 +61,13 @@ public class BiosKeyboardBuffer {
     /// <param name="code">keycode to enqueue</param>
     /// <returns>false when buffer is full, true otherwise</returns>
     public bool EnqueueKeyCode(ushort code) {
-        ushort tail = TailAddress;
-        ushort newTail = AdvancePointer(tail);
+        ushort newTail = ComputeNextAddress(TailAddress);
         if (newTail == HeadAddress) {
             // buffer full
             return false;
         }
 
-        _indexable.UInt16[0, tail] = code;
+        _memory.UInt16[0, TailAddress] = code;
         TailAddress = newTail;
         return true;
     }
@@ -83,7 +82,7 @@ public class BiosKeyboardBuffer {
             // Don't dequeue if nothing in the buffer
             return null;
         }
-        HeadAddress = AdvancePointer(HeadAddress);
+        HeadAddress = ComputeNextAddress(HeadAddress);
         return res;
     }
 
@@ -96,14 +95,14 @@ public class BiosKeyboardBuffer {
             return null;
         }
 
-        return _indexable.UInt16[0, HeadAddress];
+        return _memory.UInt16[0, HeadAddress];
     }
 
-    private ushort AdvancePointer(ushort value) {
-        ushort res = (ushort)(value + 2);
-        if (res >= EndAddress) {
+    private ushort ComputeNextAddress(ushort address) {
+        ushort next = (ushort)(address + 2);
+        if (next >= EndAddress) {
             return StartAddress;
         }
-        return res;
+        return next;
     }
 }

--- a/src/Spice86.Core/Emulator/InterruptHandlers/Input/Keyboard/BiosKeyboardBuffer.cs
+++ b/src/Spice86.Core/Emulator/InterruptHandlers/Input/Keyboard/BiosKeyboardBuffer.cs
@@ -1,48 +1,48 @@
 ﻿namespace Spice86.Core.Emulator.InterruptHandlers.Input.Keyboard;
 
 using Spice86.Core.Emulator.Memory;
-using Spice86.Core.Emulator.ReverseEngineer.DataStructure;
+using Spice86.Core.Emulator.Memory.Indexable;
 
 /// <summary>
 /// This is a memory based FIFO Queue used to store key codes
+/// Data about buffer start, end and positions are stored in the Bios Data Area.
 /// </summary>
-public class BiosKeyboardBuffer : MemoryBasedDataStructure {
-    private const ushort End = 0x482;
-    private const ushort Head = 0x41A;
-    private const int InitialLength = 0x20;
-    private const ushort InitialStartAddress = 0x41E;
-    private const ushort Start = 0x480;
-    private const ushort Tail = 0x41C;
+public class BiosKeyboardBuffer {
+    private readonly Indexable _indexable;
+    private readonly BiosDataArea _biosDataArea;
 
-    public BiosKeyboardBuffer(Memory memory) : base(memory, 0) {
+    public BiosKeyboardBuffer(Indexable indexable, BiosDataArea biosDataArea) {
+        _indexable = indexable;
+        _biosDataArea = biosDataArea;
     }
 
     public void Init() {
-        StartAddress = InitialStartAddress;
-        EndAddress = InitialStartAddress + InitialLength;
-        HeadAddress = InitialStartAddress;
-        TailAddress = InitialStartAddress;
+        // absolute base address is uint but BDA is low in memory so it fits in ushort
+        StartAddress = (ushort)_biosDataArea.KbdBuf.BaseAddress;
+        EndAddress = (ushort)(StartAddress + _biosDataArea.KbdBuf.Count);
+        HeadAddress = StartAddress;
+        TailAddress = StartAddress;
     }
 
     /// <summary>
     /// Address of the start of the buffer
     /// </summary>
-    public ushort StartAddress { get => UInt16[Start]; set => UInt16[Start] = value; }
+    private ushort StartAddress { get => _biosDataArea.KbdBufStartOffset; set => _biosDataArea.KbdBufStartOffset = value; }
 
     /// <summary>
     /// Address of the end of the buffer
     /// </summary>
-    public ushort EndAddress { get => UInt16[End]; set => UInt16[End] = value; }
+    private ushort EndAddress { get => _biosDataArea.KbdBufEndOffset; set => _biosDataArea.KbdBufEndOffset = value; }
 
     /// <summary>
     /// Address where newest item is enqueued
     /// </summary>
-    public ushort HeadAddress { get => UInt16[Head]; set => UInt16[Head] = value; }
+    private ushort HeadAddress { get => _biosDataArea.KbdBufHead; set => _biosDataArea.KbdBufHead = value; }
 
     /// <summary>
     /// Address where the oldest item is enqueued
     /// </summary>
-    public ushort TailAddress { get => UInt16[Tail]; set => UInt16[Tail] = value; }
+    private ushort TailAddress { get => _biosDataArea.KbdBufTail; set => _biosDataArea.KbdBufTail = value; }
 
     /// <summary>
     /// Returns whether there is any keycode in the buffer or not
@@ -68,7 +68,7 @@ public class BiosKeyboardBuffer : MemoryBasedDataStructure {
             return false;
         }
 
-        UInt16[tail] = code;
+        _indexable.UInt16[0, tail] = code;
         TailAddress = newTail;
         return true;
     }
@@ -96,7 +96,7 @@ public class BiosKeyboardBuffer : MemoryBasedDataStructure {
             return null;
         }
 
-        return UInt16[HeadAddress];
+        return _indexable.UInt16[0, HeadAddress];
     }
 
     private ushort AdvancePointer(ushort value) {

--- a/src/Spice86.Core/Emulator/InterruptHandlers/Input/Keyboard/BiosKeyboardInt9Handler.cs
+++ b/src/Spice86.Core/Emulator/InterruptHandlers/Input/Keyboard/BiosKeyboardInt9Handler.cs
@@ -2,6 +2,7 @@
 
 using Spice86.Core.Emulator.Devices.Input.Keyboard;
 using Spice86.Core.Emulator.InterruptHandlers;
+using Spice86.Core.Emulator.Memory;
 using Spice86.Core.Emulator.VM;
 using Spice86.Shared.Interfaces;
 
@@ -11,9 +12,9 @@ using Spice86.Shared.Interfaces;
 public class BiosKeyboardInt9Handler : InterruptHandler {
     private readonly Keyboard _keyboard;
 
-    public BiosKeyboardInt9Handler(Machine machine, ILoggerService loggerService) : base(machine, loggerService) {
+    public BiosKeyboardInt9Handler(Machine machine, BiosDataArea biosDataArea, ILoggerService loggerService) : base(machine, loggerService) {
         _keyboard = machine.Keyboard;
-        BiosKeyboardBuffer = new BiosKeyboardBuffer(machine.Memory);
+        BiosKeyboardBuffer = new BiosKeyboardBuffer(machine.Memory, biosDataArea);
         BiosKeyboardBuffer.Init();
     }
 

--- a/src/Spice86.Core/Emulator/InterruptHandlers/Timer/TimerInt8Handler.cs
+++ b/src/Spice86.Core/Emulator/InterruptHandlers/Timer/TimerInt8Handler.cs
@@ -38,7 +38,7 @@ public class TimerInt8Handler : InterruptHandler {
     /// Gets or set the value of the real time clock, in ticks.
     /// </summary>
     public uint TickCounterValue {
-        get => _machine.BiosDataArea.RealTimeClock; 
-        set => _machine.BiosDataArea.RealTimeClock = value;
+        get => _machine.BiosDataArea.TimerCounter; 
+        set => _machine.BiosDataArea.TimerCounter = value;
     }
 }

--- a/src/Spice86.Core/Emulator/InterruptHandlers/VGA/VgaFunctionality.cs
+++ b/src/Spice86.Core/Emulator/InterruptHandlers/VGA/VgaFunctionality.cs
@@ -304,7 +304,7 @@ public class VgaFunctionality : IVgaFunctionality {
     /// <inheritdoc />
     public void SelectScanLines(int lines) {
         byte modeSetCtl = _biosDataArea.ModesetCtl;
-        byte featureSwitches = _biosDataArea.FeatureSwitches;
+        byte featureSwitches = _biosDataArea.VideoFeatureSwitches;
         switch (lines) {
             case 200:
                 modeSetCtl = (byte)(modeSetCtl & ~0x10 | 0x80);
@@ -322,12 +322,12 @@ public class VgaFunctionality : IVgaFunctionality {
                 throw new NotSupportedException($"{lines}  is not a valid scan line amount");
         }
         _biosDataArea.ModesetCtl = modeSetCtl;
-        _biosDataArea.FeatureSwitches = featureSwitches;
+        _biosDataArea.VideoFeatureSwitches = featureSwitches;
     }
 
     /// <inheritdoc />
     public byte GetFeatureSwitches() {
-        return (byte)(_biosDataArea.FeatureSwitches & 0x0F);
+        return (byte)(_biosDataArea.VideoFeatureSwitches & 0x0F);
     }
 
     /// <inheritdoc />
@@ -680,7 +680,7 @@ public class VgaFunctionality : IVgaFunctionality {
         _biosDataArea.CrtControllerBaseAddress = (ushort)GetCrtControllerPort();
         _biosDataArea.CharacterHeight = characterHeight;
         _biosDataArea.VideoCtl = (byte)(0x60 | (flags.HasFlag(ModeFlags.NoClearMem) ? 0x80 : 0x00));
-        _biosDataArea.FeatureSwitches = 0xF9;
+        _biosDataArea.VideoFeatureSwitches = 0xF9;
         _biosDataArea.ModesetCtl &= 0x7F;
         for (int i = 0; i < 8; i++) {
             _biosDataArea.CursorPosition[i] = 0x0000;

--- a/src/Spice86.Core/Emulator/InterruptHandlers/VGA/VgaFunctionality.cs
+++ b/src/Spice86.Core/Emulator/InterruptHandlers/VGA/VgaFunctionality.cs
@@ -75,7 +75,7 @@ public class VgaFunctionality : IVgaFunctionality {
 
         // Update BIOS cursor pos
         int position = cursorPosition.Y << 8 | cursorPosition.X;
-        _biosDataArea.SetCursorPosition(cursorPosition.Page, (ushort)position);
+        _biosDataArea.CursorPosition[cursorPosition.Page] = (ushort)position;
     }
 
     /// <inheritdoc />
@@ -426,7 +426,7 @@ public class VgaFunctionality : IVgaFunctionality {
         if (page > 7) {
             return new CursorPosition(0, 0, 0);
         }
-        ushort xy = _biosDataArea.GetCursorPosition(page);
+        ushort xy = _biosDataArea.CursorPosition[page];
         return new CursorPosition(xy & 0xFF, xy >> 8, page);
     }
 
@@ -683,7 +683,7 @@ public class VgaFunctionality : IVgaFunctionality {
         _biosDataArea.FeatureSwitches = 0xF9;
         _biosDataArea.ModesetCtl &= 0x7F;
         for (int i = 0; i < 8; i++) {
-            _biosDataArea.SetCursorPosition(i, 0x0000);
+            _biosDataArea.CursorPosition[i] = 0x0000;
         }
         _biosDataArea.VideoPageStart = 0x0000;
         _biosDataArea.CurrentVideoPage = 0x00;

--- a/src/Spice86.Core/Emulator/Memory/BiosDataArea.cs
+++ b/src/Spice86.Core/Emulator/Memory/BiosDataArea.cs
@@ -1,158 +1,103 @@
 ﻿namespace Spice86.Core.Emulator.Memory;
 
+using Spice86.Core.Emulator.Memory.ReaderWriter;
+using Spice86.Core.Emulator.ReverseEngineer.DataStructure;
+using Spice86.Core.Emulator.ReverseEngineer.DataStructure.Array;
+using Spice86.Shared.Utils;
+
 /// <summary>
 /// Provides access to emulated memory mapped BIOS values.
 /// </summary>
-public sealed class BiosDataArea {
-    private readonly Memory _memory;
-
+public sealed class BiosDataArea : MemoryBasedDataStructure {
     /// <summary>
     /// Initializes a new instance.
     /// </summary>
-    /// <param name="memory">The memory bus.</param>
-    public BiosDataArea(Memory memory) {
-        _memory = memory;
+    /// <param name="byteReaderWriter">Where data is read and written.</param>
+    public BiosDataArea(IByteReaderWriter byteReaderWriter) : base(byteReaderWriter, MemoryUtils.ToPhysicalAddress(MemoryMap.BiosDataSegment, 0)) {
     }
-    
+
     /// <summary>
     /// Gets or sets the flags that indicate which hardware is installed.
     /// </summary>
-    public ushort EquipmentListFlags {
-        get => _memory.UInt16[MemoryMap.BiosDataSegment, 0x0010];
-        set => _memory.UInt16[MemoryMap.BiosDataSegment, 0x0010] = value;
-    }
+    public ushort EquipmentListFlags { get => UInt16[0x0010]; set => UInt16[0x0010] = value; }
 
     /// <summary>
     /// Gets or sets the value of the disk motor timer.
     /// </summary>
-    public byte DiskMotorTimer {
-        get => _memory.UInt8[MemoryMap.BiosDataSegment, 0x0040];
-        set => _memory.UInt8[MemoryMap.BiosDataSegment, 0x0040] = value;
-    }
+    public byte DiskMotorTimer { get => UInt8[0x0040]; set => UInt8[0x0040] = value; }
 
     /// <summary>
     /// Gets or sets the BIOS video mode.
     /// </summary>
-    public byte VideoMode {
-        get => _memory.UInt8[MemoryMap.BiosDataSegment, 0x0049];
-        set => _memory.UInt8[MemoryMap.BiosDataSegment, 0x0049] = value;
-    }
+    public byte VideoMode { get => UInt8[0x0049]; set => UInt8[0x0049] = value; }
 
     /// <summary>
     /// Gets or sets the BIOS screen column count.
     /// </summary>
-    public ushort ScreenColumns {
-        get => _memory.UInt16[MemoryMap.BiosDataSegment, 0x004A];
-        set => _memory.UInt16[MemoryMap.BiosDataSegment, 0x004A] = value;
-    }
-    
+    public ushort ScreenColumns { get => UInt16[0x004A]; set => UInt16[0x004A] = value; }
+
     /// <summary>
     /// Gets or sets the size of active video page in bytes.
     /// </summary>
-    public ushort VideoPageSize {
-        get => _memory.UInt16[MemoryMap.BiosDataSegment, 0x004C];
-        set => _memory.UInt16[MemoryMap.BiosDataSegment, 0x004C] = value;
-    }
-    
+    public ushort VideoPageSize { get => UInt16[0x004C]; set => UInt16[0x004C] = value; }
+
     /// <summary>
     /// Gets or sets the offset address of the active video page relative to the start of video RAM
     /// </summary>
-    public ushort VideoPageStart {
-        get => _memory.UInt16[MemoryMap.BiosDataSegment, 0x004E];
-        set => _memory.UInt16[MemoryMap.BiosDataSegment, 0x004E] = value;
-    }
+    public ushort VideoPageStart { get => UInt16[0x004E]; set => UInt16[0x004E] = value; }
 
     /// <summary>
-    /// Gets the word representing the cursor position on the specified text page.
+    /// Cursor positions for the 8 text pages.
     /// </summary>
-    public ushort GetCursorPosition(int page) {
-        return _memory.UInt16[MemoryMap.BiosDataSegment, (ushort)(0x0050 + page * 2)];
-    }
-
-    /// <summary>
-    /// Sets the word representing the cursor position on the specified text page.
-    /// </summary>
-    public void SetCursorPosition(int page, ushort value) {
-        _memory.UInt16[MemoryMap.BiosDataSegment, (ushort)(0x0050 + page * 2)] = value;
-    }
+    public UInt16Array CursorPosition => GetUInt16Array(0x0050, 8);
 
     /// <summary>
     /// Gets or sets the BIOS cursor type.
     /// </summary>
-    public ushort CursorType {
-        get => _memory.UInt16[MemoryMap.BiosDataSegment, 0x0060];
-        set => _memory.UInt16[MemoryMap.BiosDataSegment, 0x0060] = value;
-    }
+    public ushort CursorType { get => UInt16[0x0060]; set => UInt16[0x0060] = value; }
 
     /// <summary>
     /// Gets or sets the currently active video page.
     /// </summary>
-    public byte CurrentVideoPage {
-        get => _memory.UInt8[MemoryMap.BiosDataSegment, 0x0062];
-        set => _memory.UInt8[MemoryMap.BiosDataSegment, 0x0062] = value;
-    }
-    
+    public byte CurrentVideoPage { get => UInt8[0x0062]; set => UInt8[0x0062] = value; }
+
     /// <summary>
     /// Gets or sets the CRT controller I/O port address.
     /// </summary>
-    public ushort CrtControllerBaseAddress {
-        get => _memory.UInt16[MemoryMap.BiosDataSegment, 0x0063];
-        set => _memory.UInt16[MemoryMap.BiosDataSegment, 0x0063] = value;
-    }
+    public ushort CrtControllerBaseAddress { get => UInt16[0x0063]; set => UInt16[0x0063] = value; }
 
     /// <summary>
     /// Gets or sets the current value of the real time clock.
     /// </summary>
-    public uint RealTimeClock {
-        get => _memory.UInt32[MemoryMap.BiosDataSegment, 0x006C];
-        set => _memory.UInt32[MemoryMap.BiosDataSegment, 0x006C] = value;
-    }
+    public uint RealTimeClock { get => UInt32[0x006C]; set => UInt32[0x006C] = value; }
 
     /// <summary>
     /// Gets or sets the screen row count.
     /// </summary>
-    public byte ScreenRows {
-        get => _memory.UInt8[MemoryMap.BiosDataSegment, 0x0084];
-        set => _memory.UInt8[MemoryMap.BiosDataSegment, 0x0084] = value;
-    }
+    public byte ScreenRows { get => UInt8[0x0084]; set => UInt8[0x0084] = value; }
 
     /// <summary>
     /// Gets or sets the character point height.
     /// </summary>
-    public ushort CharacterHeight {
-        get => _memory.UInt16[MemoryMap.BiosDataSegment, 0x0085];
-        set => _memory.UInt16[MemoryMap.BiosDataSegment, 0x0085] = value;
-    }
-    
+    public ushort CharacterHeight { get => UInt16[0x0085]; set => UInt16[0x0085] = value; }
+
     /// <summary>
     /// Gets or sets the VideoCtl.
     /// </summary>
-    public byte VideoCtl {
-        get => _memory.UInt8[MemoryMap.BiosDataSegment, 0x0087];
-        set => _memory.UInt8[MemoryMap.BiosDataSegment, 0x0087] = value;
-    }
+    public byte VideoCtl { get => UInt8[0x0087]; set => UInt8[0x0087] = value; }
 
     /// <summary>
     /// Gets or sets the BIOS video mode options.
     /// </summary>
-    public byte FeatureSwitches {
-        get => _memory.UInt8[MemoryMap.BiosDataSegment, 0x0088];
-        set => _memory.UInt8[MemoryMap.BiosDataSegment, 0x0088] = value;
-    }
+    public byte FeatureSwitches { get => UInt8[0x0088]; set => UInt8[0x0088] = value; }
 
     /// <summary>
     /// Gets or sets the EGA feature switch values.
     /// </summary>
-    public byte ModesetCtl {
-        get => _memory.UInt8[MemoryMap.BiosDataSegment, 0x0089];
-        set => _memory.UInt8[MemoryMap.BiosDataSegment, 0x0089] = value;
-    }
-    
+    public byte ModesetCtl { get => UInt8[0x0089]; set => UInt8[0x0089] = value; }
+
     /// <summary>
     /// Gets or sets the display combination code.
     /// </summary>
-    public byte DisplayCombinationCode {
-        get => _memory.UInt8[MemoryMap.BiosDataSegment, 0x008A];
-        set => _memory.UInt8[MemoryMap.BiosDataSegment, 0x008A] = value;
-    }
+    public byte DisplayCombinationCode { get => UInt8[0x008A]; set => UInt8[0x008A] = value; }
 }

--- a/src/Spice86.Core/Emulator/Memory/BiosDataArea.cs
+++ b/src/Spice86.Core/Emulator/Memory/BiosDataArea.cs
@@ -3,6 +3,7 @@
 using Spice86.Core.Emulator.Memory.ReaderWriter;
 using Spice86.Core.Emulator.ReverseEngineer.DataStructure;
 using Spice86.Core.Emulator.ReverseEngineer.DataStructure.Array;
+using Spice86.Shared.Emulator.Memory;
 using Spice86.Shared.Utils;
 
 /// <summary>
@@ -17,87 +18,196 @@ public sealed class BiosDataArea : MemoryBasedDataStructure {
     }
 
     /// <summary>
+    /// COM1,2,3,4 port addresses
+    /// </summary>
+    public UInt16Array PortCom => GetUInt16Array(0x0, 4);
+
+    /// <summary>
+    /// LPT1,2,3 port addresses
+    /// </summary>
+    public UInt16Array PortLpt => GetUInt16Array(0x8, 3);
+
+    /// <summary>
+    /// Extended BIOS Data Area segment or LPT4 port
+    /// </summary>
+    public ushort EbdaSeg { get => UInt16[0xE]; set => UInt16[0xE] = value; }
+
+    /// <summary>
     /// Gets or sets the flags that indicate which hardware is installed.
     /// </summary>
-    public ushort EquipmentListFlags { get => UInt16[0x0010]; set => UInt16[0x0010] = value; }
+    public ushort EquipmentListFlags { get => UInt16[0x10]; set => UInt16[0x10] = value; }
+
+    // Padding at 0x12
+
+    public ushort MemSizeKb { get => UInt16[0x13]; set => UInt16[0x13] = value; }
+
+    // Padding at 0x15
+
+    public byte Ps2CtrlFlag { get => UInt8[0x16]; set => UInt8[0x16] = value; }
+
+    public ushort KbdFlag0 { get => UInt16[0x17]; set => UInt16[0x17] = value; }
+
+    public byte AltKeypad { get => UInt8[0x19]; set => UInt8[0x19] = value; }
+
+    public ushort KbdBufHead { get => UInt16[0x1A]; set => UInt16[0x1A] = value; }
+
+    public ushort KbdBufTail { get => UInt16[0x1C]; set => UInt16[0x1C] = value; }
+
+    public UInt8Array KbdBuf => GetUInt8Array(0x1E, 32);
+
+    public byte FloppyRecalibrationStatus { get => UInt8[0x3E]; set => UInt8[0x3E] = value; }
+
+    public byte FloppyMotorStatus { get => UInt8[0x3F]; set => UInt8[0x3F] = value; }
 
     /// <summary>
     /// Gets or sets the value of the disk motor timer.
     /// </summary>
-    public byte DiskMotorTimer { get => UInt8[0x0040]; set => UInt8[0x0040] = value; }
+    public byte FloppyMotorCounter { get => UInt8[0x40]; set => UInt8[0x40] = value; }
+
+    public byte FloppyLastStatus { get => UInt8[0x41]; set => UInt8[0x41] = value; }
+
+    public UInt8Array FloppyReturnStatus => GetUInt8Array(0x42, 7);
 
     /// <summary>
     /// Gets or sets the BIOS video mode.
     /// </summary>
-    public byte VideoMode { get => UInt8[0x0049]; set => UInt8[0x0049] = value; }
+    public byte VideoMode { get => UInt8[0x49]; set => UInt8[0x49] = value; }
 
     /// <summary>
     /// Gets or sets the BIOS screen column count.
     /// </summary>
-    public ushort ScreenColumns { get => UInt16[0x004A]; set => UInt16[0x004A] = value; }
+    public ushort ScreenColumns { get => UInt16[0x4A]; set => UInt16[0x4A] = value; }
 
     /// <summary>
     /// Gets or sets the size of active video page in bytes.
     /// </summary>
-    public ushort VideoPageSize { get => UInt16[0x004C]; set => UInt16[0x004C] = value; }
+    public ushort VideoPageSize { get => UInt16[0x4C]; set => UInt16[0x4C] = value; }
 
     /// <summary>
     /// Gets or sets the offset address of the active video page relative to the start of video RAM
     /// </summary>
-    public ushort VideoPageStart { get => UInt16[0x004E]; set => UInt16[0x004E] = value; }
+    public ushort VideoPageStart { get => UInt16[0x4E]; set => UInt16[0x4E] = value; }
 
     /// <summary>
     /// Cursor positions for the 8 text pages.
     /// </summary>
-    public UInt16Array CursorPosition => GetUInt16Array(0x0050, 8);
+    public UInt16Array CursorPosition => GetUInt16Array(0x50, 8);
 
     /// <summary>
     /// Gets or sets the BIOS cursor type.
     /// </summary>
-    public ushort CursorType { get => UInt16[0x0060]; set => UInt16[0x0060] = value; }
+    public ushort CursorType { get => UInt16[0x60]; set => UInt16[0x60] = value; }
 
     /// <summary>
     /// Gets or sets the currently active video page.
     /// </summary>
-    public byte CurrentVideoPage { get => UInt8[0x0062]; set => UInt8[0x0062] = value; }
+    public byte CurrentVideoPage { get => UInt8[0x62]; set => UInt8[0x62] = value; }
 
     /// <summary>
     /// Gets or sets the CRT controller I/O port address.
     /// </summary>
-    public ushort CrtControllerBaseAddress { get => UInt16[0x0063]; set => UInt16[0x0063] = value; }
+    public ushort CrtControllerBaseAddress { get => UInt16[0x63]; set => UInt16[0x63] = value; }
+
+    public byte VideoMsr { get => UInt8[0x65]; set => UInt8[0x65] = value; }
+
+    public byte VideoPal { get => UInt8[0x66]; set => UInt8[0x66] = value; }
 
     /// <summary>
-    /// Gets or sets the current value of the real time clock.
+    ///     CS:IP for 286 return from protected mode
+    /// OR  Temp storage for SS:SP during shutdown
+    /// OR  Day counter on all products after AT
+    /// OR  PS/2 Pointer to reset code with memory preserved
     /// </summary>
-    public uint RealTimeClock { get => UInt32[0x006C]; set => UInt32[0x006C] = value; }
+    public SegmentedAddress Jump { get => SegmentedAddress[0x67]; set => SegmentedAddress[0x67] = value; }
+
+    /// Padding at 0x6B
+
+    /// <summary>
+    /// Gets or sets the current value of the Int1A counter.
+    /// </summary>
+    public uint TimerCounter { get => UInt32[0x6C]; set => UInt32[0x6C] = value; }
+
+    /// <summary>
+    /// Clock rollover flag, set when TimerCounter exceeds 24hrs
+    /// </summary>
+    public byte TimerRollover { get => UInt8[0x70]; set => UInt8[0x70] = value; }
+
+    public byte BreakFlag { get => UInt8[0x71]; set => UInt8[0x71] = value; }
+
+    public ushort SoftResetFlag { get => UInt16[0x72]; set => UInt16[0x72] = value; }
+
+    public byte DiskLastStatus { get => UInt8[0x74]; set => UInt8[0x74] = value; }
+
+    public byte Hdcount { get => UInt8[0x75]; set => UInt8[0x75] = value; }
+
+    public byte DiskControlByte { get => UInt8[0x76]; set => UInt8[0x76] = value; }
+
+    public byte PortDisk { get => UInt8[0x77]; set => UInt8[0x77] = value; }
+
+    public UInt8Array LptTimeout => GetUInt8Array(0x78, 4);
+
+    public UInt8Array ComTimeout => GetUInt8Array(0x7C, 4);
+
+    public ushort KbdBufStartOffset { get => UInt16[0x80]; set => UInt16[0x80] = value; }
+
+    public ushort KbdBufEndOffset { get => UInt16[0x82]; set => UInt16[0x82] = value; }
 
     /// <summary>
     /// Gets or sets the screen row count.
     /// </summary>
-    public byte ScreenRows { get => UInt8[0x0084]; set => UInt8[0x0084] = value; }
+    public byte ScreenRows { get => UInt8[0x84]; set => UInt8[0x84] = value; }
 
     /// <summary>
     /// Gets or sets the character point height.
     /// </summary>
-    public ushort CharacterHeight { get => UInt16[0x0085]; set => UInt16[0x0085] = value; }
+    public ushort CharacterHeight { get => UInt16[0x85]; set => UInt16[0x85] = value; }
 
     /// <summary>
     /// Gets or sets the VideoCtl.
     /// </summary>
-    public byte VideoCtl { get => UInt8[0x0087]; set => UInt8[0x0087] = value; }
+    public byte VideoCtl { get => UInt8[0x87]; set => UInt8[0x87] = value; }
 
     /// <summary>
     /// Gets or sets the BIOS video mode options.
     /// </summary>
-    public byte FeatureSwitches { get => UInt8[0x0088]; set => UInt8[0x0088] = value; }
+    public byte VideoFeatureSwitches { get => UInt8[0x88]; set => UInt8[0x88] = value; }
 
     /// <summary>
     /// Gets or sets the EGA feature switch values.
     /// </summary>
-    public byte ModesetCtl { get => UInt8[0x0089]; set => UInt8[0x0089] = value; }
+    public byte ModesetCtl { get => UInt8[0x89]; set => UInt8[0x89] = value; }
 
     /// <summary>
     /// Gets or sets the display combination code.
     /// </summary>
-    public byte DisplayCombinationCode { get => UInt8[0x008A]; set => UInt8[0x008A] = value; }
+    public byte DisplayCombinationCode { get => UInt8[0x8A]; set => UInt8[0x8A] = value; }
+
+    public byte FloppyLastDataRate { get => UInt8[0x8B]; set => UInt8[0x8B] = value; }
+
+    public byte DiskStatusController { get => UInt8[0x8C]; set => UInt8[0x8C] = value; }
+
+    public byte DiskErrorController { get => UInt8[0x8D]; set => UInt8[0x8D] = value; }
+
+    public byte DiskInterruptFlag { get => UInt8[0x8E]; set => UInt8[0x8E] = value; }
+
+    public byte FloppyHarddiskInfo { get => UInt8[0x8F]; set => UInt8[0x8F] = value; }
+
+    public UInt8Array FloppyMediaState => GetUInt8Array(0x90, 4);
+
+    public UInt8Array FloppyTrack => GetUInt8Array(0x94, 2);
+
+    public byte KbdFlag1 { get => UInt8[0x96]; set => UInt8[0x96] = value; }
+
+    public byte KbdLed { get => UInt8[0x97]; set => UInt8[0x97] = value; }
+
+    public SegmentedAddress UserWaitCompleteFlag { get => SegmentedAddress[0x98]; set => SegmentedAddress[0x98] = value; }
+
+    public uint UserWaitTimeout { get => UInt32[0x9C]; set => UInt32[0x9C] = value; }
+
+    public byte RtcWaitFlag { get => UInt8[0xA0]; set => UInt8[0xA0] = value; }
+
+    /// 7 btyes of padding at 0xA1
+    
+    public SegmentedAddress VideoSavetable { get => SegmentedAddress[0xA8]; set => SegmentedAddress[0xA8] = value; }
+
 }

--- a/src/Spice86.Core/Emulator/Memory/Indexable/ByteArrayBasedIndexable.cs
+++ b/src/Spice86.Core/Emulator/Memory/Indexable/ByteArrayBasedIndexable.cs
@@ -7,6 +7,10 @@ using Spice86.Core.Emulator.Memory.ReaderWriter;
 /// Implementation of Indexable over a byte array.
 /// </summary>
 public class ByteArrayBasedIndexable : Indexable {
+    
+    /// <summary>
+    /// Access to underlying ReaderWriter
+    /// </summary>
     public ByteArrayByteReaderWriter ReaderWriter { get; }
 
     /// <summary>

--- a/src/Spice86.Core/Emulator/Memory/Indexable/ByteArrayBasedIndexable.cs
+++ b/src/Spice86.Core/Emulator/Memory/Indexable/ByteArrayBasedIndexable.cs
@@ -7,12 +7,12 @@ using Spice86.Core.Emulator.Memory.ReaderWriter;
 /// Implementation of Indexable over a byte array.
 /// </summary>
 public class ByteArrayBasedIndexable : Indexable {
-    private readonly ByteArrayByteReaderWriter _readerWriter;
+    public ByteArrayByteReaderWriter ReaderWriter { get; }
 
     /// <summary>
     /// Underlying array beeing wrapped
     /// </summary>
-    public byte[] Array { get => _readerWriter.Array; }
+    public byte[] Array { get => ReaderWriter.Array; }
 
     /// <inheritdoc/>
     public override UInt8Indexer UInt8 { get; }
@@ -32,7 +32,7 @@ public class ByteArrayBasedIndexable : Indexable {
     }
 
     public ByteArrayBasedIndexable(byte[] array) {
-        _readerWriter = new ByteArrayByteReaderWriter(array);
-        (UInt8, UInt16, UInt32, SegmentedAddressValue, SegmentedAddress) = InstantiateIndexersFromByteReaderWriter(_readerWriter);
+        ReaderWriter = new ByteArrayByteReaderWriter(array);
+        (UInt8, UInt16, UInt32, SegmentedAddressValue, SegmentedAddress) = InstantiateIndexersFromByteReaderWriter(ReaderWriter);
     }
 }

--- a/src/Spice86.Core/Emulator/ReverseEngineer/DataStructure/AbstractMemoryBasedDataStructure.cs
+++ b/src/Spice86.Core/Emulator/ReverseEngineer/DataStructure/AbstractMemoryBasedDataStructure.cs
@@ -63,14 +63,15 @@ public abstract class AbstractMemoryBasedDataStructure : Indexable, IBaseAddress
     protected uint ComputeAddressFromOffset(uint offset) {
         return (uint)(BaseAddress + offset);
     }
+
     /// <summary>
     /// Gets an 8-bit unsigned integer array from the data structure starting at the specified offset and with the specified length.
     /// </summary>
     /// <param name="start">The offset from the base address to start reading values from.</param>
     /// <param name="length">The length of the array.</param>
     /// <returns>The array of uint8 values.</returns>
-    public Uint8Array GetUint8Array(uint start, int length) {
-        return new Uint8Array(ByteReaderWriterShiftedToBaseAddress, ComputeAddressFromOffset(start), length);
+    public UInt8Array GetUInt8Array(uint start, int length) {
+        return new UInt8Array(ByteReaderWriter, ComputeAddressFromOffset(start), length);
     }
 
     /// <summary>
@@ -79,8 +80,8 @@ public abstract class AbstractMemoryBasedDataStructure : Indexable, IBaseAddress
     /// <param name="start">The offset from the base address to start reading values from.</param>
     /// <param name="length">The length of the array.</param>
     /// <returns>The array of uint16 values.</returns>
-    public Uint16Array GetUint16Array(uint start, int length) {
-        return new Uint16Array(ByteReaderWriterShiftedToBaseAddress, ComputeAddressFromOffset(start), length);
+    public UInt16Array GetUInt16Array(uint start, int length) {
+        return new UInt16Array(ByteReaderWriter, ComputeAddressFromOffset(start), length);
     }
     
     /// <summary>
@@ -89,8 +90,8 @@ public abstract class AbstractMemoryBasedDataStructure : Indexable, IBaseAddress
     /// <param name="start">The offset from the base address to start reading values from.</param>
     /// <param name="length">The length of the array.</param>
     /// <returns>The array of uint8 values.</returns>
-    public Uint32Array GetUint32Array(uint start, int length) {
-        return new Uint32Array(ByteReaderWriterShiftedToBaseAddress, ComputeAddressFromOffset(start), length);
+    public UInt32Array GetUInt32Array(uint start, int length) {
+        return new UInt32Array(ByteReaderWriter, ComputeAddressFromOffset(start), length);
     }
 
     /// <summary>
@@ -100,6 +101,6 @@ public abstract class AbstractMemoryBasedDataStructure : Indexable, IBaseAddress
     /// <param name="length">The length of the array.</param>
     /// <returns>The array of uint8 values.</returns>
     public SegmentedAddressArray GetSegmentedAddressArray(uint start, int length) {
-        return new SegmentedAddressArray(ByteReaderWriterShiftedToBaseAddress, ComputeAddressFromOffset(start), length);
+        return new SegmentedAddressArray(ByteReaderWriter, ComputeAddressFromOffset(start), length);
     }
 }

--- a/src/Spice86.Core/Emulator/ReverseEngineer/DataStructure/Array/SegmentedAddressArray.cs
+++ b/src/Spice86.Core/Emulator/ReverseEngineer/DataStructure/Array/SegmentedAddressArray.cs
@@ -8,7 +8,7 @@ using Spice86.Shared.Emulator.Memory;
 /// </summary>
 public class SegmentedAddressArray : MemoryBasedArray<SegmentedAddress> {
     /// <summary>
-    /// Initializes a new instance of the <see cref="Uint32Array"/> class with the specified memory, base address, and length.
+    /// Initializes a new instance of the <see cref="UInt32Array"/> class with the specified memory, base address, and length.
     /// </summary>
     /// <param name="byteReaderWriter">Where data is read and written.</param>
     /// <param name="baseAddress">The base address of the array.</param>

--- a/src/Spice86.Core/Emulator/ReverseEngineer/DataStructure/Array/UInt16Array.cs
+++ b/src/Spice86.Core/Emulator/ReverseEngineer/DataStructure/Array/UInt16Array.cs
@@ -5,14 +5,14 @@ using Spice86.Core.Emulator.Memory.ReaderWriter;
 /// <summary>
 /// Represents an array of 16-bit unsigned integers stored in memory.
 /// </summary>
-public class Uint16Array : MemoryBasedArray<ushort> {
+public class UInt16Array : MemoryBasedArray<ushort> {
     /// <summary>
-    /// Initializes a new instance of the <see cref="Uint16Array"/> class with the specified memory, base address, and length.
+    /// Initializes a new instance of the <see cref="UInt16Array"/> class with the specified memory, base address, and length.
     /// </summary>
     /// <param name="byteReaderWriter">Where data is read and written.</param>
     /// <param name="baseAddress">The base address of the array.</param>
     /// <param name="length">The length of the array.</param>
-    public Uint16Array(IByteReaderWriter byteReaderWriter, uint baseAddress, int length) : base(byteReaderWriter, baseAddress, length) {
+    public UInt16Array(IByteReaderWriter byteReaderWriter, uint baseAddress, int length) : base(byteReaderWriter, baseAddress, length) {
     }
 
     /// <summary>

--- a/src/Spice86.Core/Emulator/ReverseEngineer/DataStructure/Array/UInt32Array.cs
+++ b/src/Spice86.Core/Emulator/ReverseEngineer/DataStructure/Array/UInt32Array.cs
@@ -5,14 +5,14 @@ using Spice86.Core.Emulator.Memory.ReaderWriter;
 /// <summary>
 /// Represents an array of 32-bit unsigned integers stored in memory.
 /// </summary>
-public class Uint32Array : MemoryBasedArray<uint> {
+public class UInt32Array : MemoryBasedArray<uint> {
     /// <summary>
-    /// Initializes a new instance of the <see cref="Uint32Array"/> class with the specified memory, base address, and length.
+    /// Initializes a new instance of the <see cref="UInt32Array"/> class with the specified memory, base address, and length.
     /// </summary>
     /// <param name="byteReaderWriter">Where data is read and written.</param>
     /// <param name="baseAddress">The base address of the array.</param>
     /// <param name="length">The length of the array.</param>
-    public Uint32Array(IByteReaderWriter byteReaderWriter, uint baseAddress, int length) : base(byteReaderWriter, baseAddress, length) {
+    public UInt32Array(IByteReaderWriter byteReaderWriter, uint baseAddress, int length) : base(byteReaderWriter, baseAddress, length) {
     }
 
     /// <summary>

--- a/src/Spice86.Core/Emulator/ReverseEngineer/DataStructure/Array/UInt8Array.cs
+++ b/src/Spice86.Core/Emulator/ReverseEngineer/DataStructure/Array/UInt8Array.cs
@@ -5,14 +5,14 @@ using Spice86.Core.Emulator.Memory.ReaderWriter;
 /// <summary>
 /// Represents an array of unsigned 8-bit integers stored in memory.
 /// </summary>
-public class Uint8Array : MemoryBasedArray<byte> {
+public class UInt8Array : MemoryBasedArray<byte> {
     /// <summary>
-    /// Initializes a new instance of the <see cref="Uint8Array"/> class.
+    /// Initializes a new instance of the <see cref="UInt8Array"/> class.
     /// </summary>
     /// <param name="byteReaderWriter">Where data is read and written.</param>
     /// <param name="baseAddress">The base address of the array in memory.</param>
     /// <param name="length">The length of the array.</param>
-    public Uint8Array(IByteReaderWriter byteReaderWriter, uint baseAddress, int length) : base(byteReaderWriter, baseAddress, length) {
+    public UInt8Array(IByteReaderWriter byteReaderWriter, uint baseAddress, int length) : base(byteReaderWriter, baseAddress, length) {
     }
 
     /// <summary>

--- a/src/Spice86.Core/Emulator/VM/Machine.cs
+++ b/src/Spice86.Core/Emulator/VM/Machine.cs
@@ -278,7 +278,7 @@ public class Machine : IDisposable {
         VideoInt10Handler = new VgaBios(this, VgaFunctions, BiosDataArea, machineCreationOptions.LoggerService);
         
         TimerInt8Handler = new TimerInt8Handler(this, machineCreationOptions.LoggerService);
-        BiosKeyboardInt9Handler = new BiosKeyboardInt9Handler(this, machineCreationOptions.LoggerService);
+        BiosKeyboardInt9Handler = new BiosKeyboardInt9Handler(this, BiosDataArea, machineCreationOptions.LoggerService);
         
         BiosEquipmentDeterminationInt11Handler = new BiosEquipmentDeterminationInt11Handler(this, machineCreationOptions.LoggerService);
         SystemBiosInt15Handler = new SystemBiosInt15Handler(this, machineCreationOptions.LoggerService);

--- a/src/Spice86.Tests/MemoryBasedDataStructureTest.cs
+++ b/src/Spice86.Tests/MemoryBasedDataStructureTest.cs
@@ -1,0 +1,210 @@
+﻿namespace Spice86.Tests;
+
+using Spice86.Core.Emulator.Memory.Indexable;
+using Spice86.Core.Emulator.Memory.Indexer;
+using Spice86.Core.Emulator.ReverseEngineer.DataStructure;
+using Spice86.Core.Emulator.ReverseEngineer.DataStructure.Array;
+using Spice86.Shared.Emulator.Memory;
+
+using System;
+using System.Collections.Generic;
+
+using Xunit;
+
+public class MemoryBasedDataStructureTest {
+    private const byte ExpectedUInt8 = 0x01;
+    private const ushort ExpectedUInt16 = 0x0102;
+    private const uint ExpectedUInt32 = 0x01020304;
+    private const string ExpectedString = "0123456789";
+    private static readonly int ExpectedStringLength = ExpectedString.Length + 1;
+    private static readonly SegmentedAddress ExpectedSegmentedAddress = new (0x0708, 0x0900);
+    private static readonly ValueTuple<ushort, ushort> ExpectedSegmentedAddressValue = (0x0708, 0x0900);
+    
+    private static readonly byte[] ExpectedUInt8Array = { 0x01, 0x02 };
+    private static readonly ushort[] ExpectedUInt16Array = { 0x0101, 0x0202 };
+    private static readonly uint[] ExpectedUInt32Array = { 0x01010101, 0x02020202 };
+    private static readonly SegmentedAddress[] ExpectedSegmentedAddressArray = { new (0x01, 0x02), new (0x03, 0x04) };
+
+    // Offset in struct for read test
+    private const uint ReadOffset = 10;
+    // Offset in struct for write test
+    private const uint WriteOffset = 30;
+    // Address of struct in memory
+    private const uint StructAddress = 10;
+    // Physical address in memory for read test
+    private const uint ReadAddress = StructAddress + ReadOffset;
+    // Physical address in memory for write test
+    private const uint WriteAddress = StructAddress + WriteOffset;
+
+    [Fact]
+    public void CanMapUInt8() {
+        // Arrange
+        (ByteArrayBasedIndexable data, MemoryBasedDataStructure memoryBasedDataStructure) = Init(StructAddress);
+        data.UInt8[ReadAddress] = ExpectedUInt8;
+
+        // Act & Assert
+        // Read
+        Assert.Equal(ExpectedUInt8, memoryBasedDataStructure.UInt8[ReadOffset]);
+        // Write
+        memoryBasedDataStructure.UInt8[WriteOffset] = ExpectedUInt8;
+        Assert.Equal(ExpectedUInt8, data.UInt8[WriteAddress]);
+    }
+
+    [Fact]
+    public void CanMapUInt16() {
+        // Arrange
+        (ByteArrayBasedIndexable data, MemoryBasedDataStructure memoryBasedDataStructure) = Init(StructAddress);
+        data.UInt16[ReadAddress] = ExpectedUInt16;
+
+        // Act & Assert
+        // Read
+        Assert.Equal(ExpectedUInt16, memoryBasedDataStructure.UInt16[ReadOffset]);
+        // Write
+        memoryBasedDataStructure.UInt16[WriteOffset] = ExpectedUInt16;
+        Assert.Equal(ExpectedUInt16, data.UInt16[WriteAddress]);
+    }
+
+    [Fact]
+    public void CanMapUInt32() {
+        // Arrange
+        (ByteArrayBasedIndexable data, MemoryBasedDataStructure memoryBasedDataStructure) = Init(StructAddress);
+        data.UInt32[ReadAddress] = ExpectedUInt32;
+        memoryBasedDataStructure.UInt32[WriteOffset] = ExpectedUInt32;
+
+        // Act & Assert
+        // Read
+        Assert.Equal(ExpectedUInt32, memoryBasedDataStructure.UInt32[ReadOffset]);
+        // Write
+        Assert.Equal(ExpectedUInt32, data.UInt32[WriteAddress]);
+    }
+
+
+    [Fact]
+    public void CanMapSegmentedAddress() {
+        // Arrange
+        (ByteArrayBasedIndexable data, MemoryBasedDataStructure memoryBasedDataStructure) = Init(StructAddress);
+        data.SegmentedAddress[ReadAddress] = ExpectedSegmentedAddress;
+
+        // Act & Assert
+        // Read
+        Assert.Equal(ExpectedSegmentedAddress, memoryBasedDataStructure.SegmentedAddress[ReadOffset]);
+        // Write
+        memoryBasedDataStructure.SegmentedAddress[WriteOffset] = ExpectedSegmentedAddress;
+        Assert.Equal(ExpectedSegmentedAddress, data.SegmentedAddress[WriteAddress]);
+    }
+
+    [Fact]
+    public void CanMapSegmentedAddressValue() {
+        // Arrange
+        (ByteArrayBasedIndexable data, MemoryBasedDataStructure memoryBasedDataStructure) = Init(StructAddress);
+        data.SegmentedAddressValue[ReadAddress] = ExpectedSegmentedAddressValue;
+
+        // Act & Assert
+        // Read
+        Assert.Equal(ExpectedSegmentedAddressValue, memoryBasedDataStructure.SegmentedAddressValue[ReadOffset]);
+        // Write
+        memoryBasedDataStructure.SegmentedAddressValue[WriteOffset] = ExpectedSegmentedAddressValue;
+        Assert.Equal(ExpectedSegmentedAddressValue, data.SegmentedAddressValue[WriteAddress]);
+    }
+
+    [Fact]
+    public void CanMapString() {
+        // Arrange
+        (ByteArrayBasedIndexable data, MemoryBasedDataStructure memoryBasedDataStructure) = Init(StructAddress);
+        data.SetZeroTerminatedString(ReadAddress, ExpectedString, ExpectedStringLength);
+
+        // Act & Assert
+        // Read
+        Assert.Equal(ExpectedString, memoryBasedDataStructure.GetZeroTerminatedString(ReadOffset, ExpectedStringLength));
+        // Write
+        memoryBasedDataStructure.SetZeroTerminatedString(WriteOffset, ExpectedString, ExpectedStringLength);
+        Assert.Equal(ExpectedString, data.GetZeroTerminatedString(WriteAddress, ExpectedStringLength));
+    }
+
+
+    [Fact]
+    public void CanMapUInt8Array() {
+        // Arrange
+        (ByteArrayBasedIndexable data, MemoryBasedDataStructure memoryBasedDataStructure) = Init(StructAddress);
+        CopyArrayToIndexer(ExpectedUInt8Array, data.UInt8, ReadAddress, 1);
+
+        // Act & Assert
+        UInt8Array uInt8Array = memoryBasedDataStructure.GetUInt8Array(ReadOffset, ExpectedUInt8Array.Length);
+        // Read
+        AssertArrayEqualsCollection(ExpectedUInt8Array, uInt8Array);
+
+        // Write
+        WriteIndex0AndAssertIndex1Untouched<byte>(ExpectedUInt8Array, uInt8Array, data.UInt8, 1, 0);
+    }
+
+
+    [Fact]
+    public void CanMapUInt16Array() {
+        // Arrange
+        (ByteArrayBasedIndexable data, MemoryBasedDataStructure memoryBasedDataStructure) = Init(StructAddress);
+        CopyArrayToIndexer(ExpectedUInt16Array, data.UInt16, ReadAddress, 2);
+
+        // Act & Assert
+        UInt16Array uInt16Array = memoryBasedDataStructure.GetUInt16Array(ReadOffset, ExpectedUInt16Array.Length);
+        // Read
+        AssertArrayEqualsCollection(ExpectedUInt16Array, uInt16Array);
+
+        // Write
+        WriteIndex0AndAssertIndex1Untouched<ushort>(ExpectedUInt16Array, uInt16Array, data.UInt16, 2, 0);
+    }
+
+    [Fact]
+    public void CanMapUInt32Array() {
+        // Arrange
+        (ByteArrayBasedIndexable data, MemoryBasedDataStructure memoryBasedDataStructure) = Init(StructAddress);
+        CopyArrayToIndexer(ExpectedUInt32Array, data.UInt32, ReadAddress, 4);
+
+        // Act & Assert
+        UInt32Array uInt32Array = memoryBasedDataStructure.GetUInt32Array(ReadOffset, ExpectedUInt32Array.Length);
+        // Read
+        AssertArrayEqualsCollection(ExpectedUInt32Array, uInt32Array);
+        // Write
+        WriteIndex0AndAssertIndex1Untouched<uint>(ExpectedUInt32Array, uInt32Array, data.UInt32, 4, 0);
+    }
+
+    [Fact]
+    public void CanMapSegmentedAddressArray() {
+        // Arrange
+        (ByteArrayBasedIndexable data, MemoryBasedDataStructure memoryBasedDataStructure) = Init(StructAddress);
+        CopyArrayToIndexer(ExpectedSegmentedAddressArray, data.SegmentedAddress, ReadAddress, 4);
+
+        // Act & Assert
+        SegmentedAddressArray segmentedAddressArray = memoryBasedDataStructure.GetSegmentedAddressArray(ReadOffset, ExpectedUInt32Array.Length);
+        // Read
+        AssertArrayEqualsCollection(ExpectedSegmentedAddressArray, segmentedAddressArray);
+        // Write
+        WriteIndex0AndAssertIndex1Untouched<SegmentedAddress>(ExpectedSegmentedAddressArray, segmentedAddressArray, data.SegmentedAddress, 4, new SegmentedAddress(0, 0));
+    }
+
+    private void CopyArrayToIndexer<T>(IReadOnlyList<T> array, Indexer<T> data, uint baseAddress, int elementSize) {
+        for (int i = 0; i < array.Count; i++) {
+            data[(uint)(baseAddress + i * elementSize)] = array[i];
+        }
+    }
+
+    private void AssertArrayEqualsCollection<T>(IReadOnlyList<T> expectedArray, ICollection<T> collection) {
+        Assert.Equal(expectedArray.Count, collection.Count);
+
+        int index = 0;
+        foreach (T actual in collection) {
+            Assert.Equal(expectedArray[index++], actual);
+        }
+    }
+
+    private void WriteIndex0AndAssertIndex1Untouched<T>(IReadOnlyList<T> expectedArray, IList<T> inMemoryArray, Indexer<T> memoryData, int elementSize, T writeValue) {
+        inMemoryArray[0] = writeValue;
+        Assert.Equal(writeValue, memoryData[ReadAddress]);
+        Assert.Equal(expectedArray[1], memoryData[(uint)(ReadAddress + elementSize)]);
+    }
+
+    private (ByteArrayBasedIndexable Data, MemoryBasedDataStructure MemoryBasedDataStructure) Init(uint offset) {
+        ByteArrayBasedIndexable data = new ByteArrayBasedIndexable(new byte[100]);
+        MemoryBasedDataStructure memoryBasedDataStructure = new MemoryBasedDataStructure(data.ReaderWriter, offset);
+        return (data, memoryBasedDataStructure);
+    }
+}


### PR DESCRIPTION
Add tests to MemoryBasedDataStructure.
Convert BiosDataArea to Memory Based Structure. 
Complete BiosDataArea with missing fields.
Make BiosKeyboardBuffer use BiosDataArea fields.
