### PR TITLE
Use Memory.SegmentedAddressValue when applicable instead of computing…

### DIFF
--- a/src/Spice86.Core/Emulator/CPU/InstructionsImpl/Instructions16.cs
+++ b/src/Spice86.Core/Emulator/CPU/InstructionsImpl/Instructions16.cs
@@ -495,8 +495,8 @@ public class Instructions16 : Instructions16Or32 {
 
     protected override ushort DoLxsAndReturnSegmentValue() {
         uint memoryAddress = ReadLxsMemoryAddress();
-        ModRM.R16 = Memory.UInt16[memoryAddress];
-        return Memory.UInt16[memoryAddress + 2];
+        (ushort segment, ModRM.R16) = Memory.SegmentedAddressValue[memoryAddress];
+        return segment;
     }
     
     public override void InImm8() {

--- a/src/Spice86.Core/Emulator/CPU/InstructionsImpl/Instructions16Or32.cs
+++ b/src/Spice86.Core/Emulator/CPU/InstructionsImpl/Instructions16Or32.cs
@@ -110,8 +110,7 @@ public abstract class Instructions16Or32 : Instructions {
             return;
         }
 
-        ushort ip = Memory.UInt16[ipAddress.Value];
-        ushort cs = Memory.UInt16[ipAddress.Value + 2];
+        (ushort cs, ushort ip) = Memory.SegmentedAddressValue[ipAddress.Value];
         Cpu.FarCallWithReturnIpNextInstruction(cs, ip);
     }
 
@@ -125,9 +124,7 @@ public abstract class Instructions16Or32 : Instructions {
         if (ipAddress is null) {
             return;
         }
-
-        ushort ip = Memory.UInt16[ipAddress.Value];
-        ushort cs = Memory.UInt16[ipAddress.Value + 2];
+        (ushort cs, ushort ip) = Memory.SegmentedAddressValue[ipAddress.Value];
         Cpu.JumpFar(cs, ip);
     }
 

--- a/src/Spice86.Core/Emulator/OperatingSystem/Dos.cs
+++ b/src/Spice86.Core/Emulator/OperatingSystem/Dos.cs
@@ -179,8 +179,8 @@ public class Dos {
         // Make the previous device point to this one
         if (Devices.Count > 0) {
             IVirtualDevice previousDevice = Devices[^1];
-            _machine.Memory.UInt16[previousDevice.Segment, previousDevice.Offset] = device.Offset;
-            _machine.Memory.UInt16[previousDevice.Segment, (ushort)(previousDevice.Offset + 2)] = device.Segment;
+            _machine.Memory.SegmentedAddressValue[previousDevice.Segment, previousDevice.Offset] =
+                (device.Segment, device.Offset);
         }
 
         // Handle changing of current input, output or clock devices.

--- a/src/Spice86.Tests/MemoryBasedDataStructureTest.cs
+++ b/src/Spice86.Tests/MemoryBasedDataStructureTest.cs
@@ -192,7 +192,12 @@ public class MemoryBasedDataStructureTest {
 
         int index = 0;
         foreach (T actual in collection) {
-            Assert.Equal(expectedArray[index++], actual);
+            T expected = expectedArray[index];
+            if (!EqualityComparer<T>.Default.Equals(expected, actual)) {
+                Assert.Fail($"Values at index {index} do not match. Expected {expected} but got {actual}");
+            }
+
+            index++;
         }
     }
 


### PR DESCRIPTION
Use SegmentedAddressValue[address] instead of UInt16[address], UInt16[address + 2] to access segmented addresses in memory