### PR TITLE
Alu class split between 8, 16 and 32 versions

### DIFF
--- a/src/Spice86.Core/Emulator/CPU/Alu.cs
+++ b/src/Spice86.Core/Emulator/CPU/Alu.cs
@@ -1,11 +1,15 @@
 ﻿namespace Spice86.Core.Emulator.CPU;
 
-using Spice86.Core.Emulator.CPU.Exceptions;
+using System.Numerics;
 
 /// <summary>
 /// Arithmetic-logic unit
 /// </summary>
-public class Alu {
+public abstract class Alu<TUnsigned, TSigned, TUnsignedUpper, TSignedUpper>
+    where TUnsigned : IUnsignedNumber<TUnsigned>
+    where TSigned : ISignedNumber<TSigned>
+    where TUnsignedUpper : IUnsignedNumber<TUnsignedUpper>
+    where TSignedUpper : ISignedNumber<TSignedUpper> {
     /// <summary>
     /// Shifting this by the number we want to test gives 1 if number of bit is even and 0 if odd.<br/>
     /// Hardcoded numbers:<br/>
@@ -29,21 +33,9 @@ public class Alu {
     /// </summary>
     private const uint FourBitParityTable = 0b1001011001101001;
 
-    private const uint BeforeMsbMask32 = 0x40000000;
+    protected const int ShiftCountMask = 0x1F;
 
-    private const ushort BeforeMsbMask16 = 0x4000;
-
-    private const byte BeforeMsbMask8 = 0x40;
-
-    private const uint MsbMask32 = 0x80000000;
-
-    private const ushort MsbMask16 = 0x8000;
-
-    private const byte MsbMask8 = 0x80;
-
-    private const int ShiftCountMask = 0x1F;
-
-    private readonly State _state;
+    protected readonly State _state;
 
     /// <summary>
     /// Initializes a new instance.
@@ -52,744 +44,76 @@ public class Alu {
     public Alu(State state) {
         _state = state;
     }
-
-    public uint Adc32(uint value1, uint value2) {
-        return Add32(value1, value2, true);
-    }
-
-    public ushort Adc16(ushort value1, ushort value2) {
-        return Add16(value1, value2, true);
-    }
-
-    public byte Adc8(byte value1, byte value2) {
-        return Add8(value1, value2, true);
-    }
-
-    public uint Add32(uint value1, uint value2) {
-        return Add32(value1, value2, false);
-    }
-
-    public uint Add32(uint value1, uint value2, bool useCarry) {
-        int carry = useCarry && _state.CarryFlag ? 1 : 0;
-        uint res = (uint)(value1 + value2 + carry);
-        UpdateFlags32(res);
-        uint carryBits = CarryBitsAdd(value1, value2, res);
-        uint overflowBits = OverflowBitsAdd(value1, value2, res);
-        _state.CarryFlag = (carryBits >> 31 & 1) == 1;
-        _state.AuxiliaryFlag = (carryBits >> 3 & 1) == 1;
-        _state.OverflowFlag = (overflowBits >> 31 & 1) == 1;
-        return res;
-    }
-
-    public ushort Add16(ushort value1, ushort value2, bool useCarry) {
-        int carry = useCarry && _state.CarryFlag ? 1 : 0;
-        ushort res = (ushort)(value1 + value2 + carry);
-        UpdateFlags16(res);
-        uint carryBits = CarryBitsAdd(value1, value2, res);
-        uint overflowBits = OverflowBitsAdd(value1, value2, res);
-        _state.CarryFlag = (carryBits >> 15 & 1) == 1;
-        _state.AuxiliaryFlag = (carryBits >> 3 & 1) == 1;
-        _state.OverflowFlag = (overflowBits >> 15 & 1) == 1;
-        return res;
-    }
-
-    public ushort Add16(ushort value1, ushort value2) {
-        return Add16(value1, value2, false);
-    }
-
-    public byte Add8(byte value1, byte value2, bool useCarry) {
-        int carry = useCarry && _state.CarryFlag ? 1 : 0;
-        byte res = (byte)(value1 + value2 + carry);
-        UpdateFlags8(res);
-        uint carryBits = CarryBitsAdd(value1, value2, res);
-        uint overflowBits = OverflowBitsAdd(value1, value2, res);
-        _state.CarryFlag = (carryBits >> 7 & 1) == 1;
-        _state.AuxiliaryFlag = (carryBits >> 3 & 1) == 1;
-        _state.OverflowFlag = (overflowBits >> 7 & 1) == 1;
-        return res;
-    }
-
-    public byte Add8(byte value1, byte value2) {
-        return Add8(value1, value2, false);
-    }
-
-    public uint And32(uint value1, uint value2) {
-        uint res = value1 & value2;
-        UpdateFlags32(res);
-        _state.CarryFlag = false;
-        _state.OverflowFlag = false;
-        return res;
-    }
-
-    public ushort And16(ushort value1, ushort value2) {
-        ushort res = (ushort)(value1 & value2);
-        UpdateFlags16(res);
-        _state.CarryFlag = false;
-        _state.OverflowFlag = false;
-        return res;
-    }
-
-    public byte And8(byte value1, byte value2) {
-        byte res = (byte)(value1 & value2);
-        UpdateFlags8(res);
-        _state.CarryFlag = false;
-        _state.OverflowFlag = false;
-        return res;
-    }
-
-    public uint Dec32(uint value1) {
-        bool carry = _state.CarryFlag;
-        uint res = Sub32(value1, 1, false);
-        _state.CarryFlag = carry;
-        return res;
-    }
-
-    public ushort Dec16(ushort value1) {
-        bool carry = _state.CarryFlag;
-        ushort res = Sub16(value1, 1, false);
-        _state.CarryFlag = carry;
-        return res;
-    }
-
-    public byte Dec8(byte value1) {
-        bool carry = _state.CarryFlag;
-        byte res = Sub8(value1, 1, false);
-        _state.CarryFlag = carry;
-        return res;
-    }
-
-    public uint Div32(ulong value1, uint value2) {
-        if (value2 == 0) {
-            throw new CpuDivisionErrorException($"Division by zero");
-        }
-
-        ulong res = value1 / value2;
-        if (res > uint.MaxValue) {
-            throw new CpuDivisionErrorException($"Division result out of range: {res}");
-        }
-
-        return (uint)res;
-    }
-
-    public ushort Div16(uint value1, ushort value2) {
-        if (value2 == 0) {
-            throw new CpuDivisionErrorException($"Division by zero");
-        }
-
-        uint res = value1 / value2;
-        if (res > ushort.MaxValue) {
-            throw new CpuDivisionErrorException($"Division result out of range: {res}");
-        }
-
-        return (ushort)res;
-    }
-
-    public byte Div8(ushort value1, byte value2) {
-        if (value2 == 0) {
-            throw new CpuDivisionErrorException($"Division by zero");
-        }
-
-        uint res = (uint)(value1 / value2);
-        if (res > byte.MaxValue) {
-            throw new CpuDivisionErrorException($"Division result out of range: {res}");
-        }
-
-        return (byte)res;
-    }
     
-    public int Idiv32(long value1, int value2) {
-        if (value2 == 0) {
-            throw new CpuDivisionErrorException($"Division by zero");
-        }
-
-        long res = value1 / value2;
-        unchecked {
-            if (res is > 0x7FFFFFFF or < (int)0x80000000) {
-                throw new CpuDivisionErrorException($"Division result out of range: {res}");
-            }
-        }
-
-        return (int)res;
+    public TUnsigned Adc(TUnsigned value1, TUnsigned value2) {
+        return Add(value1, value2, true);
     }
 
-    public short Idiv16(int value1, short value2) {
-        if (value2 == 0) {
-            throw new CpuDivisionErrorException($"Division by zero");
-        }
-
-        int res = value1 / value2;
-        unchecked {
-            if (res is > 0x7FFF or < (short)0x8000) {
-                throw new CpuDivisionErrorException($"Division result out of range: {res}");
-            }
-        }
-
-        return (short)res;
+    public TUnsigned Add(TUnsigned value1, TUnsigned value2) {
+        return Add(value1, value2, false);
     }
 
-    public sbyte Idiv8(short value1, sbyte value2) {
-        if (value2 == 0) {
-            throw new CpuDivisionErrorException($"Division by zero");
-        }
-
-        int res = value1 / value2;
-        unchecked {
-            if (res is > 0x7F or < ((sbyte)0x80)) {
-                throw new CpuDivisionErrorException($"Division result out of range: {res}");
-            }
-        }
-
-        return (sbyte)res;
+    public TUnsigned Inc(TUnsigned value) {
+        // CF is not modified
+        bool carry = _state.CarryFlag;
+        TUnsigned res = Add(value, TUnsigned.One, false);
+        _state.CarryFlag = carry;
+        return res;
     }
 
-    public long Imul32(int value1, int value2) {
-        long res = (long)value1 * value2;
-        bool doesNotFitInDWord = res != (int)res;
-        _state.OverflowFlag = doesNotFitInDWord;
-        _state.CarryFlag = doesNotFitInDWord;
+    public abstract TUnsigned Add(TUnsigned value1, TUnsigned value2, bool useCarry);
+
+
+    public TUnsigned Sbb(TUnsigned value1, TUnsigned value2) {
+        return Sub(value1, value2, true);
+    }
+
+    public TUnsigned Sub(TUnsigned value1, TUnsigned value2) {
+        return Sub(value1, value2, false);
+    }
+
+    public TUnsigned Dec(TUnsigned value1) {
+        bool carry = _state.CarryFlag;
+        TUnsigned res = Sub(value1, TUnsigned.One, false);
+        _state.CarryFlag = carry;
         return res;
     }
     
-    public int Imul16(short value1, short value2) {
-        int res = value1 * value2;
-        bool doesNotFitInWord = res != (short)res;
-        _state.OverflowFlag = doesNotFitInWord;
-        _state.CarryFlag = doesNotFitInWord;
-        return res;
-    }
+    public abstract TUnsigned Sub(TUnsigned value1, TUnsigned value2, bool useCarry);
 
-    public short Imul8(sbyte value1, sbyte value2) {
-        int res = value1 * value2;
-        bool doesNotFitInByte = res != (sbyte)res;
-        _state.OverflowFlag = doesNotFitInByte;
-        _state.CarryFlag = doesNotFitInByte;
-        return (short)res;
-    }
+    public abstract TUnsigned Div(TUnsignedUpper value1, TUnsigned value2);
+    public abstract TUnsignedUpper Mul(TUnsigned value1, TUnsigned value2);
+    
+    public abstract TSigned Idiv(TSignedUpper value1, TSigned value2);
+    
+    public abstract TSignedUpper Imul(TSigned value1, TSigned value2);
 
-    public uint Inc32(uint value) {
-        // CF is not modified
-        bool carry = _state.CarryFlag;
-        uint res = Add32(value, 1, false);
-        _state.CarryFlag = carry;
-        return res;
-    }
 
-    public ushort Inc16(ushort value) {
-        // CF is not modified
-        bool carry = _state.CarryFlag;
-        ushort res = Add16(value, 1, false);
-        _state.CarryFlag = carry;
-        return res;
-    }
+    public abstract TUnsigned And(TUnsigned value1, TUnsigned value2);
+    public abstract TUnsigned Or(TUnsigned value1, TUnsigned value2);
+    public abstract TUnsigned Xor(TUnsigned value1, TUnsigned value2);
 
-    public byte Inc8(byte value) {
-        // CF is not modified
-        bool carry = _state.CarryFlag;
-        byte res = Add8(value, 1, false);
-        _state.CarryFlag = carry;
-        return res;
-    }
+    public abstract TUnsigned Rcl(TUnsigned value, byte count);
 
-    public ulong Mul32(uint value1, uint value2) {
-        ulong res = (ulong)value1 * value2;
-        bool upperHalfNonZero = (res & 0xFFFFFFFF00000000) != 0;
-        _state.OverflowFlag = upperHalfNonZero;
-        _state.CarryFlag = upperHalfNonZero;
-        SetZeroFlag(res);
-        SetParityFlag(res);
-        SetSignFlag32((uint)res);
-        return res;
-    }
+    public abstract TUnsigned Rcr(TUnsigned value, int count);
 
-    public uint Mul16(ushort value1, ushort value2) {
-        uint res = (uint) (value1 * value2);
-        bool upperHalfNonZero = (res & 0xFFFF0000) != 0;
-        _state.OverflowFlag = upperHalfNonZero;
-        _state.CarryFlag = upperHalfNonZero;
-        SetZeroFlag(res);
-        SetParityFlag(res);
-        SetSignFlag16((ushort)res);
-        return res;
-    }
+    public abstract TUnsigned Rol(TUnsigned value, byte count);
 
-    public ushort Mul8(byte value1, byte value2) {
-        ushort res = (ushort)(value1 * value2);
-        bool upperHalfNonZero = (res & 0xFF00) != 0;
-        _state.OverflowFlag = upperHalfNonZero;
-        _state.CarryFlag = upperHalfNonZero;
-        SetZeroFlag(res);
-        SetParityFlag(res);
-        SetSignFlag8((byte)res);
-        return res;
-    }
+    public abstract TUnsigned Ror(TUnsigned value, int count);
 
-    public uint Or32(uint value1, uint value2) {
-        uint res = value1 | value2;
-        UpdateFlags32(res);
-        _state.CarryFlag = false;
-        _state.OverflowFlag = false;
-        return res;
-    }
+    public abstract TUnsigned Sar(TUnsigned value, int count);
 
-    public ushort Or16(ushort value1, ushort value2) {
-        ushort res = (ushort)(value1 | value2);
-        UpdateFlags16(res);
-        _state.CarryFlag = false;
-        _state.OverflowFlag = false;
-        return res;
-    }
+    public abstract TUnsigned Shl(TUnsigned value, int count);
 
-    public byte Or8(byte value1, byte value2) {
-        byte res = (byte)(value1 | value2);
-        UpdateFlags8(res);
-        _state.CarryFlag = false;
-        _state.OverflowFlag = false;
-        return res;
-    }
+    public abstract TUnsigned Shld(TUnsigned destination, TUnsigned source, byte count);
 
-    public uint Rcl32(uint value, byte count) {
-        count = (byte) ((count & ShiftCountMask) % 33);
-        if (count == 0) {
-            return value;
-        }
+    public abstract TUnsigned Shr(TUnsigned value, int count);
 
-        uint carry = value >> 32 - count & 0x1;
-        uint res = value << count;
-        int mask = (1 << count - 1) - 1;
-        res = (uint)(res | (value >> 33 - count & mask));
-        if (_state.CarryFlag) {
-            res = (uint)(res | 1 << count - 1);
-        }
-
-        _state.CarryFlag = carry != 0;
-        bool msb = (res & MsbMask32) != 0;
-        _state.OverflowFlag = msb ^ _state.CarryFlag;
-        return res;
-    }
-
-    public ushort Rcl16(ushort value, byte count) {
-        count = (byte) ((count & ShiftCountMask) % 17);
-        if (count == 0) {
-            return value;
-        }
-
-        int carry = value >> 16 - count & 0x1;
-        ushort res = (ushort)(value << count);
-        int mask = (1 << count - 1) - 1;
-        res = (ushort)(res | (value >> 17 - count & mask));
-        if (_state.CarryFlag) {
-            res = (ushort)(res | 1 << count - 1);
-        }
-
-        _state.CarryFlag = carry != 0;
-        bool msb = (res & MsbMask16) != 0;
-        _state.OverflowFlag = msb ^ _state.CarryFlag;
-        return res;
-    }
-
-    public byte Rcl8(byte value, byte count) {
-        count = (byte) ((count & ShiftCountMask) % 9);
-        if (count == 0) {
-            return value;
-        }
-
-        int carry = value >> 8 - count & 0x1;
-        byte res = (byte)(value << count);
-        int mask = (1 << count - 1) - 1;
-        res = (byte)(res | (value >> 9 - count & mask));
-        if (_state.CarryFlag) {
-            res = (byte)(res | 1 << count - 1);
-        }
-
-        _state.CarryFlag = carry != 0;
-        bool msb = (res & MsbMask8) != 0;
-        _state.OverflowFlag = msb ^ _state.CarryFlag;
-        return res;
-    }
-
-    public uint Rcr32(uint value, int count) {
-        count = (count & ShiftCountMask) % 33;
-        if (count == 0) {
-            return value;
-        }
-
-        uint carry = value >> count - 1 & 0x1;
-        int mask = (1 << 32 - count) - 1;
-        uint res = (uint) (value >> count & mask);
-        res |= value << 33 - count;
-        if (_state.CarryFlag) {
-            res = (ushort)(res | 1 << 32 - count);
-        }
-
-        _state.CarryFlag = carry != 0;
-        SetOverflowForRigthRotate32(res);
-        return res;
-    }
-
-    public ushort Rcr16(ushort value, int count) {
-        count = (count & ShiftCountMask) % 17;
-        if (count == 0) {
-            return value;
-        }
-
-        int carry = value >> count - 1 & 0x1;
-        int mask = (1 << 16 - count) - 1;
-        ushort res = (ushort)(value >> count & mask);
-        res = (ushort)(res | value << 17 - count);
-        if (_state.CarryFlag) {
-            res = (ushort)(res | 1 << 16 - count);
-        }
-
-        _state.CarryFlag = carry != 0;
-        SetOverflowForRigthRotate16(res);
-        return res;
-    }
-
-    public byte Rcr8(byte value, int count) {
-        count = (count & ShiftCountMask) % 9;
-        if (count == 0) {
-            return value;
-        }
-
-        int carry = value >> count - 1 & 0x1;
-        int mask = (1 << 8 - count) - 1;
-        byte res = (byte)(value >> count & mask);
-        res = (byte)(res | value << 9 - count);
-        if (_state.CarryFlag) {
-            res = (byte)(res | 1 << 8 - count);
-        }
-
-        _state.CarryFlag = carry != 0;
-        SetOverflowForRigthRotate8(res);
-        return res;
-    }
-
-    public uint Rol32(uint value, byte count) {
-        count = (byte) ((count & ShiftCountMask) % 32);
-        if (count == 0) {
-            return value;
-        }
-
-        uint carry = value >> 32 - count & 0x1;
-        uint res = value << count;
-        res |= value >> 32 - count;
-        _state.CarryFlag = carry != 0;
-        bool msb = (res & MsbMask32) != 0;
-        _state.OverflowFlag = msb ^ _state.CarryFlag;
-        return res;
-    }
-
-    public ushort Rol16(ushort value, byte count) {
-        count = (byte) ((count & ShiftCountMask) % 16);
-        if (count == 0) {
-            return value;
-        }
-
-        int carry = value >> 16 - count & 0x1;
-        ushort res = (ushort)(value << count);
-        res = (ushort)(res | value >> 16 - count);
-        _state.CarryFlag = carry != 0;
-        bool msb = (res & MsbMask16) != 0;
-        _state.OverflowFlag = msb ^ _state.CarryFlag;
-        return res;
-    }
-
-    public byte Rol8(byte value, byte count) {
-        count = (byte) ((count & ShiftCountMask) % 8);
-        if (count == 0) {
-            return value;
-        }
-
-        int carry = value >> 8 - count & 0x1;
-        byte res = (byte)(value << count);
-        res = (byte)(res | value >> 8 - count);
-        _state.CarryFlag = carry != 0;
-        bool msb = (res & MsbMask8) != 0;
-        _state.OverflowFlag = msb ^ _state.CarryFlag;
-        return res;
-    }
-
-    public uint Ror32(uint value, int count) {
-        count = (count & ShiftCountMask) % 16;
-        if (count == 0) {
-            return value;
-        }
-
-        uint carry = value >> count - 1 & 0x1;
-        int mask = (1 << 32 - count) - 1;
-        uint res = (uint)(value >> count & mask);
-        res |= value << 32 - count;
-        _state.CarryFlag = carry != 0;
-        SetOverflowForRigthRotate32(res);
-        return res;
-    }
-
-    public ushort Ror16(ushort value, int count) {
-        count = (count & ShiftCountMask) % 16;
-        if (count == 0) {
-            return value;
-        }
-
-        int carry = value >> count - 1 & 0x1;
-        int mask = (1 << 16 - count) - 1;
-        ushort res = (ushort)(value >> count & mask);
-        res = (ushort)(res | value << 16 - count);
-        _state.CarryFlag = carry != 0;
-        SetOverflowForRigthRotate16(res);
-        return res;
-    }
-
-    public byte Ror8(byte value, int count) {
-        count = (count & ShiftCountMask) % 8;
-        if (count == 0) {
-            return value;
-        }
-
-        int carry = value >> count - 1 & 0x1;
-        int mask = (1 << 8 - count) - 1;
-        byte res = (byte)(value >> count & mask);
-        res = (byte)(res | value << 8 - count);
-        _state.CarryFlag = carry != 0;
-        SetOverflowForRigthRotate8(res);
-        return res;
-    }
-
-    public uint Sar32(uint value, int count) {
-        count &= ShiftCountMask;
-        if (count == 0) {
-            return value;
-        }
-
-        int res = (int)value;
-        SetCarryFlagForRightShifts((uint)res, count);
-        res >>= count;
-        UpdateFlags32((uint)res);
-        _state.OverflowFlag = false;
-        return (uint)res;
-    }
-
-    public ushort Sar16(ushort value, int count) {
-        count &= ShiftCountMask;
-        if (count == 0) {
-            return value;
-        }
-
-        short res = (short)value;
-        SetCarryFlagForRightShifts((uint)res, count);
-        res >>= count;
-        UpdateFlags16((ushort)res);
-        _state.OverflowFlag = false;
-        return (ushort)res;
-    }
-
-    public byte Sar8(byte value, int count) {
-        count &= ShiftCountMask;
-        if (count == 0) {
-            return value;
-        }
-
-        sbyte res = (sbyte)value;
-        SetCarryFlagForRightShifts((uint)res, count);
-        res >>= count;
-        UpdateFlags8((byte)res);
-        _state.OverflowFlag = false;
-        return (byte)res;
-    }
-
-    public uint Sbb32(uint value1, uint value2) {
-        return Sub32(value1, value2, true);
-    }
-
-    public ushort Sbb16(ushort value1, ushort value2) {
-        return Sub16(value1, value2, true);
-    }
-
-    public byte Sbb8(byte value1, byte value2) {
-        return Sub8(value1, value2, true);
-    }
-
-    public uint Shl32(uint value, int count) {
-        count &= ShiftCountMask;
-        if (count == 0) {
-            return value;
-        }
-
-        uint msbBefore = (value << (count - 1)) & MsbMask32;
-        _state.CarryFlag = msbBefore != 0;
-        uint res = value << count;
-        UpdateFlags32(res);
-        uint msb = res & MsbMask32;
-        _state.OverflowFlag = (msb ^ msbBefore) != 0;
-        return res;
-    }
-
-    public ushort Shl16(ushort value, int count) {
-        count &= ShiftCountMask;
-        if (count == 0) {
-            return value;
-        }
-
-        int msbBefore = value << count - 1 & MsbMask16;
-        _state.CarryFlag = msbBefore != 0;
-        ushort res = (ushort)(value << count);
-        UpdateFlags16(res);
-        ushort msb = (ushort) (res & MsbMask16);
-        _state.OverflowFlag = (msb ^ msbBefore) != 0;
-        return res;
-    }
-
-    public byte Shl8(byte value, int count) {
-        count &= ShiftCountMask;
-        if (count == 0) {
-            return value;
-        }
-
-        int msbBefore = value << count - 1 & MsbMask8;
-        _state.CarryFlag = msbBefore != 0;
-        byte res = (byte)(value << count);
-        UpdateFlags8(res);
-        int msb = res & MsbMask8;
-        _state.OverflowFlag = (msb ^ msbBefore) != 0;
-        return res;
-    }
-
-    public uint Shr32(uint value, int count) {
-        count &= ShiftCountMask;
-        if (count == 0) {
-            return value;
-        }
-
-        uint msb = value & MsbMask32;
-        _state.OverflowFlag = msb != 0;
-        SetCarryFlagForRightShifts(value, count);
-        uint res = value >> count;
-        UpdateFlags32(res);
-        return res;
-    }
-
-    public ushort Shr16(ushort value, int count) {
-        count &= ShiftCountMask;
-        if (count == 0) {
-            return value;
-        }
-
-        ushort msb = (ushort)(value & MsbMask16);
-        _state.OverflowFlag = msb != 0;
-        SetCarryFlagForRightShifts(value, count);
-        ushort res = (ushort)(value >> count);
-        UpdateFlags16(res);
-        return res;
-    }
-
-    public byte Shr8(byte value, int count) {
-        count &= ShiftCountMask;
-        if (count == 0) {
-            return value;
-        }
-
-        int msb = value & MsbMask8;
-        _state.OverflowFlag = msb != 0;
-        SetCarryFlagForRightShifts(value, count);
-        byte res = (byte)(value >> count);
-        UpdateFlags8(res);
-        return res;
-    }
-
-    public uint Sub32(uint value1, uint value2) {
-        return Sub32(value1, value2, false);
-    }
-
-    public uint Sub32(uint value1, uint value2, bool useCarry) {
-        int carry = (useCarry && _state.CarryFlag) ? 1 : 0;
-        uint res = (uint)(value1 - value2 - carry);
-        UpdateFlags32(res);
-        uint borrowBits = BorrowBitsSub(value1, value2, res);
-        uint overflowBits = OverflowBitsSub(value1, value2, res);
-        _state.CarryFlag = ((borrowBits >> 31) & 1) == 1;
-        _state.AuxiliaryFlag = ((borrowBits >> 3) & 1) == 1;
-        _state.OverflowFlag = ((overflowBits >> 31) & 1) == 1;
-        return res;
-    }
-
-    public ushort Sub16(ushort value1, ushort value2) {
-        return Sub16(value1, value2, false);
-    }
-
-    public ushort Sub16(ushort value1, ushort value2, bool useCarry) {
-        int carry = useCarry && _state.CarryFlag ? 1 : 0;
-        ushort res = (ushort)(value1 - value2 - carry);
-        UpdateFlags16(res);
-        uint borrowBits = BorrowBitsSub(value1, value2, res);
-        uint overflowBits = OverflowBitsSub(value1, value2, res);
-        _state.CarryFlag = (borrowBits >> 15 & 1) == 1;
-        _state.AuxiliaryFlag = (borrowBits >> 3 & 1) == 1;
-        _state.OverflowFlag = (overflowBits >> 15 & 1) == 1;
-        return res;
-    }
-
-    public byte Sub8(byte value1, byte value2) {
-        return Sub8(value1, value2, false);
-    }
-
-    public byte Sub8(byte value1, byte value2, bool useCarry) {
-        int carry = useCarry && _state.CarryFlag ? 1 : 0;
-        byte res = (byte)(value1 - value2 - carry);
-        UpdateFlags8(res);
-        uint borrowBits = BorrowBitsSub(value1, value2, res);
-        uint overflowBits = OverflowBitsSub(value1, value2, res);
-        _state.CarryFlag = (borrowBits >> 7 & 1) == 1;
-        _state.AuxiliaryFlag = (borrowBits >> 3 & 1) == 1;
-        _state.OverflowFlag = (overflowBits >> 7 & 1) == 1;
-        return res;
-    }
-
-    public void UpdateFlags32(uint value) {
-        SetZeroFlag(value);
-        SetParityFlag(value);
-        SetSignFlag32(value);
-    }
-
-    public void UpdateFlags16(ushort value) {
-        SetZeroFlag(value);
-        SetParityFlag(value);
-        SetSignFlag16(value);
-    }
-
-    public void UpdateFlags8(byte value) {
-        SetZeroFlag(value);
-        SetParityFlag(value);
-        SetSignFlag8(value);
-    }
-
-    public uint Xor32(uint value1, uint value2) {
-        uint res = value1 ^ value2;
-        UpdateFlags32(res);
-        _state.CarryFlag = false;
-        _state.OverflowFlag = false;
-        return res;
-    }
-
-    public ushort Xor16(ushort value1, ushort value2) {
-        ushort res = (ushort)(value1 ^ value2);
-        UpdateFlags16(res);
-        _state.CarryFlag = false;
-        _state.OverflowFlag = false;
-        return res;
-    }
-
-    public byte Xor8(byte value1, byte value2) {
-        byte res = (byte)(value1 ^ value2);
-        UpdateFlags8(res);
-        _state.CarryFlag = false;
-        _state.OverflowFlag = false;
-        return res;
-    }
-
-    private static uint BorrowBitsSub(uint value1, uint value2, uint dst) {
+    protected static uint BorrowBitsSub(uint value1, uint value2, uint dst) {
         return value1 ^ value2 ^ dst ^ ((value1 ^ dst) & (value1 ^ value2));
     }
 
-    private static uint CarryBitsAdd(uint value1, uint value2, uint dst) {
+    protected static uint CarryBitsAdd(uint value1, uint value2, uint dst) {
         return value1 ^ value2 ^ dst ^ ((value1 ^ dst) & ~(value1 ^ value2));
     }
 
@@ -800,89 +124,32 @@ public class Alu {
     }
 
     // from https://www.vogons.org/viewtopic.php?t=55377
-    private static uint OverflowBitsAdd(uint value1, uint value2, uint dst) {
+    protected static uint OverflowBitsAdd(uint value1, uint value2, uint dst) {
         return (value1 ^ dst) & ~(value1 ^ value2);
     }
 
-    private static uint OverflowBitsSub(uint value1, uint value2, uint dst) {
+    protected static uint OverflowBitsSub(uint value1, uint value2, uint dst) {
         return (value1 ^ dst) & (value1 ^ value2);
     }
 
-    private void SetCarryFlagForRightShifts(uint value, int count) {
+    protected void SetCarryFlagForRightShifts(uint value, int count) {
         uint lastBit = value >> count - 1 & 0x1;
         _state.CarryFlag = lastBit == 1;
     }
 
-    private void SetOverflowForRigthRotate32(uint res) {
-        bool msb = (res & MsbMask32) != 0;
-        bool beforeMsb = (res & BeforeMsbMask32) != 0;
-        _state.OverflowFlag = msb ^ beforeMsb;
-    }
-
-    private void SetOverflowForRigthRotate16(ushort res) {
-        bool msb = (res & MsbMask16) != 0;
-        bool beforeMsb = (res & BeforeMsbMask16) != 0;
-        _state.OverflowFlag = msb ^ beforeMsb;
-    }
-
-    private void SetOverflowForRigthRotate8(byte res) {
-        bool msb = (res & MsbMask8) != 0;
-        bool beforeMsb = (res & BeforeMsbMask8) != 0;
-        _state.OverflowFlag = msb ^ beforeMsb;
-    }
-
-    private void SetParityFlag(ulong value) {
+    protected void SetParityFlag(ulong value) {
         _state.ParityFlag = IsParity((byte)value);
     }
 
-    private void SetSignFlag32(uint value) {
-        _state.SignFlag = (value & MsbMask32) != 0;
-    }
-
-    private void SetSignFlag16(ushort value) {
-        _state.SignFlag = (value & MsbMask16) != 0;
-    }
-
-    private void SetSignFlag8(byte value) {
-        _state.SignFlag = (value & MsbMask8) != 0;
-    }
-
-    private void SetZeroFlag(ulong value) {
+    protected void SetZeroFlag(ulong value) {
         _state.ZeroFlag = value == 0;
     }
 
-    public ushort Shld16(ushort destination, ushort source, byte count) {
-        count &= ShiftCountMask;
-        if (count == 0) {
-            return destination;
-        }
+    protected abstract void SetSignFlag(TUnsigned value);
 
-        if (count > 16) {
-            // Undefined. We shift the source in again.
-            return (ushort)(source << (count - 16));
-        }
-
-        ushort msbBefore = (ushort)(destination & MsbMask16);
-        _state.CarryFlag = (destination >> (16 - count) & 1) != 0;
-        ushort res = (ushort)((destination << count) | (source >> (16 - count)));
-        UpdateFlags16(res);
-        ushort msb = (ushort)(res & MsbMask16);
-        _state.OverflowFlag = msb != msbBefore;
-        return res;
-    }
-
-    public uint Shld32(uint destination, uint source, byte count) {
-        count &= ShiftCountMask;
-        if (count == 0) {
-            return destination;
-        }
-
-        uint msbBefore = destination & MsbMask32;
-        _state.CarryFlag = (destination >> (32 - count) & 1) != 0;
-        uint res = (destination << count) | (source >> (32 - count));
-        UpdateFlags32(res);
-        uint msb = res & MsbMask32;
-        _state.OverflowFlag = msb != msbBefore;
-        return res;
+    public void UpdateFlags(TUnsigned value) {
+        SetZeroFlag(ulong.CreateTruncating(value));
+        SetParityFlag(ulong.CreateTruncating(value));
+        SetSignFlag(value);
     }
 }

--- a/src/Spice86.Core/Emulator/CPU/Alu16.cs
+++ b/src/Spice86.Core/Emulator/CPU/Alu16.cs
@@ -1,0 +1,249 @@
+﻿namespace Spice86.Core.Emulator.CPU;
+
+using Spice86.Core.Emulator.CPU.Exceptions;
+
+public class Alu16 : Alu<ushort, short, uint, int>  {
+    private const ushort BeforeMsbMask = 0x4000;
+
+    private const ushort MsbMask = 0x8000;
+
+    public Alu16(State state) : base(state) {
+    }
+
+    public override ushort Add(ushort value1, ushort value2, bool useCarry) {
+        int carry = useCarry && _state.CarryFlag ? 1 : 0;
+        ushort res = (ushort)(value1 + value2 + carry);
+        UpdateFlags(res);
+        uint carryBits = CarryBitsAdd(value1, value2, res);
+        uint overflowBits = OverflowBitsAdd(value1, value2, res);
+        _state.CarryFlag = (carryBits >> 15 & 1) == 1;
+        _state.AuxiliaryFlag = (carryBits >> 3 & 1) == 1;
+        _state.OverflowFlag = (overflowBits >> 15 & 1) == 1;
+        return res;
+    }
+
+    public override ushort And(ushort value1, ushort value2) {
+        ushort res = (ushort)(value1 & value2);
+        UpdateFlags(res);
+        _state.CarryFlag = false;
+        _state.OverflowFlag = false;
+        return res;
+    }
+
+    public override ushort Div(uint value1, ushort value2) {
+        if (value2 == 0) {
+            throw new CpuDivisionErrorException($"Division by zero");
+        }
+
+        uint res = value1 / value2;
+        if (res > ushort.MaxValue) {
+            throw new CpuDivisionErrorException($"Division result out of range: {res}");
+        }
+
+        return (ushort)res;
+    }
+    
+    public override short Idiv(int value1, short value2) {
+        if (value2 == 0) {
+            throw new CpuDivisionErrorException($"Division by zero");
+        }
+
+        int res = value1 / value2;
+        unchecked {
+            if (res is > 0x7FFF or < (short)0x8000) {
+                throw new CpuDivisionErrorException($"Division result out of range: {res}");
+            }
+        }
+
+        return (short)res;
+    }
+    
+    public override int Imul(short value1, short value2) {
+        int res = value1 * value2;
+        bool doesNotFitInWord = res != (short)res;
+        _state.OverflowFlag = doesNotFitInWord;
+        _state.CarryFlag = doesNotFitInWord;
+        return res;
+    }
+
+    public override uint Mul(ushort value1, ushort value2) {
+        uint res = (uint) (value1 * value2);
+        bool upperHalfNonZero = (res & 0xFFFF0000) != 0;
+        _state.OverflowFlag = upperHalfNonZero;
+        _state.CarryFlag = upperHalfNonZero;
+        SetZeroFlag(res);
+        SetParityFlag(res);
+        SetSignFlag((ushort)res);
+        return res;
+    }
+    
+    public override ushort Or(ushort value1, ushort value2) {
+        ushort res = (ushort)(value1 | value2);
+        UpdateFlags(res);
+        _state.CarryFlag = false;
+        _state.OverflowFlag = false;
+        return res;
+    }
+    
+    public override ushort Rcl(ushort value, byte count) {
+        count = (byte) ((count & ShiftCountMask) % 17);
+        if (count == 0) {
+            return value;
+        }
+
+        int carry = value >> 16 - count & 0x1;
+        ushort res = (ushort)(value << count);
+        int mask = (1 << count - 1) - 1;
+        res = (ushort)(res | (value >> 17 - count & mask));
+        if (_state.CarryFlag) {
+            res = (ushort)(res | 1 << count - 1);
+        }
+
+        _state.CarryFlag = carry != 0;
+        bool msb = (res & MsbMask) != 0;
+        _state.OverflowFlag = msb ^ _state.CarryFlag;
+        return res;
+    }
+    
+    public override ushort Rcr(ushort value, int count) {
+        count = (count & ShiftCountMask) % 17;
+        if (count == 0) {
+            return value;
+        }
+
+        int carry = value >> count - 1 & 0x1;
+        int mask = (1 << 16 - count) - 1;
+        ushort res = (ushort)(value >> count & mask);
+        res = (ushort)(res | value << 17 - count);
+        if (_state.CarryFlag) {
+            res = (ushort)(res | 1 << 16 - count);
+        }
+
+        _state.CarryFlag = carry != 0;
+        SetOverflowForRigthRotate16(res);
+        return res;
+    }
+    
+    public override ushort Rol(ushort value, byte count) {
+        count = (byte) ((count & ShiftCountMask) % 16);
+        if (count == 0) {
+            return value;
+        }
+
+        int carry = value >> 16 - count & 0x1;
+        ushort res = (ushort)(value << count);
+        res = (ushort)(res | value >> 16 - count);
+        _state.CarryFlag = carry != 0;
+        bool msb = (res & MsbMask) != 0;
+        _state.OverflowFlag = msb ^ _state.CarryFlag;
+        return res;
+    }
+    public override ushort Ror(ushort value, int count) {
+        count = (count & ShiftCountMask) % 16;
+        if (count == 0) {
+            return value;
+        }
+
+        int carry = value >> count - 1 & 0x1;
+        int mask = (1 << 16 - count) - 1;
+        ushort res = (ushort)(value >> count & mask);
+        res = (ushort)(res | value << 16 - count);
+        _state.CarryFlag = carry != 0;
+        SetOverflowForRigthRotate16(res);
+        return res;
+    }
+    
+    public override ushort Sar(ushort value, int count) {
+        count &= ShiftCountMask;
+        if (count == 0) {
+            return value;
+        }
+
+        short res = (short)value;
+        SetCarryFlagForRightShifts((uint)res, count);
+        res >>= count;
+        UpdateFlags((ushort)res);
+        _state.OverflowFlag = false;
+        return (ushort)res;
+    }
+    
+    public override ushort Shl(ushort value, int count) {
+        count &= ShiftCountMask;
+        if (count == 0) {
+            return value;
+        }
+
+        int msbBefore = value << count - 1 & MsbMask;
+        _state.CarryFlag = msbBefore != 0;
+        ushort res = (ushort)(value << count);
+        UpdateFlags(res);
+        ushort msb = (ushort) (res & MsbMask);
+        _state.OverflowFlag = (msb ^ msbBefore) != 0;
+        return res;
+    }
+    
+    public override ushort Shld(ushort destination, ushort source, byte count) {
+        count &= ShiftCountMask;
+        if (count == 0) {
+            return destination;
+        }
+
+        if (count > 16) {
+            // Undefined. We shift the source in again.
+            return (ushort)(source << (count - 16));
+        }
+
+        ushort msbBefore = (ushort)(destination & MsbMask);
+        _state.CarryFlag = (destination >> (16 - count) & 1) != 0;
+        ushort res = (ushort)((destination << count) | (source >> (16 - count)));
+        UpdateFlags(res);
+        ushort msb = (ushort)(res & MsbMask);
+        _state.OverflowFlag = msb != msbBefore;
+        return res;
+    }
+    
+    public override ushort Shr(ushort value, int count) {
+        count &= ShiftCountMask;
+        if (count == 0) {
+            return value;
+        }
+
+        ushort msb = (ushort)(value & MsbMask);
+        _state.OverflowFlag = msb != 0;
+        SetCarryFlagForRightShifts(value, count);
+        ushort res = (ushort)(value >> count);
+        UpdateFlags(res);
+        return res;
+    }
+    
+    public override ushort Sub(ushort value1, ushort value2, bool useCarry) {
+        int carry = useCarry && _state.CarryFlag ? 1 : 0;
+        ushort res = (ushort)(value1 - value2 - carry);
+        UpdateFlags(res);
+        uint borrowBits = BorrowBitsSub(value1, value2, res);
+        uint overflowBits = OverflowBitsSub(value1, value2, res);
+        _state.CarryFlag = (borrowBits >> 15 & 1) == 1;
+        _state.AuxiliaryFlag = (borrowBits >> 3 & 1) == 1;
+        _state.OverflowFlag = (overflowBits >> 15 & 1) == 1;
+        return res;
+    }
+    
+    public override ushort Xor(ushort value1, ushort value2) {
+        ushort res = (ushort)(value1 ^ value2);
+        UpdateFlags(res);
+        _state.CarryFlag = false;
+        _state.OverflowFlag = false;
+        return res;
+    }
+    
+    private void SetOverflowForRigthRotate16(ushort res) {
+        bool msb = (res & MsbMask) != 0;
+        bool beforeMsb = (res & BeforeMsbMask) != 0;
+        _state.OverflowFlag = msb ^ beforeMsb;
+    }
+
+    protected override void SetSignFlag(ushort value) {
+        _state.SignFlag = (value & MsbMask) != 0;
+    }
+    
+}

--- a/src/Spice86.Core/Emulator/CPU/Alu32.cs
+++ b/src/Spice86.Core/Emulator/CPU/Alu32.cs
@@ -1,0 +1,246 @@
+﻿namespace Spice86.Core.Emulator.CPU;
+
+using Spice86.Core.Emulator.CPU.Exceptions;
+
+public class Alu32 : Alu<uint, int, ulong, long>  {
+    
+    private const uint BeforeMsbMask = 0x40000000;
+    
+    private const uint MsbMask = 0x80000000;
+
+    public Alu32(State state) : base(state) {
+    }
+
+    public override uint Add(uint value1, uint value2, bool useCarry) {
+        int carry = useCarry && _state.CarryFlag ? 1 : 0;
+        uint res = (uint)(value1 + value2 + carry);
+        UpdateFlags(res);
+        uint carryBits = CarryBitsAdd(value1, value2, res);
+        uint overflowBits = OverflowBitsAdd(value1, value2, res);
+        _state.CarryFlag = (carryBits >> 31 & 1) == 1;
+        _state.AuxiliaryFlag = (carryBits >> 3 & 1) == 1;
+        _state.OverflowFlag = (overflowBits >> 31 & 1) == 1;
+        return res;
+    }
+
+    public override uint And(uint value1, uint value2) {
+        uint res = value1 & value2;
+        UpdateFlags(res);
+        _state.CarryFlag = false;
+        _state.OverflowFlag = false;
+        return res;
+    }
+
+    public override uint Div(ulong value1, uint value2) {
+        if (value2 == 0) {
+            throw new CpuDivisionErrorException($"Division by zero");
+        }
+
+        ulong res = value1 / value2;
+        if (res > uint.MaxValue) {
+            throw new CpuDivisionErrorException($"Division result out of range: {res}");
+        }
+
+        return (uint)res;
+    }
+    
+    public override int Idiv(long value1, int value2) {
+        if (value2 == 0) {
+            throw new CpuDivisionErrorException($"Division by zero");
+        }
+
+        long res = value1 / value2;
+        unchecked {
+            if (res is > 0x7FFFFFFF or < (int)0x80000000) {
+                throw new CpuDivisionErrorException($"Division result out of range: {res}");
+            }
+        }
+
+        return (int)res;
+    }
+    
+    public override long Imul(int value1, int value2) {
+        long res = (long)value1 * value2;
+        bool doesNotFitInDWord = res != (int)res;
+        _state.OverflowFlag = doesNotFitInDWord;
+        _state.CarryFlag = doesNotFitInDWord;
+        return res;
+    }
+
+    public override ulong Mul(uint value1, uint value2) {
+        ulong res = (ulong)value1 * value2;
+        bool upperHalfNonZero = (res & 0xFFFFFFFF00000000) != 0;
+        _state.OverflowFlag = upperHalfNonZero;
+        _state.CarryFlag = upperHalfNonZero;
+        SetZeroFlag(res);
+        SetParityFlag(res);
+        SetSignFlag((uint)res);
+        return res;
+    }
+    
+    public override uint Or(uint value1, uint value2) {
+        uint res = value1 | value2;
+        UpdateFlags(res);
+        _state.CarryFlag = false;
+        _state.OverflowFlag = false;
+        return res;
+    }
+    
+    public override uint Rcl(uint value, byte count) {
+        count = (byte) ((count & ShiftCountMask) % 33);
+        if (count == 0) {
+            return value;
+        }
+
+        uint carry = value >> 32 - count & 0x1;
+        uint res = value << count;
+        int mask = (1 << count - 1) - 1;
+        res = (uint)(res | (value >> 33 - count & mask));
+        if (_state.CarryFlag) {
+            res = (uint)(res | 1 << count - 1);
+        }
+
+        _state.CarryFlag = carry != 0;
+        bool msb = (res & MsbMask) != 0;
+        _state.OverflowFlag = msb ^ _state.CarryFlag;
+        return res;
+    }
+    
+    public override uint Rcr(uint value, int count) {
+        count = (count & ShiftCountMask) % 33;
+        if (count == 0) {
+            return value;
+        }
+
+        uint carry = value >> count - 1 & 0x1;
+        int mask = (1 << 32 - count) - 1;
+        uint res = (uint) (value >> count & mask);
+        res |= value << 33 - count;
+        if (_state.CarryFlag) {
+            res = (ushort)(res | 1 << 32 - count);
+        }
+
+        _state.CarryFlag = carry != 0;
+        SetOverflowForRigthRotate32(res);
+        return res;
+    }
+    
+    public override uint Rol(uint value, byte count) {
+        count = (byte) ((count & ShiftCountMask) % 32);
+        if (count == 0) {
+            return value;
+        }
+
+        uint carry = value >> 32 - count & 0x1;
+        uint res = value << count;
+        res |= value >> 32 - count;
+        _state.CarryFlag = carry != 0;
+        bool msb = (res & MsbMask) != 0;
+        _state.OverflowFlag = msb ^ _state.CarryFlag;
+        return res;
+    }
+    
+    public override uint Ror(uint value, int count) {
+        count = (count & ShiftCountMask) % 16;
+        if (count == 0) {
+            return value;
+        }
+
+        uint carry = value >> count - 1 & 0x1;
+        int mask = (1 << 32 - count) - 1;
+        uint res = (uint)(value >> count & mask);
+        res |= value << 32 - count;
+        _state.CarryFlag = carry != 0;
+        SetOverflowForRigthRotate32(res);
+        return res;
+    }
+    
+    public override uint Sar(uint value, int count) {
+        count &= ShiftCountMask;
+        if (count == 0) {
+            return value;
+        }
+
+        int res = (int)value;
+        SetCarryFlagForRightShifts((uint)res, count);
+        res >>= count;
+        UpdateFlags((uint)res);
+        _state.OverflowFlag = false;
+        return (uint)res;
+    }
+
+    public override uint Shl(uint value, int count) {
+        count &= ShiftCountMask;
+        if (count == 0) {
+            return value;
+        }
+
+        uint msbBefore = (value << (count - 1)) & MsbMask;
+        _state.CarryFlag = msbBefore != 0;
+        uint res = value << count;
+        UpdateFlags(res);
+        uint msb = res & MsbMask;
+        _state.OverflowFlag = (msb ^ msbBefore) != 0;
+        return res;
+    }
+    
+    public override uint Shld(uint destination, uint source, byte count) {
+        count &= ShiftCountMask;
+        if (count == 0) {
+            return destination;
+        }
+
+        uint msbBefore = destination & MsbMask;
+        _state.CarryFlag = (destination >> (32 - count) & 1) != 0;
+        uint res = (destination << count) | (source >> (32 - count));
+        UpdateFlags(res);
+        uint msb = res & MsbMask;
+        _state.OverflowFlag = msb != msbBefore;
+        return res;
+    }
+    
+    public override uint Shr(uint value, int count) {
+        count &= ShiftCountMask;
+        if (count == 0) {
+            return value;
+        }
+
+        uint msb = value & MsbMask;
+        _state.OverflowFlag = msb != 0;
+        SetCarryFlagForRightShifts(value, count);
+        uint res = value >> count;
+        UpdateFlags(res);
+        return res;
+    }
+
+    public override uint Sub(uint value1, uint value2, bool useCarry) {
+        int carry = (useCarry && _state.CarryFlag) ? 1 : 0;
+        uint res = (uint)(value1 - value2 - carry);
+        UpdateFlags(res);
+        uint borrowBits = BorrowBitsSub(value1, value2, res);
+        uint overflowBits = OverflowBitsSub(value1, value2, res);
+        _state.CarryFlag = ((borrowBits >> 31) & 1) == 1;
+        _state.AuxiliaryFlag = ((borrowBits >> 3) & 1) == 1;
+        _state.OverflowFlag = ((overflowBits >> 31) & 1) == 1;
+        return res;
+    }
+    
+    
+    public override uint Xor(uint value1, uint value2) {
+        uint res = value1 ^ value2;
+        UpdateFlags(res);
+        _state.CarryFlag = false;
+        _state.OverflowFlag = false;
+        return res;
+    }
+    
+    private void SetOverflowForRigthRotate32(uint res) {
+        bool msb = (res & MsbMask) != 0;
+        bool beforeMsb = (res & BeforeMsbMask) != 0;
+        _state.OverflowFlag = msb ^ beforeMsb;
+    }
+
+    protected override void SetSignFlag(uint value) {
+        _state.SignFlag = (value & MsbMask) != 0;
+    }
+}

--- a/src/Spice86.Core/Emulator/CPU/Alu8.cs
+++ b/src/Spice86.Core/Emulator/CPU/Alu8.cs
@@ -1,0 +1,234 @@
+﻿namespace Spice86.Core.Emulator.CPU;
+
+using Spice86.Core.Emulator.CPU.Exceptions;
+
+public class Alu8 : Alu<byte, sbyte, ushort, short> {
+    private const byte BeforeMsbMask = 0x40;
+
+    private const byte MsbMask = 0x80;
+    
+    public Alu8(State state) : base(state) {
+    }
+
+    public override byte Add(byte value1, byte value2, bool useCarry) {
+        int carry = useCarry && _state.CarryFlag ? 1 : 0;
+        byte res = (byte)(value1 + value2 + carry);
+        UpdateFlags(res);
+        uint carryBits = CarryBitsAdd(value1, value2, res);
+        uint overflowBits = OverflowBitsAdd(value1, value2, res);
+        _state.CarryFlag = (carryBits >> 7 & 1) == 1;
+        _state.AuxiliaryFlag = (carryBits >> 3 & 1) == 1;
+        _state.OverflowFlag = (overflowBits >> 7 & 1) == 1;
+        return res;
+    }
+
+    public override byte And(byte value1, byte value2) {
+        byte res = (byte)(value1 & value2);
+        UpdateFlags(res);
+        _state.CarryFlag = false;
+        _state.OverflowFlag = false;
+        return res;
+    }
+
+    public override byte Div(ushort value1, byte value2) {
+        if (value2 == 0) {
+            throw new CpuDivisionErrorException($"Division by zero");
+        }
+
+        uint res = (uint)(value1 / value2);
+        if (res > byte.MaxValue) {
+            throw new CpuDivisionErrorException($"Division result out of range: {res}");
+        }
+
+        return (byte)res;
+    }
+
+    public override sbyte Idiv(short value1, sbyte value2) {
+        if (value2 == 0) {
+            throw new CpuDivisionErrorException($"Division by zero");
+        }
+
+        int res = value1 / value2;
+        unchecked {
+            if (res is > 0x7F or < ((sbyte)0x80)) {
+                throw new CpuDivisionErrorException($"Division result out of range: {res}");
+            }
+        }
+
+        return (sbyte)res;
+    }
+
+    public override short Imul(sbyte value1, sbyte value2) {
+        int res = value1 * value2;
+        bool doesNotFitInByte = res != (sbyte)res;
+        _state.OverflowFlag = doesNotFitInByte;
+        _state.CarryFlag = doesNotFitInByte;
+        return (short)res;
+    }
+
+
+    public override ushort Mul(byte value1, byte value2) {
+        ushort res = (ushort)(value1 * value2);
+        bool upperHalfNonZero = (res & 0xFF00) != 0;
+        _state.OverflowFlag = upperHalfNonZero;
+        _state.CarryFlag = upperHalfNonZero;
+        SetZeroFlag(res);
+        SetParityFlag(res);
+        SetSignFlag((byte)res);
+        return res;
+    }
+
+    public override byte Or(byte value1, byte value2) {
+        byte res = (byte)(value1 | value2);
+        UpdateFlags(res);
+        _state.CarryFlag = false;
+        _state.OverflowFlag = false;
+        return res;
+    }
+
+    public override byte Rcl(byte value, byte count) {
+        count = (byte)((count & ShiftCountMask) % 9);
+        if (count == 0) {
+            return value;
+        }
+
+        int carry = value >> 8 - count & 0x1;
+        byte res = (byte)(value << count);
+        int mask = (1 << count - 1) - 1;
+        res = (byte)(res | (value >> 9 - count & mask));
+        if (_state.CarryFlag) {
+            res = (byte)(res | 1 << count - 1);
+        }
+
+        _state.CarryFlag = carry != 0;
+        bool msb = (res & MsbMask) != 0;
+        _state.OverflowFlag = msb ^ _state.CarryFlag;
+        return res;
+    }
+
+    public override byte Rcr(byte value, int count) {
+        count = (count & ShiftCountMask) % 9;
+        if (count == 0) {
+            return value;
+        }
+
+        int carry = value >> count - 1 & 0x1;
+        int mask = (1 << 8 - count) - 1;
+        byte res = (byte)(value >> count & mask);
+        res = (byte)(res | value << 9 - count);
+        if (_state.CarryFlag) {
+            res = (byte)(res | 1 << 8 - count);
+        }
+
+        _state.CarryFlag = carry != 0;
+        SetOverflowForRigthRotate8(res);
+        return res;
+    }
+
+    public override byte Rol(byte value, byte count) {
+        count = (byte)((count & ShiftCountMask) % 8);
+        if (count == 0) {
+            return value;
+        }
+
+        int carry = value >> 8 - count & 0x1;
+        byte res = (byte)(value << count);
+        res = (byte)(res | value >> 8 - count);
+        _state.CarryFlag = carry != 0;
+        bool msb = (res & MsbMask) != 0;
+        _state.OverflowFlag = msb ^ _state.CarryFlag;
+        return res;
+    }
+
+    public override byte Ror(byte value, int count) {
+        count = (count & ShiftCountMask) % 8;
+        if (count == 0) {
+            return value;
+        }
+
+        int carry = value >> count - 1 & 0x1;
+        int mask = (1 << 8 - count) - 1;
+        byte res = (byte)(value >> count & mask);
+        res = (byte)(res | value << 8 - count);
+        _state.CarryFlag = carry != 0;
+        SetOverflowForRigthRotate8(res);
+        return res;
+    }
+
+    public override byte Sar(byte value, int count) {
+        count &= ShiftCountMask;
+        if (count == 0) {
+            return value;
+        }
+
+        sbyte res = (sbyte)value;
+        SetCarryFlagForRightShifts((uint)res, count);
+        res >>= count;
+        UpdateFlags((byte)res);
+        _state.OverflowFlag = false;
+        return (byte)res;
+    }
+
+    public override byte Shl(byte value, int count) {
+        count &= ShiftCountMask;
+        if (count == 0) {
+            return value;
+        }
+
+        int msbBefore = value << count - 1 & MsbMask;
+        _state.CarryFlag = msbBefore != 0;
+        byte res = (byte)(value << count);
+        UpdateFlags(res);
+        int msb = res & MsbMask;
+        _state.OverflowFlag = (msb ^ msbBefore) != 0;
+        return res;
+    }
+
+    public override byte Shld(byte destination, byte source, byte count) {
+        throw new NotImplementedException("Shld is not available for 8bits operations");
+    }
+
+    public override byte Shr(byte value, int count) {
+        count &= ShiftCountMask;
+        if (count == 0) {
+            return value;
+        }
+
+        int msb = value & MsbMask;
+        _state.OverflowFlag = msb != 0;
+        SetCarryFlagForRightShifts(value, count);
+        byte res = (byte)(value >> count);
+        UpdateFlags(res);
+        return res;
+    }
+
+    public override byte Sub(byte value1, byte value2, bool useCarry) {
+        int carry = useCarry && _state.CarryFlag ? 1 : 0;
+        byte res = (byte)(value1 - value2 - carry);
+        UpdateFlags(res);
+        uint borrowBits = BorrowBitsSub(value1, value2, res);
+        uint overflowBits = OverflowBitsSub(value1, value2, res);
+        _state.CarryFlag = (borrowBits >> 7 & 1) == 1;
+        _state.AuxiliaryFlag = (borrowBits >> 3 & 1) == 1;
+        _state.OverflowFlag = (overflowBits >> 7 & 1) == 1;
+        return res;
+    }
+
+    public override byte Xor(byte value1, byte value2) {
+        byte res = (byte)(value1 ^ value2);
+        UpdateFlags(res);
+        _state.CarryFlag = false;
+        _state.OverflowFlag = false;
+        return res;
+    }
+
+    private void SetOverflowForRigthRotate8(byte res) {
+        bool msb = (res & MsbMask) != 0;
+        bool beforeMsb = (res & BeforeMsbMask) != 0;
+        _state.OverflowFlag = msb ^ beforeMsb;
+    }
+
+    protected override void SetSignFlag(byte value) {
+        _state.SignFlag = (value & MsbMask) != 0;
+    }
+}

--- a/src/Spice86.Core/Emulator/CPU/InstructionsImpl/Instructions.cs
+++ b/src/Spice86.Core/Emulator/CPU/InstructionsImpl/Instructions.cs
@@ -1,13 +1,10 @@
 using Spice86.Core.Emulator.Errors;
-using Spice86.Core.Emulator.Memory;
-using Spice86.Core.Emulator.VM;
 
 namespace Spice86.Core.Emulator.CPU.InstructionsImpl;
 
 using Spice86.Shared.Utils;
 
 public abstract class Instructions {
-    protected readonly Alu Alu;
     protected readonly Cpu Cpu;
     protected readonly State State;
     protected readonly Stack Stack;
@@ -20,8 +17,7 @@ public abstract class Instructions {
 
     protected uint DsNextUint16Address => ModRM.GetAddress(SegmentRegisters.DsIndex, Cpu.NextUint16());
 
-    public Instructions(Alu alu, Cpu cpu, Memory.IMemory memory, ModRM modRm) {
-        Alu = alu;
+    public Instructions(Cpu cpu, Memory.IMemory memory, ModRM modRm) {
         Cpu = cpu;
         State = cpu.State;
         Stack = cpu.Stack;

--- a/src/Spice86.Core/Emulator/CPU/InstructionsImpl/Instructions16.cs
+++ b/src/Spice86.Core/Emulator/CPU/InstructionsImpl/Instructions16.cs
@@ -1,157 +1,160 @@
 using Spice86.Core.Emulator.CPU.Exceptions;
-using Spice86.Core.Emulator.VM;
 
 namespace Spice86.Core.Emulator.CPU.InstructionsImpl;
 
 public class Instructions16 : Instructions16Or32 {
-    public Instructions16(Alu alu, Cpu cpu, Memory.IMemory memory, ModRM modRm)
-        : base(alu, cpu, memory, modRm) {
+    private readonly Alu16 _alu16;
+
+    public Instructions16(Cpu cpu, Memory.IMemory memory, ModRM modRm)
+        : base(cpu, memory, modRm) {
+        _alu16 = new Alu16(cpu.State);
+
     }
 
     public override void AddRmReg() {
         // ADD rmw rw
         ModRM.Read();
-        ModRM.SetRm16(Alu.Add16(ModRM.GetRm16(), ModRM.R16));
+        ModRM.SetRm16(_alu16.Add(ModRM.GetRm16(), ModRM.R16));
     }
 
     public override void AddRegRm() {
         // ADD rw rmw
         ModRM.Read();
-        ModRM.R16 = Alu.Add16(ModRM.R16, ModRM.GetRm16());
+        ModRM.R16 = _alu16.Add(ModRM.R16, ModRM.GetRm16());
     }
 
     public override void AddAccImm() {
         // ADD AX iw
-        State.AX = Alu.Add16(State.AX, Cpu.NextUint16());
+        State.AX = _alu16.Add(State.AX, Cpu.NextUint16());
     }
 
     public override void OrRmReg() {
         // OR rmw rw
         ModRM.Read();
-        ModRM.SetRm16(Alu.Or16(ModRM.GetRm16(), ModRM.R16));
+        ModRM.SetRm16(_alu16.Or(ModRM.GetRm16(), ModRM.R16));
     }
 
     public override void OrRegRm() {
         // OR rw rmw
         ModRM.Read();
-        ModRM.R16 = Alu.Or16(ModRM.R16, ModRM.GetRm16());
+        ModRM.R16 = _alu16.Or(ModRM.R16, ModRM.GetRm16());
     }
 
     public override void OrAccImm() {
         // OR AX iw
-        State.AX = Alu.Or16(State.AX, Cpu.NextUint16());
+        State.AX = _alu16.Or(State.AX, Cpu.NextUint16());
     }
 
     public override void AdcRmReg() {
         // ADC rmw rw
         ModRM.Read();
-        ModRM.SetRm16(Alu.Adc16(ModRM.GetRm16(), ModRM.R16));
+        ModRM.SetRm16(_alu16.Adc(ModRM.GetRm16(), ModRM.R16));
     }
 
     public override void AdcRegRm() {
         // ADC rw rmw
         ModRM.Read();
-        ModRM.R16 = Alu.Adc16(ModRM.R16, ModRM.GetRm16());
+        ModRM.R16 = _alu16.Adc(ModRM.R16, ModRM.GetRm16());
     }
 
     public override void AdcAccImm() {
         // ADC AX iw
-        State.AX = Alu.Adc16(State.AX, Cpu.NextUint16());
+        State.AX = _alu16.Adc(State.AX, Cpu.NextUint16());
     }
 
     public override void SbbRmReg() {
         // SBB rmw rw
         ModRM.Read();
-        ModRM.SetRm16(Alu.Sbb16(ModRM.GetRm16(), ModRM.R16));
+        ModRM.SetRm16(_alu16.Sbb(ModRM.GetRm16(), ModRM.R16));
     }
 
     public override void SbbRegRm() {
         // SBB rw rmw
         ModRM.Read();
-        ModRM.R16 = Alu.Sbb16(ModRM.R16, ModRM.GetRm16());
+        ModRM.R16 = _alu16.Sbb(ModRM.R16, ModRM.GetRm16());
     }
 
     public override void SbbAccImm() {
         // SBB AX iw
-        State.AX = Alu.Sbb16(State.AX, Cpu.NextUint16());
+        State.AX = _alu16.Sbb(State.AX, Cpu.NextUint16());
     }
 
     public override void AndRmReg() {
         // AND rmw rw
         ModRM.Read();
-        ModRM.SetRm16(Alu.And16(ModRM.GetRm16(), ModRM.R16));
+        ModRM.SetRm16(_alu16.And(ModRM.GetRm16(), ModRM.R16));
     }
 
     public override void AndRegRm() {
         // AND rw rmw
         ModRM.Read();
-        ModRM.R16 = Alu.And16(ModRM.R16, ModRM.GetRm16());
+        ModRM.R16 = _alu16.And(ModRM.R16, ModRM.GetRm16());
     }
 
     public override void AndAccImm() {
         // AND AX ib
-        State.AX = Alu.And16(State.AX, Cpu.NextUint16());
+        State.AX = _alu16.And(State.AX, Cpu.NextUint16());
     }
 
     public override void SubRmReg() {
         // SUB rmw rw
         ModRM.Read();
-        ModRM.SetRm16(Alu.Sub16(ModRM.GetRm16(), ModRM.R16));
+        ModRM.SetRm16(_alu16.Sub(ModRM.GetRm16(), ModRM.R16));
     }
 
     public override void SubRegRm() {
         // SUB rw rmw
         ModRM.Read();
-        ModRM.R16 = Alu.Sub16(ModRM.R16, ModRM.GetRm16());
+        ModRM.R16 = _alu16.Sub(ModRM.R16, ModRM.GetRm16());
     }
 
     public override void SubAccImm() {
         // SUB AX iw
-        State.AX = Alu.Sub16(State.AX, Cpu.NextUint16());
+        State.AX = _alu16.Sub(State.AX, Cpu.NextUint16());
     }
 
     public override void XorRmReg() {
         // XOR rmw rw
         ModRM.Read();
-        ModRM.SetRm16(Alu.Xor16(ModRM.GetRm16(), ModRM.R16));
+        ModRM.SetRm16(_alu16.Xor(ModRM.GetRm16(), ModRM.R16));
     }
 
     public override void XorRegRm() {
         // XOR rw rmw
         ModRM.Read();
-        ModRM.R16 = Alu.Xor16(ModRM.R16, ModRM.GetRm16());
+        ModRM.R16 = _alu16.Xor(ModRM.R16, ModRM.GetRm16());
     }
 
     public override void XorAccImm() {
         // XOR AX iw
-        State.AX = Alu.Xor16(State.AX, Cpu.NextUint16());
+        State.AX = _alu16.Xor(State.AX, Cpu.NextUint16());
     }
 
     public override void CmpRmReg() {
         // CMP rmw rw
         ModRM.Read();
-        Alu.Sub16(ModRM.GetRm16(), ModRM.R16);
+        _alu16.Sub(ModRM.GetRm16(), ModRM.R16);
     }
 
     public override void CmpRegRm() {
         // CMP rw rmw
         ModRM.Read();
-        Alu.Sub16(ModRM.R16, ModRM.GetRm16());
+        _alu16.Sub(ModRM.R16, ModRM.GetRm16());
     }
 
     public override void CmpAccImm() {
         // CMP AX iw
-        Alu.Sub16(State.AX, Cpu.NextUint16());
+        _alu16.Sub(State.AX, Cpu.NextUint16());
     }
 
     public override void IncReg(int regIndex) {
         // INC regIndex
-        State.Registers.SetRegister16(regIndex, Alu.Inc16(State.Registers.GetRegister16(regIndex)));
+        State.Registers.SetRegister16(regIndex, _alu16.Inc(State.Registers.GetRegister16(regIndex)));
     }
 
     public override void DecReg(int regIndex) {
         // DEC regIndex
-        State.Registers.SetRegister16(regIndex, Alu.Dec16(State.Registers.GetRegister16(regIndex)));
+        State.Registers.SetRegister16(regIndex, _alu16.Dec(State.Registers.GetRegister16(regIndex)));
     }
 
     public override void PushReg(int regIndex) {
@@ -216,7 +219,7 @@ public class Instructions16 : Instructions16Or32 {
     }
 
     private void ImulRmVal(short value) {
-        int result = Alu.Imul16(value, (short)ModRM.GetRm16());
+        int result = _alu16.Imul(value, (short)ModRM.GetRm16());
         ModRM.R16 = (ushort)result;
     }
     
@@ -242,19 +245,19 @@ public class Instructions16 : Instructions16Or32 {
 
     public override void Cmps() {
         ushort value = Memory.UInt16[MemoryAddressOverridableDsSi];
-        Alu.Sub16(value, Memory.UInt16[MemoryAddressEsDi]);
+        _alu16.Sub(value, Memory.UInt16[MemoryAddressEsDi]);
         AdvanceSIDI();
     }
 
     public override void TestRmReg() {
         // TEST rmw rw
         ModRM.Read();
-        Alu.And16(ModRM.GetRm16(), ModRM.R16);
+        _alu16.And(ModRM.GetRm16(), ModRM.R16);
     }
 
     public override void TestAccImm() {
         // TEST AX iw
-        Alu.And16(State.AX, Cpu.NextUint16());
+        _alu16.And(State.AX, Cpu.NextUint16());
     }
 
     public override void Stos() {
@@ -268,7 +271,7 @@ public class Instructions16 : Instructions16Or32 {
     }
 
     public override void Scas() {
-        Alu.Sub16(State.AX, Memory.UInt16[MemoryAddressEsDi]);
+        _alu16.Sub(State.AX, Memory.UInt16[MemoryAddressEsDi]);
         AdvanceDI();
     }
 
@@ -298,14 +301,14 @@ public class Instructions16 : Instructions16Or32 {
         }
 
         ushort res = groupIndex switch {
-            0 => Alu.Add16(op1, op2),
-            1 => Alu.Or16(op1, op2),
-            2 => Alu.Adc16(op1, op2),
-            3 => Alu.Sbb16(op1, op2),
-            4 => Alu.And16(op1, op2),
-            5 => Alu.Sub16(op1, op2),
-            6 => Alu.Xor16(op1, op2),
-            7 => Alu.Sub16(op1, op2),
+            0 => _alu16.Add(op1, op2),
+            1 => _alu16.Or(op1, op2),
+            2 => _alu16.Adc(op1, op2),
+            3 => _alu16.Sbb(op1, op2),
+            4 => _alu16.And(op1, op2),
+            5 => _alu16.Sub(op1, op2),
+            6 => _alu16.Xor(op1, op2),
+            7 => _alu16.Sub(op1, op2),
             _ => throw new InvalidGroupIndexException(State, groupIndex)
         };
         // 7 is CMP so no memory to set
@@ -321,20 +324,20 @@ public class Instructions16 : Instructions16Or32 {
         byte count = ComputeGrp2Count(countSource);
 
         ushort res = groupIndex switch {
-            0 => Alu.Rol16(value, count),
-            1 => Alu.Ror16(value, count),
-            2 => Alu.Rcl16(value, count),
-            3 => Alu.Rcr16(value, count),
-            4 => Alu.Shl16(value, count),
-            5 => Alu.Shr16(value, count),
-            7 => Alu.Sar16(value, count),
+            0 => _alu16.Rol(value, count),
+            1 => _alu16.Ror(value, count),
+            2 => _alu16.Rcl(value, count),
+            3 => _alu16.Rcr(value, count),
+            4 => _alu16.Shl(value, count),
+            5 => _alu16.Shr(value, count),
+            7 => _alu16.Sar(value, count),
             _ => throw new InvalidGroupIndexException(State, groupIndex)
         };
         ModRM.SetRm16(res);
     }
 
     protected override void Grp3TestRm() {
-        Alu.And16(ModRM.GetRm16(), Cpu.NextUint16());
+        _alu16.And(ModRM.GetRm16(), Cpu.NextUint16());
     }
 
     protected override void Grp3NotRm() {
@@ -343,20 +346,20 @@ public class Instructions16 : Instructions16Or32 {
     
     protected override void Grp3NegRm() {
         ushort value = ModRM.GetRm16();
-        value = Alu.Sub16(0, value);
+        value = _alu16.Sub(0, value);
         ModRM.SetRm16(value);
         State.CarryFlag = value != 0;
     }
     
     protected override void Grp3MulRmAcc() {
-        uint result = Alu.Mul16(State.AX, ModRM.GetRm16());
+        uint result = _alu16.Mul(State.AX, ModRM.GetRm16());
         // Upper part of the result goes in DX
         State.DX = (ushort)(result >> 16);
         State.AX = (ushort)result;
     }
 
     protected override void Grp3IMulRmAcc() {
-        int result = Alu.Imul16((short)State.AX, (short)ModRM.GetRm16());
+        int result = _alu16.Imul((short)State.AX, (short)ModRM.GetRm16());
         // Upper part of the result goes in DX
         State.DX = (ushort)(result >> 16);
         State.AX = (ushort)result;
@@ -365,7 +368,7 @@ public class Instructions16 : Instructions16Or32 {
     protected override void Grp3DivRmAcc() {
         uint v1 = (uint)(State.DX << 16 | State.AX);
         ushort v2 = ModRM.GetRm16();
-        ushort result = Alu.Div16(v1, v2);
+        ushort result = _alu16.Div(v1, v2);
         State.AX = result;
         State.DX = (ushort)(v1 % v2);
     }
@@ -374,19 +377,19 @@ public class Instructions16 : Instructions16Or32 {
         // no sign extension for v1 as it is already a 32bit value
         int v1 = State.DX << 16 | State.AX;
         short v2 = (short) ModRM.GetRm16();
-        short result = Alu.Idiv16(v1, v2);
+        short result = _alu16.Idiv(v1, v2);
         State.AX = (ushort)result;
         State.DX = (ushort)(v1 % v2);
     }
 
     protected override void Grp45RmInc() {
         // INC
-        ModRM.SetRm16(Alu.Inc16(ModRM.GetRm16()));
+        ModRM.SetRm16(_alu16.Inc(ModRM.GetRm16()));
     }
 
     protected override void Grp45RmDec() {
         // DEC
-        ModRM.SetRm16(Alu.Dec16(ModRM.GetRm16()));
+        ModRM.SetRm16(_alu16.Dec(ModRM.GetRm16()));
     }
 
     protected override void Grp5RmPush() {
@@ -549,7 +552,7 @@ public class Instructions16 : Instructions16Or32 {
 
         ushort source = ModRM.R16;
         ushort destination = ModRM.GetRm16();
-        ushort value = Alu.Shld16(destination, source, count);
+        ushort value = _alu16.Shld(destination, source, count);
         ModRM.SetRm16(value);
     }
 

--- a/src/Spice86.Core/Emulator/CPU/InstructionsImpl/Instructions16Or32.cs
+++ b/src/Spice86.Core/Emulator/CPU/InstructionsImpl/Instructions16Or32.cs
@@ -4,8 +4,8 @@ using Spice86.Core.Emulator.VM;
 namespace Spice86.Core.Emulator.CPU.InstructionsImpl;
 
 public abstract class Instructions16Or32 : Instructions {
-    protected Instructions16Or32(Alu alu, Cpu cpu, Memory.IMemory memory, ModRM modRm) 
-        : base(alu, cpu, memory, modRm) {
+    protected Instructions16Or32(Cpu cpu, Memory.IMemory memory, ModRM modRm) 
+        : base(cpu, memory, modRm) {
     }
 
     // Inc Reg

--- a/src/Spice86.Core/Emulator/CPU/InstructionsImpl/Instructions32.cs
+++ b/src/Spice86.Core/Emulator/CPU/InstructionsImpl/Instructions32.cs
@@ -1,156 +1,158 @@
-using Spice86.Core.Emulator.VM;
-
 namespace Spice86.Core.Emulator.CPU.InstructionsImpl;
 
 public class Instructions32 : Instructions16Or32 {
-    public Instructions32(Alu alu, Cpu cpu, Memory.IMemory memory, ModRM modRm) :
-        base(alu, cpu, memory, modRm) {
+    
+    private readonly Alu32 _alu32;
+
+    public Instructions32(Cpu cpu, Memory.IMemory memory, ModRM modRm) :
+        base(cpu, memory, modRm) {
+        _alu32 = new Alu32(cpu.State);
     }
 
     public override void AddRmReg() {
         // ADD rmdw rdw
         ModRM.Read();
-        ModRM.SetRm32(Alu.Add32(ModRM.GetRm32(), ModRM.R32));
+        ModRM.SetRm32(_alu32.Add(ModRM.GetRm32(), ModRM.R32));
     }
 
     public override void AddRegRm() {
         // ADD rdw rmdw
         ModRM.Read();
-        ModRM.R32 = Alu.Add32(ModRM.R32, ModRM.GetRm32());
+        ModRM.R32 = _alu32.Add(ModRM.R32, ModRM.GetRm32());
     }
 
     public override void AddAccImm() {
         // ADD EAX idw
-        State.EAX = Alu.Add32(State.EAX, Cpu.NextUint32());
+        State.EAX = _alu32.Add(State.EAX, Cpu.NextUint32());
     }
 
     public override void OrRmReg() {
         // OR rmdw rdw
         ModRM.Read();
-        ModRM.SetRm32(Alu.Or32(ModRM.GetRm32(), ModRM.R32));
+        ModRM.SetRm32(_alu32.Or(ModRM.GetRm32(), ModRM.R32));
     }
 
     public override void OrRegRm() {
         // OR rdw rmdw
         ModRM.Read();
-        ModRM.R32 = Alu.Or32(ModRM.R32, ModRM.GetRm32());
+        ModRM.R32 = _alu32.Or(ModRM.R32, ModRM.GetRm32());
     }
 
     public override void OrAccImm() {
         // OR EAX idw
-        State.EAX = Alu.Or32(State.EAX, Cpu.NextUint32());
+        State.EAX = _alu32.Or(State.EAX, Cpu.NextUint32());
     }
 
     public override void AdcRmReg() {
         // ADC rmdw rdw
         ModRM.Read();
-        ModRM.SetRm32(Alu.Adc32(ModRM.GetRm32(), ModRM.R32));
+        ModRM.SetRm32(_alu32.Adc(ModRM.GetRm32(), ModRM.R32));
     }
 
     public override void AdcRegRm() {
         // ADC rdw rmdw
         ModRM.Read();
-        ModRM.R32 = Alu.Adc32(ModRM.R32, ModRM.GetRm32());
+        ModRM.R32 = _alu32.Adc(ModRM.R32, ModRM.GetRm32());
     }
 
     public override void AdcAccImm() {
         // ADC EAX idw
-        State.EAX = Alu.Adc32(State.EAX, Cpu.NextUint32());
+        State.EAX = _alu32.Adc(State.EAX, Cpu.NextUint32());
     }
 
     public override void SbbRmReg() {
         // SBB rmdw rdw
         ModRM.Read();
-        ModRM.SetRm32(Alu.Sbb32(ModRM.GetRm32(), ModRM.R32));
+        ModRM.SetRm32(_alu32.Sbb(ModRM.GetRm32(), ModRM.R32));
     }
 
     public override void SbbRegRm() {
         // SBB rdw rmdw
         ModRM.Read();
-        ModRM.R32 = Alu.Sbb32(ModRM.R32, ModRM.GetRm32());
+        ModRM.R32 = _alu32.Sbb(ModRM.R32, ModRM.GetRm32());
     }
 
     public override void SbbAccImm() {
         // SBB EAX idw
-        State.EAX = Alu.Sbb32(State.EAX, Cpu.NextUint32());
+        State.EAX = _alu32.Sbb(State.EAX, Cpu.NextUint32());
     }
 
     public override void AndRmReg() {
         // AND rmdw rdw
         ModRM.Read();
-        ModRM.SetRm32(Alu.And32(ModRM.GetRm32(), ModRM.R32));
+        ModRM.SetRm32(_alu32.And(ModRM.GetRm32(), ModRM.R32));
     }
 
     public override void AndRegRm() {
         // AND rdw rmdw
         ModRM.Read();
-        ModRM.R32 = Alu.And32(ModRM.R32, ModRM.GetRm32());
+        ModRM.R32 = _alu32.And(ModRM.R32, ModRM.GetRm32());
     }
 
     public override void AndAccImm() {
         // AND EAX idw
-        State.EAX = Alu.And32(State.EAX, Cpu.NextUint32());
+        State.EAX = _alu32.And(State.EAX, Cpu.NextUint32());
     }
 
     public override void SubRmReg() {
         // SUB rmdw rdw
         ModRM.Read();
-        ModRM.SetRm32(Alu.Sub32(ModRM.GetRm32(), ModRM.R32));
+        ModRM.SetRm32(_alu32.Sub(ModRM.GetRm32(), ModRM.R32));
     }
 
     public override void SubRegRm() {
         // SUB rdw rmdw
         ModRM.Read();
-        ModRM.R32 = Alu.Sub32(ModRM.R32, ModRM.GetRm32());
+        ModRM.R32 = _alu32.Sub(ModRM.R32, ModRM.GetRm32());
     }
 
     public override void SubAccImm() {
         // SUB EAX idw
-        State.EAX = Alu.Sub32(State.EAX, Cpu.NextUint32());
+        State.EAX = _alu32.Sub(State.EAX, Cpu.NextUint32());
     }
 
     public override void XorRmReg() {
         // XOR rmdw rdw
         ModRM.Read();
-        ModRM.SetRm32(Alu.Xor32(ModRM.GetRm32(), ModRM.R32));
+        ModRM.SetRm32(_alu32.Xor(ModRM.GetRm32(), ModRM.R32));
     }
 
     public override void XorRegRm() {
         // XOR rdw rmdw
         ModRM.Read();
-        ModRM.R32 = Alu.Xor32(ModRM.R32, ModRM.GetRm32());
+        ModRM.R32 = _alu32.Xor(ModRM.R32, ModRM.GetRm32());
     }
 
     public override void XorAccImm() {
         // XOR EAX idw
-        State.EAX = Alu.Xor32(State.EAX, Cpu.NextUint32());
+        State.EAX = _alu32.Xor(State.EAX, Cpu.NextUint32());
     }
 
     public override void CmpRmReg() {
         // CMP rmdw rdw
         ModRM.Read();
-        Alu.Sub32(ModRM.GetRm32(), ModRM.R32);
+        _alu32.Sub(ModRM.GetRm32(), ModRM.R32);
     }
 
     public override void CmpRegRm() {
         // CMP rdw rmdw
         ModRM.Read();
-        Alu.Sub32(ModRM.R32, ModRM.GetRm32());
+        _alu32.Sub(ModRM.R32, ModRM.GetRm32());
     }
 
     public override void CmpAccImm() {
         // CMP EAX idw
-        Alu.Sub32(State.EAX, Cpu.NextUint32());
+        _alu32.Sub(State.EAX, Cpu.NextUint32());
     }
 
     public override void IncReg(int regIndex) {
         // INC regIndex
-        State.Registers.SetRegister32(regIndex, Alu.Inc32(State.Registers.GetRegister32(regIndex)));
+        State.Registers.SetRegister32(regIndex, _alu32.Inc(State.Registers.GetRegister32(regIndex)));
     }
 
     public override void DecReg(int regIndex) {
         // DEC regIndex
-        State.Registers.SetRegister32(regIndex, Alu.Dec32(State.Registers.GetRegister32(regIndex)));
+        State.Registers.SetRegister32(regIndex, _alu32.Dec(State.Registers.GetRegister32(regIndex)));
     }
 
     public override void PushReg(int regIndex) {
@@ -214,7 +216,7 @@ public class Instructions32 : Instructions16Or32 {
     }
 
     private void ImulRmVal(int value) {
-        long result = Alu.Imul32(value, (int)ModRM.GetRm32());
+        long result = _alu32.Imul(value, (int)ModRM.GetRm32());
         ModRM.R32 = (uint)result;
     }
     
@@ -240,19 +242,19 @@ public class Instructions32 : Instructions16Or32 {
     
     public override void Cmps() {
         uint value = Memory.UInt32[MemoryAddressOverridableDsSi];
-        Alu.Sub32(value, Memory.UInt32[MemoryAddressEsDi]);
+        _alu32.Sub(value, Memory.UInt32[MemoryAddressEsDi]);
         AdvanceSIDI();
     }
 
     public override void TestRmReg() {
         // TEST rmdw rdw
         ModRM.Read();
-        Alu.And32(ModRM.GetRm32(), ModRM.R32);
+        _alu32.And(ModRM.GetRm32(), ModRM.R32);
     }
 
     public override void TestAccImm() {
         // TEST EAX idw
-        Alu.And32(State.EAX, Cpu.NextUint32());
+        _alu32.And(State.EAX, Cpu.NextUint32());
     }
     
     public override void Stos() {
@@ -266,7 +268,7 @@ public class Instructions32 : Instructions16Or32 {
     }
     
     public override void Scas() {
-        Alu.Sub32(State.EAX, Memory.UInt32[MemoryAddressEsDi]);
+        _alu32.Sub(State.EAX, Memory.UInt32[MemoryAddressEsDi]);
         AdvanceDI();
     }
     
@@ -295,14 +297,14 @@ public class Instructions32 : Instructions16Or32 {
             op2 = Cpu.NextUint32();
         }
         uint res = groupIndex switch {
-            0 => Alu.Add32(op1, op2),
-            1 => Alu.Or32(op1, op2),
-            2 => Alu.Adc32(op1, op2),
-            3 => Alu.Sbb32(op1, op2),
-            4 => Alu.And32(op1, op2),
-            5 => Alu.Sub32(op1, op2),
-            6 => Alu.Xor32(op1, op2),
-            7 => Alu.Sub32(op1, op2),
+            0 => _alu32.Add(op1, op2),
+            1 => _alu32.Or(op1, op2),
+            2 => _alu32.Adc(op1, op2),
+            3 => _alu32.Sbb(op1, op2),
+            4 => _alu32.And(op1, op2),
+            5 => _alu32.Sub(op1, op2),
+            6 => _alu32.Xor(op1, op2),
+            7 => _alu32.Sub(op1, op2),
             _ => throw new InvalidGroupIndexException(State, groupIndex)
         };
         // 7 is CMP so no memory to set
@@ -318,13 +320,13 @@ public class Instructions32 : Instructions16Or32 {
         byte count = ComputeGrp2Count(countSource);
 
         uint res = groupIndex switch {
-            0 => Alu.Rol32(value, count),
-            1 => Alu.Ror32(value, count),
-            2 => Alu.Rcl32(value, count),
-            3 => Alu.Rcr32(value, count),
-            4 => Alu.Shl32(value, count),
-            5 => Alu.Shr32(value, count),
-            7 => Alu.Sar32(value, count),
+            0 => _alu32.Rol(value, count),
+            1 => _alu32.Ror(value, count),
+            2 => _alu32.Rcl(value, count),
+            3 => _alu32.Rcr(value, count),
+            4 => _alu32.Shl(value, count),
+            5 => _alu32.Shr(value, count),
+            7 => _alu32.Sar(value, count),
             _ => throw new InvalidGroupIndexException(State, groupIndex)
         };
         ModRM.SetRm32(res);
@@ -332,7 +334,7 @@ public class Instructions32 : Instructions16Or32 {
     
     
     protected override void Grp3TestRm() {
-        Alu.And32(ModRM.GetRm32(), Cpu.NextUint32());
+        _alu32.And(ModRM.GetRm32(), Cpu.NextUint32());
     }
 
     protected override void Grp3NotRm() {
@@ -341,20 +343,20 @@ public class Instructions32 : Instructions16Or32 {
     
     protected override void Grp3NegRm() {
         uint value = ModRM.GetRm32();
-        value = Alu.Sub32(0, value);
+        value = _alu32.Sub(0, value);
         ModRM.SetRm32(value);
         State.CarryFlag = value != 0;
     }
 
     protected override void Grp3MulRmAcc() {
-        ulong result = Alu.Mul32(State.EAX, ModRM.GetRm32());
+        ulong result = _alu32.Mul(State.EAX, ModRM.GetRm32());
         // Upper part of the result goes in EDX
         State.EDX = (uint)(result >> 32);
         State.EAX = (uint)result;
     }
 
     protected override void Grp3IMulRmAcc() {
-        long result = Alu.Imul32((int)State.EAX, (int)ModRM.GetRm32());
+        long result = _alu32.Imul((int)State.EAX, (int)ModRM.GetRm32());
         // Upper part of the result goes in EDX
         State.EDX = (uint)(result >> 32);
         State.EAX = (uint)result;
@@ -363,7 +365,7 @@ public class Instructions32 : Instructions16Or32 {
     protected override void Grp3DivRmAcc() {
         ulong v1 = ((ulong)State.EDX << 32) | State.EAX;
         uint v2 = ModRM.GetRm32();
-        uint result = Alu.Div32(v1, v2);
+        uint result = _alu32.Div(v1, v2);
         State.EAX = result;
         State.EDX = (uint)(v1 % v2);
     }
@@ -372,17 +374,17 @@ public class Instructions32 : Instructions16Or32 {
         // no sign extension for v1 as it is already a 32bit value
         long v1 = (long)(((ulong)State.EDX << 32) | State.EAX);
         int v2 = (int) ModRM.GetRm32();
-        int result = Alu.Idiv32(v1, v2);
+        int result = _alu32.Idiv(v1, v2);
         State.EAX = (uint)result;
         State.EDX = (uint)(v1 % v2);
     }
 
     protected override void Grp45RmInc() {
-        ModRM.SetRm32(Alu.Inc32(ModRM.GetRm32()));
+        ModRM.SetRm32(_alu32.Inc(ModRM.GetRm32()));
     }
 
     protected override void Grp45RmDec() {
-        ModRM.SetRm32(Alu.Dec32(ModRM.GetRm32()));
+        ModRM.SetRm32(_alu32.Dec(ModRM.GetRm32()));
     }
 
     protected override void Grp5RmPush() {
@@ -534,7 +536,7 @@ public class Instructions32 : Instructions16Or32 {
         byte count = ComputeGrp2Count(countSource);
         uint source = ModRM.R32;
         uint destination = ModRM.GetRm32();
-        uint value = Alu.Shld32(destination, source, count);
+        uint value = _alu32.Shld(destination, source, count);
         ModRM.SetRm32(value);
     }
 

--- a/src/Spice86.Core/Emulator/CPU/InstructionsImpl/Instructions8.cs
+++ b/src/Spice86.Core/Emulator/CPU/InstructionsImpl/Instructions8.cs
@@ -1,146 +1,146 @@
-using Spice86.Core.Emulator.VM;
-
 namespace Spice86.Core.Emulator.CPU.InstructionsImpl;
 
 public class Instructions8 : Instructions {
-    public Instructions8(Alu alu, Cpu cpu, Memory.IMemory memory, ModRM modRm) :
-        base(alu, cpu, memory, modRm) {
+    private readonly Alu8 _alu8;
+    public Instructions8(Cpu cpu, Memory.IMemory memory, ModRM modRm) :
+        base(cpu, memory, modRm) {
+        _alu8 = new Alu8(cpu.State);
     }
 
     public override void AddRmReg() {
         // ADD rmb rb
         ModRM.Read();
-        ModRM.SetRm8(Alu.Add8(ModRM.GetRm8(), ModRM.R8));
+        ModRM.SetRm8(_alu8.Add(ModRM.GetRm8(), ModRM.R8));
     }
 
     public override void AddRegRm() {
         // ADD rb rmb
         ModRM.Read();
-        ModRM.R8 = Alu.Add8(ModRM.R8, ModRM.GetRm8());
+        ModRM.R8 = _alu8.Add(ModRM.R8, ModRM.GetRm8());
     }
 
     public override void AddAccImm() {
         // ADD AL ib
-        State.AL = Alu.Add8(State.AL, Cpu.NextUint8());
+        State.AL = _alu8.Add(State.AL, Cpu.NextUint8());
     }
 
     public override void OrRmReg() {
         // OR rmb rb
         ModRM.Read();
-        ModRM.SetRm8(Alu.Or8(ModRM.GetRm8(), ModRM.R8));
+        ModRM.SetRm8(_alu8.Or(ModRM.GetRm8(), ModRM.R8));
     }
 
     public override void OrRegRm() {
         // OR rb rmb
         ModRM.Read();
-        ModRM.R8 = Alu.Or8(ModRM.R8, ModRM.GetRm8());
+        ModRM.R8 = _alu8.Or(ModRM.R8, ModRM.GetRm8());
     }
 
     public override void OrAccImm() {
         // OR AL ib
-        State.AL = Alu.Or8(State.AL, Cpu.NextUint8());
+        State.AL = _alu8.Or(State.AL, Cpu.NextUint8());
     }
 
     public override void AdcRmReg() {
         // ADC rmb rb
         ModRM.Read();
-        ModRM.SetRm8(Alu.Adc8(ModRM.GetRm8(), ModRM.R8));
+        ModRM.SetRm8(_alu8.Adc(ModRM.GetRm8(), ModRM.R8));
     }
 
     public override void AdcRegRm() {
         // ADC rb rmb
         ModRM.Read();
-        ModRM.R8 = Alu.Adc8(ModRM.R8, ModRM.GetRm8());
+        ModRM.R8 = _alu8.Adc(ModRM.R8, ModRM.GetRm8());
     }
 
     public override void AdcAccImm() {
         // ADC AL ib
-        State.AL = Alu.Adc8(State.AL, Cpu.NextUint8());
+        State.AL = _alu8.Adc(State.AL, Cpu.NextUint8());
     }
 
     public override void SbbRmReg() {
         // SBB rmb rb
         ModRM.Read();
-        ModRM.SetRm8(Alu.Sbb8(ModRM.GetRm8(), ModRM.R8));
+        ModRM.SetRm8(_alu8.Sbb(ModRM.GetRm8(), ModRM.R8));
     }
 
     public override void SbbRegRm() {
         // SBB rb rmb
         ModRM.Read();
-        ModRM.R8 = Alu.Sbb8(ModRM.R8, ModRM.GetRm8());
+        ModRM.R8 = _alu8.Sbb(ModRM.R8, ModRM.GetRm8());
     }
 
     public override void SbbAccImm() {
         // SBB AL ib
-        State.AL = Alu.Sbb8(State.AL, Cpu.NextUint8());
+        State.AL = _alu8.Sbb(State.AL, Cpu.NextUint8());
     }
 
     public override void AndRmReg() {
         // AND rmb rb
         ModRM.Read();
-        ModRM.SetRm8(Alu.And8(ModRM.GetRm8(), ModRM.R8));
+        ModRM.SetRm8(_alu8.And(ModRM.GetRm8(), ModRM.R8));
     }
 
     public override void AndRegRm() {
         // AND rb rmb
         ModRM.Read();
-        ModRM.R8 = Alu.And8(ModRM.R8, ModRM.GetRm8());
+        ModRM.R8 = _alu8.And(ModRM.R8, ModRM.GetRm8());
     }
 
     public override void AndAccImm() {
         // AND AL ib
-        State.AL = Alu.And8(State.AL, Cpu.NextUint8());
+        State.AL = _alu8.And(State.AL, Cpu.NextUint8());
     }
 
     public override void SubRmReg() {
         // SUB rmb rb
         ModRM.Read();
-        ModRM.SetRm8(Alu.Sub8(ModRM.GetRm8(), ModRM.R8));
+        ModRM.SetRm8(_alu8.Sub(ModRM.GetRm8(), ModRM.R8));
     }
 
     public override void SubRegRm() {
         // SUB rb rmb
         ModRM.Read();
-        ModRM.R8 = Alu.Sub8(ModRM.R8, ModRM.GetRm8());
+        ModRM.R8 = _alu8.Sub(ModRM.R8, ModRM.GetRm8());
     }
 
     public override void SubAccImm() {
         // SUB AL ib
-        State.AL = Alu.Sub8(State.AL, Cpu.NextUint8());
+        State.AL = _alu8.Sub(State.AL, Cpu.NextUint8());
     }
 
     public override void XorRmReg() {
         // XOR rmb rb
         ModRM.Read();
-        ModRM.SetRm8(Alu.Xor8(ModRM.GetRm8(), ModRM.R8));
+        ModRM.SetRm8(_alu8.Xor(ModRM.GetRm8(), ModRM.R8));
     }
 
     public override void XorRegRm() {
         // XOR rb rmb
         ModRM.Read();
-        ModRM.R8 = Alu.Xor8(ModRM.R8, ModRM.GetRm8());
+        ModRM.R8 = _alu8.Xor(ModRM.R8, ModRM.GetRm8());
     }
 
     public override void XorAccImm() {
         // XOR AL ib
-        State.AL = Alu.Xor8(State.AL, Cpu.NextUint8());
+        State.AL = _alu8.Xor(State.AL, Cpu.NextUint8());
     }
 
     public override void CmpRmReg() {
         // CMP rmb rb
         ModRM.Read();
-        Alu.Sub8(ModRM.GetRm8(), ModRM.R8);
+        _alu8.Sub(ModRM.GetRm8(), ModRM.R8);
     }
 
     public override void CmpRegRm() {
         // CMP rb rmb
         ModRM.Read();
-        Alu.Sub8(ModRM.R8, ModRM.GetRm8());
+        _alu8.Sub(ModRM.R8, ModRM.GetRm8());
     }
 
     public override void CmpAccImm() {
         // CMP AL ib
-        Alu.Sub8(State.AL, Cpu.NextUint8());
+        _alu8.Sub(State.AL, Cpu.NextUint8());
     }
 
 
@@ -160,19 +160,19 @@ public class Instructions8 : Instructions {
 
     public override void Cmps() {
         byte value = Memory.UInt8[MemoryAddressOverridableDsSi];
-        Alu.Sub8(value, Memory.UInt8[MemoryAddressEsDi]);
+        _alu8.Sub(value, Memory.UInt8[MemoryAddressEsDi]);
         AdvanceSIDI();
     }
 
     public override void TestRmReg() {
         // TEST rmb rb
         ModRM.Read();
-        Alu.And8(ModRM.GetRm8(), ModRM.R8);
+        _alu8.And(ModRM.GetRm8(), ModRM.R8);
     }
 
     public override void TestAccImm() {
         // TEST AL ib
-        Alu.And8(State.AL, Cpu.NextUint8());
+        _alu8.And(State.AL, Cpu.NextUint8());
     }
 
     public override void Stos() {
@@ -186,7 +186,7 @@ public class Instructions8 : Instructions {
     }
 
     public override void Scas() {
-        Alu.Sub8(State.AL, Memory.UInt8[MemoryAddressEsDi]);
+        _alu8.Sub(State.AL, Memory.UInt8[MemoryAddressEsDi]);
         AdvanceDI();
     }
 
@@ -210,14 +210,14 @@ public class Instructions8 : Instructions {
         byte op1 = ModRM.GetRm8();
         byte op2 = Cpu.NextUint8();
         byte res = groupIndex switch {
-            0 => Alu.Add8(op1, op2),
-            1 => Alu.Or8(op1, op2),
-            2 => Alu.Adc8(op1, op2),
-            3 => Alu.Sbb8(op1, op2),
-            4 => Alu.And8(op1, op2),
-            5 => Alu.Sub8(op1, op2),
-            6 => Alu.Xor8(op1, op2),
-            7 => Alu.Sub8(op1, op2),
+            0 => _alu8.Add(op1, op2),
+            1 => _alu8.Or(op1, op2),
+            2 => _alu8.Adc(op1, op2),
+            3 => _alu8.Sbb(op1, op2),
+            4 => _alu8.And(op1, op2),
+            5 => _alu8.Sub(op1, op2),
+            6 => _alu8.Xor(op1, op2),
+            7 => _alu8.Sub(op1, op2),
             _ => throw new InvalidGroupIndexException(State, groupIndex)
         };
         // 7 is CMP so no memory to set
@@ -233,20 +233,20 @@ public class Instructions8 : Instructions {
         byte count = ComputeGrp2Count(countSource);
 
         byte res = groupIndex switch {
-            0 => Alu.Rol8(value, count),
-            1 => Alu.Ror8(value, count),
-            2 => Alu.Rcl8(value, count),
-            3 => Alu.Rcr8(value, count),
-            4 => Alu.Shl8(value, count),
-            5 => Alu.Shr8(value, count),
-            7 => Alu.Sar8(value, count),
+            0 => _alu8.Rol(value, count),
+            1 => _alu8.Ror(value, count),
+            2 => _alu8.Rcl(value, count),
+            3 => _alu8.Rcr(value, count),
+            4 => _alu8.Shl(value, count),
+            5 => _alu8.Shr(value, count),
+            7 => _alu8.Sar(value, count),
             _ => throw new InvalidGroupIndexException(State, groupIndex)
         };
         ModRM.SetRm8(res);
     }
 
     protected override void Grp3TestRm() {
-        Alu.And8(ModRM.GetRm8(), Cpu.NextUint8());
+        _alu8.And(ModRM.GetRm8(), Cpu.NextUint8());
     }
 
     protected override void Grp3NotRm() {
@@ -255,13 +255,13 @@ public class Instructions8 : Instructions {
 
     protected override void Grp3NegRm() {
         byte value = ModRM.GetRm8();
-        value = Alu.Sub8(0, value);
+        value = _alu8.Sub(0, value);
         ModRM.SetRm8(value);
         State.CarryFlag = value != 0;
     }
 
     protected override void Grp3MulRmAcc() {
-        ushort result = Alu.Mul8(State.AL, ModRM.GetRm8());
+        ushort result = _alu8.Mul(State.AL, ModRM.GetRm8());
         // Upper part of the result goes in AH
         State.AH = (byte)(result >> 8);
         State.AL = (byte)result;
@@ -269,7 +269,7 @@ public class Instructions8 : Instructions {
 
     protected override void Grp3IMulRmAcc() {
         sbyte v2 = (sbyte)ModRM.GetRm8();
-        short result = Alu.Imul8((sbyte)State.AL, v2);
+        short result = _alu8.Imul((sbyte)State.AL, v2);
         // Upper part of the result goes in AH
         State.AH = (byte)(result >> 8);
         State.AL = (byte)result;
@@ -278,7 +278,7 @@ public class Instructions8 : Instructions {
     protected override void Grp3DivRmAcc() {
         ushort v1 = State.AX;
         byte v2 = ModRM.GetRm8();
-        byte result = Alu.Div8(v1, v2);
+        byte result = _alu8.Div(v1, v2);
         State.AL = result;
         State.AH = (byte)(v1 % v2);
     }
@@ -286,7 +286,7 @@ public class Instructions8 : Instructions {
     protected override void Grp3IdivRmAcc() {
         short v1 = (short)State.AX;
         sbyte v2 = (sbyte)ModRM.GetRm8();
-        sbyte result = Alu.Idiv8(v1, v2);
+        sbyte result = _alu8.Idiv(v1, v2);
         State.AL = (byte)result;
         State.AH = (byte)(v1 % v2);
     }
@@ -313,12 +313,12 @@ public class Instructions8 : Instructions {
 
     protected override void Grp45RmInc() {
         // INC
-        ModRM.SetRm8(Alu.Inc8(ModRM.GetRm8()));
+        ModRM.SetRm8(_alu8.Inc(ModRM.GetRm8()));
     }
 
     protected override void Grp45RmDec() {
         // DEC
-        ModRM.SetRm8(Alu.Dec8(ModRM.GetRm8()));
+        ModRM.SetRm8(_alu8.Dec(ModRM.GetRm8()));
     }
 
     public override void XchgRm() {

--- a/src/Spice86.Core/Emulator/ReverseEngineer/CSharpOverrideHelper.cs
+++ b/src/Spice86.Core/Emulator/ReverseEngineer/CSharpOverrideHelper.cs
@@ -71,9 +71,19 @@ public class CSharpOverrideHelper {
     public State State => Cpu.State;
 
     /// <summary>
-    /// Gets the arithmetic-logic unit
+    /// Arithmetic-logic unit for 8 bit operations
     /// </summary>
-    public Alu Alu => Cpu.Alu;
+    public Alu8 Alu8 { get; }
+
+    /// <summary>
+    /// Arithmetic-logic unit for 16 bit operations
+    /// </summary>
+    public Alu16 Alu16 { get; }
+    
+    /// <summary>
+    /// Arithmetic-logic unit for 32 bit operations
+    /// </summary>
+    public Alu32 Alu32 { get; }
 
     /// <summary>
     /// Gets or sets the value of AX register.
@@ -297,6 +307,9 @@ public class CSharpOverrideHelper {
         _functionInformations = functionInformations;
         Machine = machine;
         JumpDispatcher = new();
+        Alu8 = new(machine.Cpu.State);
+        Alu16 = new(machine.Cpu.State);
+        Alu32 = new(machine.Cpu.State);
     }
 
     /// <summary>

--- a/tests/Spice86.Tests/MachineTest.cs
+++ b/tests/Spice86.Tests/MachineTest.cs
@@ -285,10 +285,10 @@ public class MachineTest {
             CarryFlag = true,
             OverflowFlag = true
         };
-        var alu = new Alu(state);
+        var alu = new Alu16(state);
 
         // Act
-        ushort result = alu.Shld16(destination, source, count);
+        ushort result = alu.Shld(destination, source, count);
 
         // Assert
         Assert.Equal(expected, result);
@@ -312,10 +312,10 @@ public class MachineTest {
             CarryFlag = true,
             OverflowFlag = true
         };
-        var alu = new Alu(state);
+        var alu = new Alu32(state);
 
         // Act
-        uint result = alu.Shld32(destination, source, count);
+        uint result = alu.Shld(destination, source, count);
 
         // Assert
         Assert.Equal(expected, result);


### PR DESCRIPTION
Split the ALU between 8, 16 and 32bits versions with a common class Alu providing common logic and abstract methods.
This is needed to unify instructions behaviour with generic math in cfgcpu.