### PR TITLE
Feature: XMS 3.0

### DIFF
--- a/src/Spice86.Core/CLI/Configuration.cs
+++ b/src/Spice86.Core/CLI/Configuration.cs
@@ -133,6 +133,12 @@ public class Configuration {
     public bool Ems { get; init; }
     
     /// <summary>
+    /// Determines whether XMS (Extended Memory Specification) should be enabled or not.
+    /// </summary>
+    [Option(nameof(Xms), Default = false, Required = false, HelpText = "Enable XMS")]
+    public bool Xms { get; init; }
+    
+    /// <summary>
     /// Specify the type of mouse to use.
     /// </summary>
     [Option(nameof(Mouse), Default = MouseType.Ps2, Required = false, HelpText = "Specify the type of mouse to use. Valid values are None, PS2 (default), and PS2Wheel")]

--- a/src/Spice86.Core/Emulator/Extensions/LinkedListExtensions.cs
+++ b/src/Spice86.Core/Emulator/Extensions/LinkedListExtensions.cs
@@ -1,0 +1,62 @@
+namespace Spice86.Core.Emulator.Extensions; 
+
+public static class LinkedListExtensions
+    {
+        /// <summary>
+        /// Replaces an existing linked list node with zero or more new nodes.
+        /// </summary>
+        /// <typeparam name="T">Type of list item.</typeparam>
+        /// <param name="list">Linked list instance.</param>
+        /// <param name="originalItem">Item to replace.</param>
+        /// <param name="newItems">Values to insert in place of the original item.</param>
+        public static void Replace<T>(this LinkedList<T> list, T originalItem, T[] newItems)
+        {
+            ArgumentNullException.ThrowIfNull(list);
+            ArgumentNullException.ThrowIfNull(newItems);
+
+            var originalNode = list.Find(originalItem);
+            if (originalNode == null)
+                throw new ArgumentException("Original item not found.");
+
+            if (originalNode.Previous == null)
+            {
+                list.RemoveFirst();
+                for (int i = newItems.Length - 1; i >= 0; i--)
+                    list.AddFirst(newItems[i]);
+            }
+            else
+            {
+                var previous = originalNode.Previous;
+                list.Remove(originalNode);
+                for (int i = newItems.Length - 1; i >= 0; i--)
+                    list.AddAfter(previous, newItems[i]);
+            }
+        }
+        /// <summary>
+        /// Replaces an existing linked list node with a new node.
+        /// </summary>
+        /// <typeparam name="T">Type of list item.</typeparam>
+        /// <param name="list">Linked list instance.</param>
+        /// <param name="originalItem">Item to replace.</param>
+        /// <param name="newItems">New item to replace the original with.</param>
+        public static void Replace<T>(this LinkedList<T> list, T originalItem, T newItem)
+        {
+            ArgumentNullException.ThrowIfNull(list);
+
+            var originalNode = list.Find(originalItem);
+            if (originalNode == null)
+                throw new ArgumentException("Original item not found.");
+
+            if (originalNode.Previous == null)
+            {
+                list.RemoveFirst();
+                list.AddFirst(newItem);
+            }
+            else
+            {
+                var previous = originalNode.Previous;
+                list.Remove(originalNode);
+                list.AddAfter(previous, newItem);
+            }
+        }
+    }

--- a/src/Spice86.Core/Emulator/InterruptHandlers/Common/MemoryWriter/MemoryAsmWriter.cs
+++ b/src/Spice86.Core/Emulator/InterruptHandlers/Common/MemoryWriter/MemoryAsmWriter.cs
@@ -95,4 +95,9 @@ public class MemoryAsmWriter : MemoryWriter {
     public void WriteFarRet() {
         WriteUInt8(0xCB);
     }
+
+    public void WriteJmpNear(byte offset) {
+        WriteUInt8(0xEB);
+        WriteUInt8(offset);
+    }
 }

--- a/src/Spice86.Core/Emulator/InterruptHandlers/Dos/Ems/Emm.cs
+++ b/src/Spice86.Core/Emulator/InterruptHandlers/Dos/Ems/Emm.cs
@@ -16,7 +16,7 @@ using Spice86.Shared.Utils;
 using System.Linq;
 
 /// <summary>
-/// Provides DOS applications with EMS memory. <br/>
+/// An Expanded Memory Manager. Provides DOS applications with EMS memory. <br/>
 /// Expanded memory is memory beyond DOS's 640K-byte limit.  This LIM <br/>
 /// implementation supports 8 MB of expanded memory. <br/>
 /// Because the 8086, 8088, and 80286 (in real mode) microprocessors can <br/>
@@ -25,7 +25,7 @@ using System.Linq;
 /// <remarks>This is a LIM standard implementation. Which means there's no
 /// difference between EMM pages and raw pages. They're both 16 KB.</remarks>
 /// </summary>
-public sealed class ExpandedMemoryManager : InterruptHandler {
+public sealed class Emm : InterruptHandler {
     /// <summary>
     /// The string identifier in main memory for the EMS Handler. <br/>
     /// DOS programs can detect the presence of an EMS handler by looking for it <br/>
@@ -101,7 +101,7 @@ public sealed class ExpandedMemoryManager : InterruptHandler {
     /// <param name="cpu">The emulated CPU.</param>
     /// <param name="dos">The DOS kernel.</param>
     /// <param name="loggerService">The logger service implementation.</param>
-    public ExpandedMemoryManager(IMemory memory, Cpu cpu, Dos dos, ILoggerService loggerService) : base(memory, cpu, loggerService) {
+    public Emm(IMemory memory, Cpu cpu, Dos dos, ILoggerService loggerService) : base(memory, cpu, loggerService) {
         var device = new CharacterDevice(DeviceAttributes.Ioctl, EmsIdentifier, loggerService);
         dos.AddDevice(device, DosDeviceSegment, 0x0000);
         FillDispatchTable();

--- a/src/Spice86.Core/Emulator/InterruptHandlers/Dos/Ems/EmmHandle.cs
+++ b/src/Spice86.Core/Emulator/InterruptHandlers/Dos/Ems/EmmHandle.cs
@@ -7,7 +7,7 @@ public class EmmHandle {
     /// <summary>
     /// The EMM handle number.
     /// </summary>
-    public ushort HandleNumber { get; init; } = ExpandedMemoryManager.EmmNullHandle;
+    public ushort HandleNumber { get; init; } = Emm.EmmNullHandle;
     
     private const string NullHandleName = "";
     

--- a/src/Spice86.Core/Emulator/InterruptHandlers/Dos/Ems/EmmPage.cs
+++ b/src/Spice86.Core/Emulator/InterruptHandlers/Dos/Ems/EmmPage.cs
@@ -22,5 +22,5 @@ public class EmmPage {
     /// <summary>
     /// The logical page number, for book keeping inside our dictionaries.
     /// </summary>
-    public ushort PageNumber { get; set; } = ExpandedMemoryManager.EmmNullPage;
+    public ushort PageNumber { get; set; } = Emm.EmmNullPage;
 }

--- a/src/Spice86.Core/Emulator/InterruptHandlers/Dos/Ems/EmmRegister.cs
+++ b/src/Spice86.Core/Emulator/InterruptHandlers/Dos/Ems/EmmRegister.cs
@@ -29,7 +29,7 @@ public class EmmRegister : IMemoryDevice {
     }
 
     /// <inheritdoc />
-    public uint Size => ExpandedMemoryManager.EmmPageSize;
+    public uint Size => Emm.EmmPageSize;
 
     /// <inheritdoc />
     public byte Read(uint address) {

--- a/src/Spice86.Core/Emulator/InterruptHandlers/Dos/Xms/IXmsDriver.cs
+++ b/src/Spice86.Core/Emulator/InterruptHandlers/Dos/Xms/IXmsDriver.cs
@@ -1,0 +1,8 @@
+namespace Spice86.Core.Emulator.InterruptHandlers.Dos.Xms;
+
+using Spice86.Core.Emulator.InterruptHandlers.Common.RoutineInstall;
+using Spice86.Core.Emulator.OperatingSystem.Devices;
+
+public interface IXmsDriver : IAssemblyRoutineWriter {
+    
+}

--- a/src/Spice86.Core/Emulator/InterruptHandlers/Dos/Xms/Xmm.cs
+++ b/src/Spice86.Core/Emulator/InterruptHandlers/Dos/Xms/Xmm.cs
@@ -1,0 +1,480 @@
+﻿namespace Spice86.Core.Emulator.InterruptHandlers.Dos.Xms;
+
+using Spice86.Core.Emulator.CPU;
+using Spice86.Core.Emulator.Extensions;
+using Spice86.Core.Emulator.InterruptHandlers.Common.MemoryWriter;
+using Spice86.Core.Emulator.Memory;
+using Spice86.Core.Emulator.OperatingSystem.Devices;
+using Spice86.Core.Emulator.OperatingSystem.Enums;
+using Spice86.Shared.Emulator.Memory;
+using Spice86.Shared.Interfaces;
+using Spice86.Shared.Utils;
+
+using System.Diagnostics.CodeAnalysis;
+using System.Linq;
+
+/// <summary>
+/// XMS allows DOS programs to utilize additional memory,
+/// found in Intel's 80286 and 80386 based machines in a consistent, machine independent manner.
+/// With some restrictions, XMS adds almost 64K to the 640K which DOS programs can
+/// access directly.  <br/>
+/// Depending on available hardware, XMS may provide
+/// even more memory to DOS programs.  XMS also provides DOS programs with
+/// a standard method of storing data in extended memory. <br/><br/>
+/// An Extended Memory Manager.  A DOS device driver which implements
+/// XMS.  XMMs are machine specific but allow programs to use extended
+/// memory in a machine-independent manner.
+/// </summary>
+public sealed class Xmm : CharacterDevice, IXmsDriver {
+    private int _a20EnableCount;
+    private readonly LinkedList<XmsBlock> _xmsBlocksLinkedList = new();
+    private readonly SortedList<int, int> _xmsHandles = new();
+    public const ushort CallbackAsmFunctionSegment = 0xD000;
+
+    /// <summary>
+    /// The size of available XMS Memory, in bytes.
+    /// </summary>
+    public const uint XmsMemorySize = 8 * 1024 * 1024;
+    
+    private readonly State _state;
+
+    private readonly ILoggerService _loggerService;
+
+    private readonly IMemory _memory = new Memory(new Ram(XmsMemorySize), false);
+
+    public Xmm(State state, ILoggerService loggerService) : base(DeviceAttributes.NonIBM, "XMSXXXX0" ,loggerService) {
+        _loggerService = loggerService;
+        _state = state;
+        _xmsBlocksLinkedList.AddFirst(new XmsBlock(0, 0, XmsMemorySize, false, _memory, 0));
+        FillDispatchTable();
+    }
+    
+    public SegmentedAddress WriteAssemblyInRam(MemoryAsmWriter memoryAsmWriter) {
+        SegmentedAddress startAddress = new(CallbackAsmFunctionSegment, 0);
+        memoryAsmWriter.CurrentAddress = startAddress;
+        memoryAsmWriter.WriteJmpNear(0x3);
+        memoryAsmWriter.WriteNop();
+        memoryAsmWriter.WriteNop();
+        memoryAsmWriter.WriteNop();
+        return startAddress;
+    }
+
+    /// <summary>
+    /// Specifies the starting physical address of XMS, from the point of view of main memory.
+    /// </summary>
+    /// <remarks>We store XMS memory in another memory class instance, in which actual XMS Memory starts at 0.</remarks>
+    private const uint XmsBaseAddress = 0x10FFF0;
+
+    /// <summary>
+    /// Total number of handles available at once.
+    /// </summary>
+    private const int MaxHandles = 128;
+
+    /// <summary>
+    /// Gets the largest free block of memory in bytes.
+    /// </summary>
+    public uint LargestFreeBlock => GetFreeBlocks().FirstOrDefault()?.Length ?? 0;
+    
+    /// <summary>
+    /// Gets the total amount of free memory in bytes.
+    /// </summary>
+    public long TotalFreeMemory => GetFreeBlocks().Sum(b => b.Length);
+    
+    private void FillDispatchTable() {
+        // TODO: Implement more (see XMS.TXT, and their unreferenced names in Aeon)
+        // AddAction(0x00, GetVersionNumber);
+        // AddAction(0x01, RequestHighMemoryArea);
+        // AddAction(0x02, ReleaseHighMemoryArea);
+        // AddAction(0x03, GlobalEnableA20);
+        // AddAction(0x04, GlobalDisableA20);
+        // AddAction(0x05, EnableLocalA20);
+        // AddAction(0x06, DisableLocalA20);
+        // AddAction(0x07, QueryA20);
+        // AddAction(0x08, QueryFreeExtendedMemory);
+        // AddAction(0x09, AllocateExtendedMemoryBlock);
+        // AddAction(0x10, RequestUpperMemoryBlock);
+        // AddAction(0x0A, FreeExtendedMemoryBlock);
+        // AddAction(0x0B, MoveExtendedMemoryBlock);
+        // AddAction(0x0C, LockExtendedMemoryBlock);
+        // AddAction(0x0D, UnlockExtendedMemoryBlock);
+        // AddAction(0x0E, GetHandleInformation);
+        // AddAction(0x88, QueryAnyFreeExtendedMemory);
+        // AddAction(0x89,  () => AllocateAnyExtendedMemory(_state.EDX));
+    }
+
+    /*/// <inheritdoc />
+    public override void Run() {
+        byte operation = _state.AH;
+        if (!HasRunnable(operation)) {
+            switch (_state.AL) {
+                case XmsHandlerFunctions.InstallationCheck:
+                    _state.AL = 0x80;
+                    break;
+
+                case XmsHandlerFunctions.GetCallbackAddress:
+                    _state.EBX = MemoryUtils.ToPhysicalAddress(CallbackAsmFunctionSegment, 0);
+                    _state.ES = CallbackAsmFunctionSegment;
+                    break;
+                default:
+                    _loggerService.Error("XMS function not provided: {@Function}", operation);
+                    break;
+            }
+        }
+        if (_loggerService.IsEnabled(LogEventLevel.Verbose)) {
+            _loggerService.Verbose("XMS function: 0x{@Function:X2} AL=0x{Al:X2}", operation, _state.AL);
+        }
+        Run(operation);
+    }*/
+
+    public void GetVersionNumber() {
+        _state.AX = 0x0300; // Return version 3.00
+        _state.BX = 0; // Internal version
+        _state.DX = 1; // HMA exists
+    }
+
+    public void RequestHighMemoryArea() {
+        _state.AX = 0; // Didn't work
+        _state.BL = 0x91; // HMA already in use
+    }
+
+    public void ReleaseHighMemoryArea() {
+        _state.AX = 0; // Didn't work
+        _state.BL = 0x93; // HMA not allocated
+    }
+
+    public void QueryFreeExtendedMemory() {
+        if (LargestFreeBlock <= ushort.MaxValue * 1024u) {
+            _state.AX = (ushort)(LargestFreeBlock / 1024u);
+        } else {
+            _state.AX = ushort.MaxValue;
+        }
+
+        if (TotalFreeMemory <= ushort.MaxValue * 1024u) {
+            _state.DX = (ushort)(TotalFreeMemory / 1024);
+        } else {
+            _state.DX = ushort.MaxValue;
+        }
+
+        if (_state.AX == 0 && _state.DX == 0) {
+            _state.BL = 0xA0;
+        }
+    }
+
+    public void AllocateExtendedMemoryBlock() {
+        AllocateAnyExtendedMemory(_state.DX);
+    }
+
+    public void RequestUpperMemoryBlock() {
+        _state.BL = 0xB1; // No UMB's available.
+        _state.AX = 0; // Didn't work.
+    }
+
+    public void GlobalDisableA20() {
+        _memory.A20Gate.IsEnabled = false;
+        _state.AX = 1; // Success
+    }
+
+    public void GlobalEnableA20() {
+        _memory.A20Gate.IsEnabled = true;
+        _state.AX = 1; // Success
+    }
+
+    public void QueryA20() {
+        _state.AX = (ushort)(_a20EnableCount > 0 ? (short)1 : (short)0);
+    }
+
+    /// <summary>
+    /// Attempts to allocate a block of extended memory.
+    /// </summary>
+    /// <param name="length">Number of bytes to allocate.</param>
+    /// <param name="handle">If successful, contains the allocation handle.</param>
+    /// <returns>Zero on success. Nonzero indicates error code.</returns>
+    public byte TryAllocate(uint length, out short handle) {
+        handle = (short)GetNextHandle();
+        if (handle == 0) {
+            return 0xA1; // All handles are used.
+        }
+
+        // Round up to next kbyte if necessary.
+        if (length % 1024 != 0) {
+            length = (length & 0xFFFFFC00u) + 1024u;
+        } else {
+            length &= 0xFFFFFC00u;
+        }
+
+        // Zero-length allocations are allowed.
+        if (length == 0) {
+            _xmsHandles.Add(handle, 0);
+            return 0;
+        }
+
+        XmsBlock? smallestFreeBlock = GetFreeBlocks()
+            .Where(b => b.Length >= length)
+            .Select(static b => new XmsBlock(b))
+            .FirstOrDefault();
+
+        if (smallestFreeBlock == null) {
+            return 0xA0; // Not enough free memory.
+        }
+
+        LinkedListNode<XmsBlock>? freeNode = _xmsBlocksLinkedList.Find(smallestFreeBlock);
+        if (freeNode is not null) {
+            XmsBlock[] newNodes = freeNode.Value.Allocate(handle, length);
+            _xmsBlocksLinkedList.Replace(smallestFreeBlock, newNodes);
+        }
+
+        _xmsHandles.Add(handle, 0);
+        return 0;
+    }
+
+    /// <summary>
+    /// Returns the block with the specified handle if found; otherwise returns null.
+    /// </summary>
+    /// <param name="handle">Handle of block to search for.</param>
+    /// <param name="block">On success, contains information about the block.</param>
+    /// <returns>True if handle was found; otherwise false.</returns>
+    public bool TryGetBlock(int handle, [NotNullWhen(true)] out XmsBlock? block) {
+        foreach (XmsBlock b in _xmsBlocksLinkedList.Where(b => b.IsUsed && b.Handle == handle)) {
+            block = b;
+            return true;
+        }
+
+        block = default;
+        return false;
+    }
+
+    /// <summary>
+    /// Increments the A20 enable count.
+    /// </summary>
+    public void EnableLocalA20() {
+        if (_a20EnableCount == 0) {
+            _memory.A20Gate.IsEnabled = true;
+        }
+        _a20EnableCount++;
+        _state.AX = 1; // Success
+    }
+
+    /// <summary>
+    /// Decrements the A20 enable count.
+    /// </summary>
+    public void DisableLocalA20() {
+        if (_a20EnableCount == 1) {
+            _memory.A20Gate.IsEnabled = false;
+        }
+
+        if (_a20EnableCount > 0) {
+            _a20EnableCount--;
+        }
+        _state.AX = 1; // Success
+    }
+    
+    /// <summary>
+    /// Returns all of the free blocks in the map sorted by size in ascending order.
+    /// </summary>
+    /// <returns>Sorted list of free blocks in the map.</returns>
+    public IEnumerable<XmsBlock> GetFreeBlocks() => _xmsBlocksLinkedList.Where(static x => !x.IsUsed).OrderBy(static x => x.Length);
+
+    /// <summary>
+    /// Returns the next available handle for an allocation on success; returns 0 if no handles are available.
+    /// </summary>
+    /// <returns>New handle if available; otherwise returns null.</returns>
+    public int GetNextHandle() {
+        for (int i = 1; i <= MaxHandles; i++) {
+            if (!_xmsHandles.ContainsKey(i)) {
+                return i;
+            }
+        }
+
+        return 0;
+    }
+
+    /// <summary>
+    /// Attempts to merge a free block with the following block if possible.
+    /// </summary>
+    /// <param name="firstBlock">Free block to merge.</param>
+    public void MergeFreeBlocks(XmsBlock firstBlock) {
+        LinkedListNode<XmsBlock>? firstNode = _xmsBlocksLinkedList.Find(firstBlock);
+
+        if (firstNode?.Next != null) {
+            LinkedListNode<XmsBlock> nextNode = firstNode.Next;
+            if (!nextNode.Value.IsUsed) {
+                XmsBlock newBlock = firstBlock.Join(nextNode.Value);
+                _xmsBlocksLinkedList.Remove(nextNode);
+                _xmsBlocksLinkedList.Replace(firstBlock, newBlock);
+            }
+        }
+    }
+
+    /// <summary>
+    /// Allocates a new block of memory.
+    /// </summary>
+    /// <param name="kbytes">Number of kilobytes requested.</param>
+    public void AllocateAnyExtendedMemory(uint kbytes) {
+        byte res = TryAllocate(kbytes * 1024u, out short handle);
+        if (res == 0) {
+            _state.AX = 1; // Success.
+            _state.DX = (ushort)handle;
+        } else {
+            _state.AX = 0; // Didn't work.
+            _state.BL = res;
+        }
+    }
+
+    /// <summary>
+    /// Frees a block of memory.
+    /// </summary>
+    public void FreeExtendedMemoryBlock() {
+        int handle = _state.DX;
+
+        if (!_xmsHandles.TryGetValue(handle, out int lockCount)) {
+            _state.AX = 0; // Didn't work.
+            _state.BL = 0xA2; // Invalid handle.
+            return;
+        }
+
+        if (lockCount > 0) {
+            _state.AX = 0; // Didn't work.
+            _state.BL = 0xAB; // Handle is locked.
+            return;
+        }
+
+        if (TryGetBlock(handle, out XmsBlock? block)) {
+            XmsBlock freeBlock = block.Free();
+            _xmsBlocksLinkedList.Replace(block, freeBlock);
+            MergeFreeBlocks(freeBlock);
+        }
+
+        _xmsHandles.Remove(handle);
+        _state.AX = 1; // Success.
+    }
+
+    /// <summary>
+    /// Locks a block of memory.
+    /// </summary>
+    public void LockExtendedMemoryBlock() {
+        int handle = _state.DX;
+
+        if (!_xmsHandles.TryGetValue(handle, out int lockCount)) {
+            _state.AX = 0; // Didn't work.
+            _state.BL = 0xA2; // Invalid handle.
+            return;
+        }
+
+        _xmsHandles[handle] = lockCount + 1;
+
+        _ = TryGetBlock(handle, out XmsBlock? block);
+        uint fullAddress = XmsBaseAddress + block?.Offset ?? 0;
+
+        _state.AX = 1; // Success.
+        _state.DX = (ushort)(fullAddress >> 16);
+        _state.BX = (ushort)(fullAddress & 0xFFFFu);
+    }
+
+    /// <summary>
+    /// Unlocks a block of memory.
+    /// </summary>
+    public void UnlockExtendedMemoryBlock() {
+        int handle = _state.DX;
+
+        if (!_xmsHandles.TryGetValue(handle, out int lockCount)) {
+            _state.AX = 0; // Didn't work.
+            _state.BL = 0xA2; // Invalid handle.
+            return;
+        }
+
+        if (lockCount < 1) {
+            _state.AX = 0;
+            _state.BL = 0xAA; // Handle is not locked.
+            return;
+        }
+
+        _xmsHandles[handle] = lockCount - 1;
+
+        _state.AX = 1; // Success.
+    }
+
+    /// <summary>
+    /// Returns information about an XMS handle.
+    /// </summary>
+    public void GetHandleInformation() {
+        int handle = _state.DX;
+
+        if (!_xmsHandles.TryGetValue(handle, out int lockCount)) {
+            _state.AX = 0; // Didn't work.
+            _state.BL = 0xA2; // Invalid handle.
+            return;
+        }
+
+        _state.BH = (byte)lockCount;
+        _state.BL = (byte)(MaxHandles - _xmsHandles.Count);
+
+        if (!TryGetBlock(handle, out XmsBlock? block)) {
+            _state.DX = 0;
+        } else {
+            _state.DX = (ushort)(block.Length / 1024u);
+        }
+
+        _state.AX = 1; // Success.
+    }
+
+    /// <summary>
+    /// Copies a block of memory.
+    /// TODO: Verify this works
+    /// </summary>
+    public unsafe void MoveExtendedMemoryBlock() {
+        bool a20State = _memory.A20Gate.IsEnabled;
+        _memory.A20Gate.IsEnabled = true;
+
+        XmsMoveData moveData = new XmsMoveData(_memory, _state.DS);
+        uint srcAddress = 0;
+        uint destAddress = 0;
+
+        if (moveData.SourceHandle == 0) {
+            srcAddress = MemoryUtils.ToPhysicalAddress(moveData.SourceAddress.Segment, moveData.SourceAddress.Offset);
+        } else {
+            if (TryGetBlock(moveData.SourceHandle, out XmsBlock? srcBlock)) {
+                srcAddress = XmsBaseAddress + srcBlock.Offset + moveData.SourceOffset;
+            }
+        }
+
+        if (moveData.DestHandle == 0) {
+            destAddress = MemoryUtils.ToPhysicalAddress(moveData.DestAddress.Segment, moveData.DestAddress.Offset);
+        } else {
+            if (TryGetBlock(moveData.DestHandle, out XmsBlock? destBlock)) {
+                destAddress = XmsBaseAddress + destBlock.Offset + moveData.DestOffset;
+            }
+        }
+
+        if (srcAddress == 0) {
+            _state.BL = 0xA3; // Invalid source handle.
+            _state.AX = 0; // Didn't work.
+            return;
+        }
+
+        if (destAddress == 0) {
+            _state.BL = 0xA5; // Invalid destination handle.
+            _state.AX = 0; // Didn't work.
+            return;
+        }
+
+        _memory.MemCopy(srcAddress, destAddress, moveData.Length);
+
+        _state.AX = 1; // Success.
+        _memory.A20Gate.IsEnabled = a20State;
+    }
+
+    /// <summary>
+    /// Queries free memory using 32-bit registers.
+    /// </summary>
+    public void QueryAnyFreeExtendedMemory() {
+        _state.EAX = LargestFreeBlock / 1024u;
+        _state.ECX = _memory.Length - 1;
+        _state.EDX = (uint)(TotalFreeMemory / 1024);
+
+        if (_state.EAX == 0) {
+            _state.BL = 0xA0;
+        } else {
+            _state.BL = 0;
+        }
+    }
+}

--- a/src/Spice86.Core/Emulator/InterruptHandlers/Dos/Xms/XmsBlock.cs
+++ b/src/Spice86.Core/Emulator/InterruptHandlers/Dos/Xms/XmsBlock.cs
@@ -1,0 +1,128 @@
+﻿namespace Spice86.Core.Emulator.InterruptHandlers.Dos.Xms;
+
+using Spice86.Core.Emulator.Memory;
+using Spice86.Core.Emulator.Memory.ReaderWriter;
+using Spice86.Core.Emulator.ReverseEngineer.DataStructure;
+
+using System;
+
+/// <summary>
+/// Represents a block of XMS memory.
+/// </summary>
+public class XmsBlock : MemoryBasedDataStructure, IEquatable<XmsBlock> {
+    /// <summary>
+    /// Initializes a new instance.
+    /// </summary>
+    public XmsBlock(int Handle, uint Offset, uint Length, bool IsUsed, IByteReaderWriter byteReaderWriter, uint baseAddress) : base(byteReaderWriter, baseAddress) {
+        this.Handle = Handle;
+        this.Offset = Offset;
+        this.Length = Length;
+        this.IsUsed = IsUsed;
+    }
+
+    public XmsBlock(XmsBlock other) : base(other.ByteReaderWriter, other.BaseAddress) {
+        this.Handle = other.Handle;
+        this.Offset = other.Offset;
+        this.Length = other.Length;
+        this.IsUsed = other.IsUsed;
+    }
+
+    /// <inheritdoc />
+    public override string ToString() {
+        if (IsUsed) {
+            return $"{Handle:X4}: {Offset:X8} to {Offset + Length:X8}";
+        } else {
+            return "Free";
+        }
+    }
+
+    /// <inheritdoc />
+    public override int GetHashCode() {
+        return HashCode.Combine(Handle, Offset, Length, IsUsed);
+    }
+
+    /// <inheritdoc />
+    public override bool Equals(object? obj) {
+        if (ReferenceEquals(null, obj)) {
+            return false;
+        }
+
+        if (ReferenceEquals(this, obj)) {
+            return true;
+        }
+
+        if (obj.GetType() != this.GetType()) {
+            return false;
+        }
+
+        return Equals((XmsBlock)obj);
+    }
+
+    /// <summary>
+    /// Allocates a block of memory from a free block.
+    /// </summary>
+    /// <param name="handle">Handle making the allocation.</param>
+    /// <param name="length">Length of the requested block in bytes.</param>
+    /// <returns>Array of blocks to replace this block.</returns>
+    public XmsBlock[] Allocate(int handle, uint length) {
+        if (IsUsed) {
+            throw new InvalidOperationException();
+        }
+
+        if (length > Length) {
+            throw new ArgumentOutOfRangeException(nameof(length));
+        }
+
+        if (length == Length) {
+            return new XmsBlock[] { new XmsBlock(handle, Offset, length, true, ByteReaderWriter, BaseAddress) };
+        }
+
+        var blocks = new XmsBlock[2];
+
+        blocks[0] = new XmsBlock(handle, Offset, length, true, ByteReaderWriter, BaseAddress);
+        blocks[1] = new XmsBlock(0, Offset + length, Length - length, false, ByteReaderWriter, BaseAddress);
+
+        return blocks;
+    }
+
+    /// <summary>
+    /// Frees a used block of memory.
+    /// </summary>
+    /// <returns>Freed block to replace this block.</returns>
+    public XmsBlock Free() => new(0, Offset, Length, false, ByteReaderWriter, BaseAddress);
+
+    /// <summary>
+    /// Merges two contiguous unused blocks of memory.
+    /// </summary>
+    /// <param name="other">Other unused block to merge with.</param>
+    /// <returns>Merged block of memory.</returns>
+    public XmsBlock Join(XmsBlock other) {
+        if (IsUsed || other.IsUsed) {
+            throw new InvalidOperationException();
+        }
+        
+        if (Offset + Length != other.Offset) {
+            throw new ArgumentException($"{nameof(other)} could not be joined", nameof(other));
+        }
+
+        return new XmsBlock(0, Offset, Length + other.Length, false, ByteReaderWriter, BaseAddress);
+    }
+
+    public int Handle { get; init; }
+    public uint Offset { get; init; }
+    public uint Length { get; init; }
+    public bool IsUsed { get; init; }
+
+    public bool Equals(XmsBlock? other)
+    {
+        if (ReferenceEquals(null, other)) {
+            return false;
+        }
+
+        if (ReferenceEquals(this, other)) {
+            return true;
+        }
+
+        return Handle == other.Handle && Offset == other.Offset && Length == other.Length && IsUsed == other.IsUsed;
+    }
+}

--- a/src/Spice86.Core/Emulator/InterruptHandlers/Dos/Xms/XmsHandlerFunctions.cs
+++ b/src/Spice86.Core/Emulator/InterruptHandlers/Dos/Xms/XmsHandlerFunctions.cs
@@ -1,0 +1,7 @@
+namespace Spice86.Core.Emulator.InterruptHandlers.Dos.Xms; 
+
+public static class XmsHandlerFunctions
+{
+    public const byte InstallationCheck = 0x00;
+    public const byte GetCallbackAddress = 0x10;
+}

--- a/src/Spice86.Core/Emulator/InterruptHandlers/Dos/Xms/XmsMoveData.cs
+++ b/src/Spice86.Core/Emulator/InterruptHandlers/Dos/Xms/XmsMoveData.cs
@@ -1,0 +1,49 @@
+﻿namespace Spice86.Core.Emulator.InterruptHandlers.Dos.Xms;
+
+using Spice86.Core.Emulator.Memory.ReaderWriter;
+using Spice86.Core.Emulator.ReverseEngineer.DataStructure;
+using Spice86.Shared.Emulator.Memory;
+
+/// <summary>
+/// In-memory structure with information about an XMS move request.
+/// </summary>
+public class XmsMoveData : MemoryBasedDataStructure {
+    /// <summary>
+    /// Number of bytes to move.
+    /// </summary>
+    public uint Length;
+
+    /// <summary>
+    /// Handle of source block; zero if moving from segment:offset pair.
+    /// </summary>
+    public ushort SourceHandle;
+
+    /// <summary>
+    /// Source offset as a 32-bit value or a segment:offset pair.
+    /// </summary>
+    public uint SourceOffset;
+
+    /// <summary>
+    /// Handle of destination block; zero if moving to segment:offset pair.
+    /// </summary>
+    public ushort DestHandle;
+
+    /// <summary>
+    /// Destination offset as a 32-bit value or a segment:offset pair.
+    /// </summary>
+    public uint DestOffset;
+
+    /// <summary>
+    /// Gets the source address as a segment:offset value.
+    /// </summary>
+    public SegmentedAddress SourceAddress => new((ushort)(SourceOffset >> 16), (ushort)SourceOffset);
+
+    /// <summary>
+    /// Gets the destination address as a segment:offset value.
+    /// </summary>
+    public SegmentedAddress DestAddress => new((ushort)(DestOffset >> 16), (ushort)DestOffset);
+
+    public XmsMoveData(IByteReaderWriter byteReaderWriter, uint baseAddress) : base(byteReaderWriter, baseAddress)
+    {
+    }
+}

--- a/src/Spice86.Core/Emulator/Memory/IMemory.cs
+++ b/src/Spice86.Core/Emulator/Memory/IMemory.cs
@@ -22,7 +22,7 @@ public interface IMemory : IIndexable, IByteReaderWriter, IDebuggableComponent {
     /// Represents the optional 20th address line suppression feature for legacy 8086 programs.
     /// </summary>
     A20Gate A20Gate { get; }
-
+    
     /// <summary>
     /// Gets a copy of the current memory state.
     /// </summary>

--- a/src/Spice86.Core/Emulator/Memory/Memory.cs
+++ b/src/Spice86.Core/Emulator/Memory/Memory.cs
@@ -6,7 +6,7 @@ using Spice86.Core.Emulator.Memory.Indexer;
 /// <summary>
 /// Represents the memory bus of the IBM PC.
 /// </summary>
-public class Memory : Indexable.Indexable, IMemory, IDebuggableComponent {
+public class Memory : Indexable.Indexable, IMemory {
     /// <inheritdoc/>
     public IMemoryDevice Ram { get; }
 
@@ -19,7 +19,7 @@ public class Memory : Indexable.Indexable, IMemory, IDebuggableComponent {
     /// Represents the optional 20th address line suppression feature for legacy 8086 programs.
     /// </summary>
     public A20Gate A20Gate { get; }
-
+    
     /// <summary>
     /// Instantiate a new memory bus.
     /// </summary>

--- a/src/Spice86.Core/Emulator/OperatingSystem/Dos.cs
+++ b/src/Spice86.Core/Emulator/OperatingSystem/Dos.cs
@@ -6,8 +6,10 @@ using Spice86.Core.Emulator.CPU;
 using Spice86.Core.Emulator.Devices.Input.Keyboard;
 using Spice86.Core.Emulator.Devices.Sound;
 using Spice86.Core.Emulator.Devices.Video;
+using Spice86.Core.Emulator.InterruptHandlers.Common.RoutineInstall;
 using Spice86.Core.Emulator.InterruptHandlers.Dos;
 using Spice86.Core.Emulator.InterruptHandlers.Dos.Ems;
+using Spice86.Core.Emulator.InterruptHandlers.Dos.Xms;
 using Spice86.Core.Emulator.InterruptHandlers.Input.Keyboard;
 using Spice86.Core.Emulator.Memory;
 using Spice86.Core.Emulator.OperatingSystem.Devices;
@@ -89,9 +91,14 @@ public class Dos {
     public EnvironmentVariables EnvironmentVariables { get; } = new EnvironmentVariables();
     
     /// <summary>
-    /// The EMS device driver.
+    /// The Expanded Memory driver.
     /// </summary>
-    public ExpandedMemoryManager? Ems { get; private set; }
+    public Emm? Ems { get; private set; }
+    
+    /// <summary>
+    /// The Extended Memory driver.
+    /// </summary>
+    public Xmm? Xms { get; private set; }
 
     /// <summary>
     /// Initializes a new instance.
@@ -118,7 +125,8 @@ public class Dos {
         DosInt2FHandler = new DosInt2fHandler(_memory, _cpu, _loggerService);
     }
 
-    internal void Initialize(IBlasterEnvVarProvider blasterEnvVarProvider, State state, bool enableEms) {
+    internal void Initialize(IBlasterEnvVarProvider blasterEnvVarProvider, bool enableEms,
+        bool enableXms, AssemblyRoutineInstaller assemblyRoutineInstaller) {
         if (_loggerService.IsEnabled(LogEventLevel.Verbose)) {
             _loggerService.Verbose("Initializing DOS");
         }
@@ -128,6 +136,11 @@ public class Dos {
 
         if (enableEms) {
             Ems = new(_memory, _cpu, this, _loggerService);
+        }
+
+        if (enableXms) {
+            Xms = new(_state, _loggerService);
+            AddDevice(Xms);
         }
     }
 

--- a/src/Spice86.Core/Emulator/OperatingSystem/Enums/DeviceAttributes.cs
+++ b/src/Spice86.Core/Emulator/OperatingSystem/Enums/DeviceAttributes.cs
@@ -31,6 +31,12 @@ public enum DeviceAttributes {
     Special = 0x10,
     
     /// <summary>
+    /// The device is not an IBM device.
+    /// </summary>
+    /// <remarks>This is from the HIMEM.SYS source code for MS-DOS 2.0 ans XMS 2.0</remarks>
+    NonIBM = 0b1010000000000000,
+    
+    /// <summary>
     /// The device is a FAT device.
     /// </summary>
     FatDevice = 0x2000,

--- a/src/Spice86.Core/Emulator/VM/Machine.cs
+++ b/src/Spice86.Core/Emulator/VM/Machine.cs
@@ -17,6 +17,7 @@ using Spice86.Core.Emulator.InterruptHandlers.Bios;
 using Spice86.Core.Emulator.InterruptHandlers.Common.Callback;
 using Spice86.Core.Emulator.InterruptHandlers.Common.MemoryWriter;
 using Spice86.Core.Emulator.InterruptHandlers.Common.RoutineInstall;
+using Spice86.Core.Emulator.InterruptHandlers.Dos.Xms;
 using Spice86.Core.Emulator.InterruptHandlers.Input.Keyboard;
 using Spice86.Core.Emulator.InterruptHandlers.Input.Mouse;
 using Spice86.Core.Emulator.InterruptHandlers.SystemClock;
@@ -193,7 +194,8 @@ public sealed class Machine : IDisposable, IDebuggableComponent {
     /// Initializes a new instance
     /// </summary>
     public Machine(IGui? gui, ILoggerService loggerService, CounterConfigurator counterConfigurator, ExecutionFlowRecorder executionFlowRecorder, Configuration configuration, bool recordData) {
-        Memory = new Memory(new Ram(A20Gate.EndOfHighMemoryArea), configuration.A20Gate);
+        const uint mainMemorySize = A20Gate.EndOfHighMemoryArea;
+        Memory = new Memory(new Ram(mainMemorySize), configuration.A20Gate);
         bool initializeResetVector = configuration.InitializeDOS is true;
         if (initializeResetVector) {
             // Put HLT instruction at the reset address
@@ -286,7 +288,7 @@ public sealed class Machine : IDisposable, IDebuggableComponent {
             RegisterInterruptHandler(Dos.DosInt2FHandler);
 
             // Initialize DOS.
-            Dos.Initialize(SoundBlaster, CpuState, configuration.Ems);
+            Dos.Initialize(SoundBlaster, configuration.Ems, configuration.Xms, AssemblyRoutineInstaller);
             if (Dos.Ems is not null) {
                 RegisterInterruptHandler(Dos.Ems);
             }


### PR DESCRIPTION
Fixes #245 

**CREDITS: This is ported from the [Aeon emulator](https://github.com/gregdivis/Aeon) by @gregdivis**

This is a partial implementation of [XMS 3.0](https://www.phatcode.net/res/219/files/xms30.txt). 

_Dune_ works well with this. But if you enable XMS with Dune, it only uses the BIOS function "COPY EXTENDED MEMORY" (0x87) .

Command line arguments to enable XMS mode in Dune:

```
XMS000
```

For example with sound and music:

```
ADL SBP2227 XMS000
```

I also tested _Lost Eden_, but it also only uses the BIOS' support for XMS memory.

One game for which XMS could be tested if it worked would be [_LIERO_](http://liero.be/) :

```

Minimum:  386SX
VGA video card + monitor
560kB free conventional memory


Recommended:  486 or better
VGA video card + monitor
560kB free conventional memory
Sound Blaster or 100% compatible sound card
760kB free XMS memory for sound effects
```

Here is the error that it gives:

```
{
  "TargetSite": "Void ExecOpcode(Byte)",
  "Message": "An error occurred while machine was in this state: Cycles=560 CS:IP=0x24DD:0x302B/0x27DFB EAX=0xFF01 EBX=0x7B40 ECX=0x0 EDX=0x1330 ESI=0x264 EDI=0x0 EBP=0x0 ESP=0xFFEA SS=0x3127 DS=0x2971 ES=0x4C42 FS=0x0 GS=0x0 flags=0x7246 (  I  Z P ).\nError is: Invalid group index 0x5",
  "StackTrace": "   at void Spice86.Core.Emulator.CPU.Cpu.ExecOpcode(byte opcode) in /home/max/source/repos/Spice86/src/Spice86.Core/Emulator/CPU/CPU.cs:line 873\n   at void Spice86.Core.Emulator.CPU.Cpu.ExecuteNextInstruction() in /home/max/source/repos/Spice86/src/Spice86.Core/Emulator/CPU/CPU.cs:line 110\n   at void Spice86.Core.Emulator.VM.EmulationLoop.RunLoop() in /home/max/source/repos/Spice86/src/Spice86.Core/Emulator/VM/EmulationLoop.cs:line 105\n   at void Spice86.Core.Emulator.VM.EmulationLoop.StartRunLoop(FunctionHandler functionHandler) in /home/max/source/repos/Spice86/src/Spice86.Core/Emulator/VM/EmulationLoop.cs:line 95\n   at void Spice86.Core.Emulator.VM.EmulationLoop.Run() in /home/max/source/repos/Spice86/src/Spice86.Core/Emulator/VM/EmulationLoop.cs:line 68\n   at void Spice86.Core.Emulator.ProgramExecutor.Run() in /home/max/source/repos/Spice86/src/Spice86.Core/Emulator/ProgramExecutor.cs:line 62\n   at void Spice86.ViewModels.MainWindowViewModel.StartProgramExecutor() in /home/max/source/repos/Spice86/src/Spice86/ViewModels/MainWindowViewModel.cs:line 602\n   at void Spice86.ViewModels.MainWindowViewModel.MachineThread() in /home/max/source/repos/Spice86/src/Spice86/ViewModels/MainWindowViewModel.cs:line 581"
}
```

The _LIERO_ level editor already works, but it doesn't use XMS.

Documented games known for their use of XMS:
- Theme Park (could not start up)
- Doom (could not start up)
- A lot of other games...

This is a draft, as a working game that requires a XMS driver (NOT the BIOS level XMS functions) needs to be found first.

Also, some more functions defined in the XMS specs could be implemented. This is the second reason why this is a draft.