### PR TITLE
Move to .NET 8

### DIFF
--- a/.github/workflows/autorelease.yml
+++ b/.github/workflows/autorelease.yml
@@ -16,7 +16,7 @@ jobs:
        - name: Setup .NET
          uses: actions/setup-dotnet@v1
          with:
-           dotnet-version: '7.0.x'
+           dotnet-version: '8.0.x'
 
        - name: Install zip
          uses: montudor/action-zip@v1

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -66,8 +66,9 @@ jobs:
     #   If the Autobuild fails above, remove it and uncomment the following three lines.
     #   modify them (or add more) to build your code if your project, please refer to the EXAMPLE below for guidance.
 
-    - name: Autobuild
-      uses: github/codeql-action/autobuild@v2
+    - run: |
+        echo "running custom build action..."
+        dotnet build ./src/Spice86.sln
 
     - name: Perform CodeQL Analysis
       uses: github/codeql-action/analyze@v2

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -66,6 +66,11 @@ jobs:
     #   If the Autobuild fails above, remove it and uncomment the following three lines.
     #   modify them (or add more) to build your code if your project, please refer to the EXAMPLE below for guidance.
 
+    - name: Setup .NET
+      uses: actions/setup-dotnet@v1
+      with:
+        dotnet-version: '8.0.x'
+
     - run: |
         echo "running custom build action..."
         dotnet build ./src/Spice86.sln

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -66,9 +66,8 @@ jobs:
     #   If the Autobuild fails above, remove it and uncomment the following three lines.
     #   modify them (or add more) to build your code if your project, please refer to the EXAMPLE below for guidance.
 
-    - run: |
-        echo "running custom build action..."
-        dotnet build ./src/Spice86.sln
+    - name: Autobuild
+      uses: github/codeql-action/autobuild@v2
 
     - name: Perform CodeQL Analysis
       uses: github/codeql-action/analyze@v2

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -19,7 +19,7 @@ jobs:
     - name: Setup .NET
       uses: actions/setup-dotnet@v1
       with:
-        dotnet-version: '7.0.x'
+        dotnet-version: '8.0.x'
 
     - name: Test with dotnet
       working-directory: ./src

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Pre-releases are also available [on the Release page](https://github.com/OpenRak
 
 NOTE: This is a port, and a continuation from the [original Java Spice86](https://github.com/kevinferrare/spice86).
 
-It requires [.NET 7](https://dotnet.microsoft.com/en-us/download/dotnet/7.0) and runs on Windows, macOS, and Linux.
+It requires [.NET 8](https://dotnet.microsoft.com/en-us/download/dotnet/8.0) and runs on Windows, macOS, and Linux.
 
 ## Approach
 Rewriting a program from only the binary is a hard task.

--- a/src/Bufdio.Spice86/Bindings/PortAudio/Structs/PaStreamParameters.cs
+++ b/src/Bufdio.Spice86/Bindings/PortAudio/Structs/PaStreamParameters.cs
@@ -6,11 +6,11 @@ using System.Runtime.InteropServices;
 using Bufdio.Spice86.Bindings.PortAudio.Enums;
 
 [StructLayout(LayoutKind.Sequential)]
-internal record struct PaStreamParameters
+internal readonly record struct PaStreamParameters
 {
-    public int device;
-    public int channelCount;
-    public PaSampleFormat sampleFormat;
-    public double suggestedLatency;
-    public IntPtr hostApiSpecificStreamInfo;
+    public readonly int Device { get; init; }
+    public readonly int ChannelCount { get; init; }
+    public readonly PaSampleFormat SampleFormat { get; init; }
+    public readonly double SuggestedLatency { get; init; }
+    public readonly IntPtr HostApiSpecificStreamInfo { get; init; }
 }

--- a/src/Bufdio.Spice86/Bufdio.Spice86.csproj
+++ b/src/Bufdio.Spice86/Bufdio.Spice86.csproj
@@ -5,7 +5,7 @@
     <RootNamespace>Bufdio.Spice86</RootNamespace>
     <Copyright>Luthfi Tri Atmaja</Copyright>
     <Description>Only for Spice86 usage. A cross platform audio playback library for .NET based on PortAudio, forked from the original Bufdio by Luthfi Tri Atmaja.</Description>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <Nullable>enable</Nullable>
     <WarningsAsErrors>nullable</WarningsAsErrors>
   </PropertyGroup>

--- a/src/Bufdio.Spice86/Engines/IAudioEngine.cs
+++ b/src/Bufdio.Spice86/Engines/IAudioEngine.cs
@@ -3,13 +3,13 @@
 using System;
 
 /// <summary>
-/// An interface to interact with output audio device.
+/// An interface to interact with the output audio device.
 /// <para>Implements: <see cref="IDisposable"/>.</para>
 /// </summary>
 public interface IAudioEngine : IDisposable
 {
     /// <summary>
-    /// Sends audio samples to the output device (this should be a blocking calls).
+    /// Sends audio samples to the output device.
     /// </summary>
     /// <param name="samples">Audio samples in <c>Float32</c> format.</param>
     void Send(Span<float> samples);

--- a/src/Bufdio.Spice86/Engines/PortAudioEngine.cs
+++ b/src/Bufdio.Spice86/Engines/PortAudioEngine.cs
@@ -10,7 +10,7 @@ using Bufdio.Spice86.Exceptions;
 using Bufdio.Spice86.Utilities.Extensions;
 
 /// <summary>
-/// Interact with output audio device by using PortAudio library.
+/// Interact with output audio device by using the PortAudio library.
 /// This class cannot be inherited.
 /// <para>Implements: <see cref="IAudioEngine"/>.</para>
 /// </summary>

--- a/src/Bufdio.Spice86/Engines/PortAudioEngine.cs
+++ b/src/Bufdio.Spice86/Engines/PortAudioEngine.cs
@@ -31,12 +31,12 @@ public sealed class PortAudioEngine : IAudioEngine {
     public PortAudioEngine(int framesPerBuffer, AudioEngineOptions? options = default) {
         _options = options ?? new AudioEngineOptions();
 
-        PaStreamParameters parameters = new PaStreamParameters {
-            channelCount = _options.Channels,
-            device = _options.DefaultAudioDevice.DeviceIndex,
-            hostApiSpecificStreamInfo = IntPtr.Zero,
-            sampleFormat = (PaSampleFormat)PortAudioLib.Constants.PaSampleFormat,
-            suggestedLatency = _options.Latency
+        PaStreamParameters parameters = new() {
+            ChannelCount = _options.Channels,
+            Device = _options.DefaultAudioDevice.DeviceIndex,
+            HostApiSpecificStreamInfo = IntPtr.Zero,
+            SampleFormat = (PaSampleFormat)PortAudioLib.Constants.PaSampleFormat,
+            SuggestedLatency = _options.Latency
         };
 
         IntPtr stream;

--- a/src/Spice86.Core/Spice86.Core.csproj
+++ b/src/Spice86.Core/Spice86.Core.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<TargetFramework>net7.0</TargetFramework>
+		<TargetFramework>net8.0</TargetFramework>
 		<ImplicitUsings>enable</ImplicitUsings>
 		<Nullable>enable</Nullable>
 		<WarningsAsErrors>nullable</WarningsAsErrors>

--- a/src/Spice86.Logging/Spice86.Logging.csproj
+++ b/src/Spice86.Logging/Spice86.Logging.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <WarningsAsErrors>Nullable</WarningsAsErrors>

--- a/src/Spice86.Shared/Emulator/Errors/UnrecoverableException.cs
+++ b/src/Spice86.Shared/Emulator/Errors/UnrecoverableException.cs
@@ -5,7 +5,6 @@ using System;
 /// <summary>
 /// Exception thrown when an unrecoverable error occurs and the emulator cannot continue normal operation.
 /// </summary>
-[Serializable]
 public class UnrecoverableException : Exception {
     /// <summary>
     /// Initializes a new instance of the UnrecoverableException class.
@@ -27,13 +26,4 @@ public class UnrecoverableException : Exception {
     /// <param name="inner">The exception that is the cause of the current exception, or a null reference if no inner exception is specified.</param>
     public UnrecoverableException(string message, Exception inner) : base(message, inner) {
     }
-
-    /// <summary>
-    /// Initializes a new instance of the UnrecoverableException class with serialized data.
-    /// </summary>
-    /// <param name="info">The SerializationInfo that holds the serialized object data about the exception being thrown.</param>
-    /// <param name="context">The StreamingContext that contains contextual information about the source or destination.</param>
-    protected UnrecoverableException(
-      System.Runtime.Serialization.SerializationInfo info,
-      System.Runtime.Serialization.StreamingContext context) : base(info, context) { }
 }

--- a/src/Spice86.Shared/Emulator/Memory/SegmentedAddress.cs
+++ b/src/Spice86.Shared/Emulator/Memory/SegmentedAddress.cs
@@ -115,7 +115,11 @@ public class SegmentedAddress : IComparable<SegmentedAddress> {
     public override string ToString() {
         return $"{ToSegmentOffsetRepresentation()}/{ConvertUtils.ToHex(ToPhysical())}";
     }
-    
+
+    /// <summary>
+    /// Converts the SegmentedAddress object to a string in segment:offset/hex-physical format.
+    /// </summary>
+    /// <returns>A string representation of the SegmentedAddress object, or "null" if input was <c>null</c>.</returns>
     public static string ToString(SegmentedAddress? segmentedAddress) {
         if (segmentedAddress is not null) {
             return segmentedAddress.ToString();

--- a/src/Spice86.Shared/Spice86.Shared.csproj
+++ b/src/Spice86.Shared/Spice86.Shared.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<TargetFramework>net7.0</TargetFramework>
+		<TargetFramework>net8.0</TargetFramework>
 		<ImplicitUsings>enable</ImplicitUsings>
 		<Nullable>enable</Nullable>
 		<WarningsAsErrors>Nullable</WarningsAsErrors>

--- a/src/Spice86/Spice86.csproj
+++ b/src/Spice86/Spice86.csproj
@@ -2,7 +2,7 @@
 
 	<PropertyGroup>
 		<OutputType>Exe</OutputType>
-		<TargetFramework>net7.0</TargetFramework>
+		<TargetFramework>net8.0</TargetFramework>
 		<Nullable>enable</Nullable>
 		<WarningsAsErrors>nullable</WarningsAsErrors>
 		<ImplicitUsings>enable</ImplicitUsings>
@@ -30,7 +30,7 @@
 	</PropertyGroup>
 	<ItemGroup>
 		<Content Include="libportaudio.dll">
-			<PackagePath>lib\net7.0\libportaudio.dll</PackagePath>
+			<PackagePath>lib\net8.0\libportaudio.dll</PackagePath>
 			<CopyToOutputDirectory>Always</CopyToOutputDirectory>
 			<Pack>True</Pack>
 		</Content>

--- a/tests/Spice86.Tests/Spice86.Tests.csproj
+++ b/tests/Spice86.Tests/Spice86.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-	<TargetFramework>net7.0</TargetFramework>
+	<TargetFramework>net8.0</TargetFramework>
 	<Nullable>enable</Nullable>
 	<ImplicitUsings>enable</ImplicitUsings>
 	<WarningsAsErrors>nullable</WarningsAsErrors>


### PR DESCRIPTION
### Description of Changes

Upgrades Spcie86 to the latest .NET 8 SDK, released today.

.NET 8 is the new LTS.

### Rationale behind Changes

6 months from now, .NET 7 will be out of support (EOL).

### Suggested Testing Steps

Test this with your favorite game, if need be. No regressions are expected.