### PR TITLE
Introduce FrozenDictionnary/Set for most lookup tables

### DIFF
--- a/src/Spice86.Core/Emulator/Devices/Sound/SoundBlaster.cs
+++ b/src/Spice86.Core/Emulator/Devices/Sound/SoundBlaster.cs
@@ -1,5 +1,6 @@
 ﻿namespace Spice86.Core.Emulator.Devices.Sound;
 
+using System.Collections.Frozen;
 using System.Threading;
 
 using Serilog.Events;
@@ -91,26 +92,26 @@ public sealed class SoundBlaster : DefaultIOPortHandler, IDmaDevice8, IDmaDevice
 
     private bool _disposed;
 
-    private static readonly SortedList<byte, byte> CommandLengths = new() {
-        [Commands.SetTimeConstant] = 1,
-        [Commands.SingleCycleDmaOutput8] = 2,
-        [Commands.DspIdentification] = 1,
-        [Commands.SetBlockTransferSize] = 2,
-        [Commands.SetSampleRate] = 2,
-        [Commands.SetInputSampleRate] = 2,
-        [Commands.SingleCycleDmaOutput16] = 3,
-        [Commands.AutoInitDmaOutput16] = 3,
-        [Commands.SingleCycleDmaOutput16Fifo] = 3,
-        [Commands.AutoInitDmaOutput16Fifo] = 3,
-        [Commands.SingleCycleDmaOutput8_Alt] = 3,
-        [Commands.AutoInitDmaOutput8_Alt] = 3,
-        [Commands.SingleCycleDmaOutput8Fifo_Alt] = 3,
-        [Commands.AutoInitDmaOutput8Fifo_Alt] = 3,
-        [Commands.PauseForDuration] = 2,
-        [Commands.SingleCycleDmaOutputADPCM4Ref] = 2,
-        [Commands.SingleCycleDmaOutputADPCM2Ref] = 2,
-        [Commands.SingleCycleDmaOutputADPCM3Ref] = 2
-    };
+    private static readonly FrozenDictionary<byte, byte> CommandLengths = new Dictionary<byte, byte>() {
+        {Commands.SetTimeConstant, 1},
+        {Commands.SingleCycleDmaOutput8, 2},
+        {Commands.DspIdentification, 1},
+        {Commands.SetBlockTransferSize, 2},
+        {Commands.SetSampleRate, 2},
+        {Commands.SetInputSampleRate, 2},
+        {Commands.SingleCycleDmaOutput16, 3},
+        {Commands.AutoInitDmaOutput16, 3},
+        {Commands.SingleCycleDmaOutput16Fifo, 3},
+        {Commands.AutoInitDmaOutput16Fifo, 3},
+        {Commands.SingleCycleDmaOutput8_Alt, 3},
+        {Commands.AutoInitDmaOutput8_Alt, 3},
+        {Commands.SingleCycleDmaOutput8Fifo_Alt, 3},
+        {Commands.AutoInitDmaOutput8Fifo_Alt, 3},
+        {Commands.PauseForDuration, 2},
+        {Commands.SingleCycleDmaOutputADPCM4Ref, 2},
+        {Commands.SingleCycleDmaOutputADPCM2Ref, 2},
+        {Commands.SingleCycleDmaOutputADPCM3Ref, 2}
+    }.ToFrozenDictionary();
 
     private readonly List<byte> _commandData = new();
     private readonly int _dma16;
@@ -152,7 +153,7 @@ public sealed class SoundBlaster : DefaultIOPortHandler, IDmaDevice8, IDmaDevice
         _dualPic = dualPic;
         _mixer = new Mixer(this);
         _eightByteDmaChannel = _dmaController.Channels[soundBlasterHardwareConfig.LowDma];
-        _dsp = new Dsp(_eightByteDmaChannel, _dmaController.Channels[soundBlasterHardwareConfig.HighDma], this, DMA, _dma16);
+        _dsp = new Dsp(_eightByteDmaChannel, _dmaController.Channels[soundBlasterHardwareConfig.HighDma], this);
         _playbackThread = new Thread(AudioPlayback) {
             Name = "PCMAudio",
         };
@@ -256,7 +257,7 @@ public sealed class SoundBlaster : DefaultIOPortHandler, IDmaDevice8, IDmaDevice
     /// <summary>
     /// The list of input ports.
     /// </summary>
-    public IEnumerable<int> InputPorts => new int[] { DspPorts.DspReadData, DspPorts.DspWrite, DspPorts.DspReadBufferStatus, DspPorts.MixerAddress, DspPorts.MixerData };
+    public FrozenSet<int> InputPorts => new int[] { DspPorts.DspReadData, DspPorts.DspWrite, DspPorts.DspReadBufferStatus, DspPorts.MixerAddress, DspPorts.MixerData }.ToFrozenSet();
 
     /// <summary>
     /// Gets the hardware IRQ assigned to the device.
@@ -266,7 +267,7 @@ public sealed class SoundBlaster : DefaultIOPortHandler, IDmaDevice8, IDmaDevice
     /// <summary>
     /// The list of output ports.
     /// </summary>
-    public IEnumerable<int> OutputPorts => new int[] { DspPorts.DspReset, DspPorts.DspWrite, DspPorts.MixerAddress };
+    public FrozenSet<int> OutputPorts => new int[] { DspPorts.DspReset, DspPorts.DspWrite, DspPorts.MixerAddress }.ToFrozenSet();
 
     /// <inheritdoc />
     public void Dispose() {

--- a/src/Spice86.Core/Emulator/Devices/Sound/Ym7128b/YM7128B.cs
+++ b/src/Spice86.Core/Emulator/Devices/Sound/Ym7128b/YM7128B.cs
@@ -2,6 +2,7 @@
 namespace Spice86.Core.Emulator.Devices.Sound.Ym7128b;
 
 using System;
+using System.Collections.Frozen;
 using System.Collections.ObjectModel;
 using System.Diagnostics.Contracts;
 
@@ -11,7 +12,7 @@ public static class Ym7128B {
 
     public const string Version = "0.1.1";
 
-    static readonly ReadOnlyCollection<sbyte> GainDecibelTable = Array.AsReadOnly(new sbyte[]
+    static readonly FrozenSet<sbyte> GainDecibelTable = new sbyte[]
     {
     -128,  //  0 = -oo
     - 60,  //  1
@@ -45,11 +46,11 @@ public static class Ym7128B {
     -  4,  // 29
     -  2,  // 30
        0   // 31
-});
+}.ToFrozenSet();
 
     private static int GainFixed(double real) => (short)(real * (int)ImplementationSpecs.GainMax) & unchecked((short)ImplementationSpecs.GainMask);
 
-    static readonly ReadOnlyCollection<short> GainFixedTable = Array.AsReadOnly(new[]
+    static readonly FrozenSet<short> GainFixedTable = new short[]
 {
     // Pseudo-negative gains
     (short)~GainFixed(0.000000000000000000),  // -oo dB-
@@ -118,8 +119,9 @@ public static class Ym7128B {
     (short)+GainFixed(0.630957344480193250),  // - 4 dB(short)+
     (short)+GainFixed(0.794328234724281490),  // - 2 dB(short)+
     (short)+GainFixed(1.000000000000000000)   // - 0 dB+
-});
-    static readonly ReadOnlyCollection<double> GainFloatTable = Array.AsReadOnly(new[]
+}.ToFrozenSet();
+
+    static readonly FrozenSet<double> GainFloatTable = new double[]
 {
     // Negative gains
     -0.000000000000000000,  // -oo dB-
@@ -188,11 +190,11 @@ public static class Ym7128B {
     +0.630957344480193250,  // - 4 dB+
     +0.794328234724281490,  // - 2 dB+
     +1.000000000000000000   // - 0 dB+
-});
+}.ToFrozenSet();
 
     private static short GainShort(double real) => (short)(real * (int)ImplementationSpecs.GainMax);
 
-    static readonly ReadOnlyCollection<short> GainShortTable = Array.AsReadOnly(new[]
+    static readonly FrozenSet<short> GainShortTable = new short[]
     {
         // Negative gains
         (short)-GainShort(0.000000000000000000),  // -oo dB-
@@ -261,11 +263,11 @@ public static class Ym7128B {
         (short)+GainShort(0.630957344480193250),  // - 4 dB(short)+
         (short)+GainShort(0.794328234724281490),  // - 2 dB(short)+
         (short)+GainShort(1.000000000000000000)   // - 0 dB(short)+
-    });
+    }.ToFrozenSet();
 
     private static ushort Tap(int index) => (ushort)(index * ((int)DatasheetSpecs.BufferLength - 1) / ((int)DatasheetSpecs.TapValueCount - 1));
 
-    static readonly ReadOnlyCollection<ushort> TapTable = Array.AsReadOnly(new[]
+    static readonly FrozenSet<ushort> TapTable = new ushort[]
 {
     Tap( 0),  //   0.0 ms
     Tap( 1),  //   3.2 ms
@@ -299,15 +301,15 @@ public static class Ym7128B {
     Tap(29),  //  93.6 ms
     Tap(30),  //  96.8 ms
     Tap(31)   // 100.0 ms
-});
+}.ToFrozenSet();
 
     private static short Kernel(double real) {
         unchecked {
-            return ((short)(((short)real) * ((short)ImplementationSpecs.FixedMax) & ((short)ImplementationSpecs.CoeffMask)));
+            return (short)(((short)real) * ((short)ImplementationSpecs.FixedMax) & ((short)ImplementationSpecs.CoeffMask));
         }
     }
 
-    static readonly ReadOnlyCollection<short> OversamplerFixedKernelTable = Array.AsReadOnly(new[]
+    static readonly FrozenSet<short> OversamplerFixedKernelTable = new short[]
 {
 #if YM7128B_USE_MINPHASE
     // minimum phase
@@ -352,7 +354,7 @@ public static class Ym7128B {
     Kernel(-0.003826518613910499),
     Kernel(+0.005969087803865891)
 #endif
-});
+}.ToFrozenSet();
 
     public static short OversamplerFixedProcess(
         ref OversamplerFixed self,
@@ -362,7 +364,7 @@ public static class Ym7128B {
             short sample = self.Buffer[i];
             self.Buffer[i] = input;
             input = sample;
-            short kernel = OversamplerFixedKernelTable[i];
+            short kernel = OversamplerFixedKernelTable.Items[i];
             short oversampled = MulFixed(sample, kernel);
             accum += oversampled;
         }
@@ -583,7 +585,7 @@ public static class Ym7128B {
 
     public static ushort RegisterToTap(byte data) {
         byte i = (byte)(data & (int)DatasheetSpecs.TapValueMask);
-        ushort t = TapTable[i];
+        ushort t = TapTable.Items[i];
         return t;
     }
 
@@ -598,19 +600,19 @@ public static class Ym7128B {
 
     private static short RegisterToGainFixed(byte data) {
         byte i = (byte)(data & (int)DatasheetSpecs.GainDataMask);
-        short g = GainFixedTable[i];
+        short g = GainFixedTable.Items[i];
         return g;
     }
 
     private static double RegisterToGainFloat(byte data) {
         byte i = (byte)(data & (int)DatasheetSpecs.GainDataMask);
-        double g = GainFloatTable[i];
+        double g = GainFloatTable.Items[i];
         return g;
     }
 
     private static short RegisterToGainShort(byte data) {
         byte i = (byte)(data & (int)DatasheetSpecs.GainDataMask);
-        short g = GainShortTable[i];
+        short g = GainShortTable.Items[i];
         return g;
     }
 

--- a/src/Spice86.Core/Emulator/Devices/Timer/Counter.cs
+++ b/src/Spice86.Core/Emulator/Devices/Timer/Counter.cs
@@ -60,9 +60,8 @@ public class Counter {
     /// <summary>
     /// TODO: Use <paramref name="currentCycles"/>
     /// </summary>
-    /// <param name="currentCycles"></param>
-    /// <returns></returns>
-    public bool ProcessActivation(long currentCycles) {
+    /// <returns>Whether the activation was processed.</returns>
+    public bool ProcessActivation() {
         if (Activator.IsActivated) {
             Ticks--;
             return true;

--- a/src/Spice86.Core/Emulator/Devices/Timer/Counter.cs
+++ b/src/Spice86.Core/Emulator/Devices/Timer/Counter.cs
@@ -1,13 +1,9 @@
-﻿using Spice86.Logging;
-using Spice86.Shared.Interfaces;
+﻿using Spice86.Shared.Interfaces;
 
 namespace Spice86.Core.Emulator.Devices.Timer;
 
-using Serilog;
-
 using Spice86.Core.Emulator.CPU;
 using Spice86.Core.Emulator.Errors;
-using Spice86.Core.Emulator.VM;
 using Spice86.Shared.Utils;
 
 public class Counter {

--- a/src/Spice86.Core/Emulator/Devices/Timer/Timer.cs
+++ b/src/Spice86.Core/Emulator/Devices/Timer/Timer.cs
@@ -114,12 +114,11 @@ public class Timer : DefaultIOPortHandler, ITimeMultiplier {
     }
 
     public void Tick() {
-        long cycles = _state.Cycles;
-        if (_counters[0].ProcessActivation(cycles)) {
+        if (_counters[0].ProcessActivation()) {
             _dualPic.ProcessInterruptRequest(0);
         }
 
-        if (_vgaScreenRefreshCounter.ProcessActivation(cycles)) {
+        if (_vgaScreenRefreshCounter.ProcessActivation()) {
             _vgaCard?.UpdateScreen();
         }
     }

--- a/src/Spice86.Core/Emulator/Function/Dump/ExecutionFlowDumper.cs
+++ b/src/Spice86.Core/Emulator/Function/Dump/ExecutionFlowDumper.cs
@@ -1,15 +1,14 @@
 ﻿namespace Spice86.Core.Emulator.Function.Dump;
 
-using System.Diagnostics;
-using System.IO;
-
-using System.Text.Json;
 using Serilog.Events;
 
 using Spice86.Core.Emulator.Function;
-using Spice86.Core.Emulator.Memory;
 using Spice86.Shared.Emulator.Errors;
 using Spice86.Shared.Interfaces;
+
+using System.Diagnostics;
+using System.IO;
+using System.Text.Json;
 
 /// <summary>
 /// Provides functionality for dumping and reading execution flow data to and from a file.

--- a/src/Spice86.Core/Emulator/InterruptHandlers/Bios/BiosEquipmentDeterminationInt11Handler.cs
+++ b/src/Spice86.Core/Emulator/InterruptHandlers/Bios/BiosEquipmentDeterminationInt11Handler.cs
@@ -3,7 +3,6 @@
 using Spice86.Core.Emulator.CPU;
 using Spice86.Core.Emulator.InterruptHandlers;
 using Spice86.Core.Emulator.Memory;
-using Spice86.Core.Emulator.VM;
 using Spice86.Shared.Interfaces;
 
 /// <summary>

--- a/src/Spice86.Core/Emulator/InterruptHandlers/Bios/SystemBiosInt15Handler.cs
+++ b/src/Spice86.Core/Emulator/InterruptHandlers/Bios/SystemBiosInt15Handler.cs
@@ -5,7 +5,6 @@ using Serilog.Events;
 using Spice86.Core.Emulator.CPU;
 using Spice86.Core.Emulator.InterruptHandlers;
 using Spice86.Core.Emulator.Memory;
-using Spice86.Core.Emulator.VM;
 using Spice86.Shared.Interfaces;
 
 /// <summary>

--- a/src/Spice86.Core/Emulator/InterruptHandlers/Common/IndexBasedDispatcher/IndexBasedDispatcher.cs
+++ b/src/Spice86.Core/Emulator/InterruptHandlers/Common/IndexBasedDispatcher/IndexBasedDispatcher.cs
@@ -2,11 +2,7 @@ namespace Spice86.Core.Emulator.InterruptHandlers.Common.IndexBasedDispatcher;
 
 using Spice86.Core.Emulator.CPU;
 using Spice86.Core.Emulator.Errors;
-using Spice86.Core.Emulator.VM;
 using Spice86.Shared.Interfaces;
-
-using System.Collections;
-using System.Linq;
 
 /// <summary>
 /// Base class for most classes having to dispatch operations depending on a numeric value, like interrupts.

--- a/src/Spice86.Core/Emulator/InterruptHandlers/Common/MemoryWriter/MemoryAsmWriter.cs
+++ b/src/Spice86.Core/Emulator/InterruptHandlers/Common/MemoryWriter/MemoryAsmWriter.cs
@@ -1,9 +1,7 @@
 namespace Spice86.Core.Emulator.InterruptHandlers.Common.MemoryWriter;
 
 using Spice86.Core.Emulator.InterruptHandlers.Common.Callback;
-using Spice86.Core.Emulator.Memory;
 using Spice86.Core.Emulator.Memory.Indexable;
-using Spice86.Core.Emulator.Memory.Indexer;
 using Spice86.Shared.Emulator.Errors;
 using Spice86.Shared.Emulator.Memory;
 

--- a/src/Spice86.Core/Emulator/InterruptHandlers/Dos/DosInt21Handler.cs
+++ b/src/Spice86.Core/Emulator/InterruptHandlers/Dos/DosInt21Handler.cs
@@ -4,14 +4,14 @@ using Serilog.Events;
 
 using Spice86.Core.Emulator.CPU;
 using Spice86.Core.Emulator.Devices.Video;
-using Spice86.Core.Emulator.OperatingSystem;
 using Spice86.Core.Emulator.Errors;
 using Spice86.Core.Emulator.InterruptHandlers;
 using Spice86.Core.Emulator.InterruptHandlers.Input.Keyboard;
 using Spice86.Core.Emulator.Memory;
+using Spice86.Core.Emulator.OperatingSystem;
 using Spice86.Core.Emulator.OperatingSystem.Devices;
+using Spice86.Core.Emulator.OperatingSystem.Enums;
 using Spice86.Core.Emulator.OperatingSystem.Structures;
-using Spice86.Core.Emulator.VM;
 using Spice86.Shared.Interfaces;
 using Spice86.Shared.Utils;
 
@@ -19,8 +19,6 @@ using System;
 using System.IO;
 using System.Linq;
 using System.Text;
-using Spice86.Core.Emulator.Memory.Indexable;
-using Spice86.Core.Emulator.OperatingSystem.Enums;
 
 /// <summary>
 /// Implements the DOS interrupt dispatcher

--- a/src/Spice86.Core/Emulator/InterruptHandlers/Dos/DosInt2fHandler.cs
+++ b/src/Spice86.Core/Emulator/InterruptHandlers/Dos/DosInt2fHandler.cs
@@ -1,13 +1,11 @@
 namespace Spice86.Core.Emulator.InterruptHandlers.Dos;
 
-using Spice86.Shared.Interfaces;
-
 using Serilog.Events;
 
 using Spice86.Core.Emulator.CPU;
 using Spice86.Core.Emulator.InterruptHandlers;
 using Spice86.Core.Emulator.Memory;
-using Spice86.Core.Emulator.VM;
+using Spice86.Shared.Interfaces;
 using Spice86.Shared.Utils;
 
 /// <summary>

--- a/src/Spice86.Core/Emulator/InterruptHandlers/Input/Mouse/MouseInt33Handler.cs
+++ b/src/Spice86.Core/Emulator/InterruptHandlers/Input/Mouse/MouseInt33Handler.cs
@@ -5,7 +5,6 @@ using Serilog.Events;
 using Spice86.Core.Emulator.CPU;
 using Spice86.Core.Emulator.Devices.Input.Mouse;
 using Spice86.Core.Emulator.Memory;
-using Spice86.Core.Emulator.VM;
 using Spice86.Shared.Interfaces;
 
 /// <summary>

--- a/src/Spice86.Core/Emulator/InterruptHandlers/Timer/TimerInt8Handler.cs
+++ b/src/Spice86.Core/Emulator/InterruptHandlers/Timer/TimerInt8Handler.cs
@@ -5,7 +5,6 @@ using Spice86.Core.Emulator.Devices.ExternalInput;
 using Spice86.Core.Emulator.Devices.Timer;
 using Spice86.Core.Emulator.InterruptHandlers;
 using Spice86.Core.Emulator.Memory;
-using Spice86.Core.Emulator.VM;
 using Spice86.Shared.Interfaces;
 
 /// <summary>
@@ -19,7 +18,6 @@ public class TimerInt8Handler : InterruptHandler {
     /// <summary>
     /// Initializes a new instance.
     /// </summary>
-    /// <param name="machine">The emulator machine.</param>
     /// <param name="biosDataArea">The memory mapped BIOS values.</param>
     /// <param name="loggerService">The logger service implementation.</param>
     /// <param name="memory">The memory bus.</param>

--- a/src/Spice86.Core/Emulator/InterruptHandlers/VGA/Records/CharacterPlusAttribute.cs
+++ b/src/Spice86.Core/Emulator/InterruptHandlers/VGA/Records/CharacterPlusAttribute.cs
@@ -6,4 +6,4 @@ namespace Spice86.Core.Emulator.InterruptHandlers.VGA.Records;
 /// <param name="Character">The ASCII code of a character</param>
 /// <param name="Attribute">The byte that describes color, blinking and charset</param>
 /// <param name="UseAttribute">Whether or not the attribute needs to be used</param>
-public record struct CharacterPlusAttribute(char Character, byte Attribute, bool UseAttribute);
+public readonly record struct CharacterPlusAttribute(char Character, byte Attribute, bool UseAttribute);

--- a/src/Spice86.Core/Emulator/InterruptHandlers/VGA/Records/VgaMode.cs
+++ b/src/Spice86.Core/Emulator/InterruptHandlers/VGA/Records/VgaMode.cs
@@ -12,4 +12,4 @@ using Spice86.Core.Emulator.InterruptHandlers.VGA.Enums;
 /// <param name="CharacterWidth">The default width of characters in this mode</param>
 /// <param name="CharacterHeight">The default height of characters in this mode</param>
 /// <param name="StartSegment">Which segment this mode uses</param>
-public record struct VgaMode(MemoryModel MemoryModel, ushort Width, ushort Height, byte BitsPerPixel, byte CharacterWidth, byte CharacterHeight, ushort StartSegment);
+public readonly record struct VgaMode(MemoryModel MemoryModel, ushort Width, ushort Height, byte BitsPerPixel, byte CharacterWidth, byte CharacterHeight, ushort StartSegment);

--- a/src/Spice86.Core/Emulator/InterruptHandlers/VGA/Records/VideoMode.cs
+++ b/src/Spice86.Core/Emulator/InterruptHandlers/VGA/Records/VideoMode.cs
@@ -1,7 +1,4 @@
 namespace Spice86.Core.Emulator.InterruptHandlers.VGA.Records;
-
-using System.Collections.Frozen;
-
 /// <summary>
 ///     Represents a VGA video mode.
 /// </summary>

--- a/src/Spice86.Core/Emulator/InterruptHandlers/VGA/Records/VideoMode.cs
+++ b/src/Spice86.Core/Emulator/InterruptHandlers/VGA/Records/VideoMode.cs
@@ -1,5 +1,7 @@
 namespace Spice86.Core.Emulator.InterruptHandlers.VGA.Records;
 
+using System.Collections.Frozen;
+
 /// <summary>
 ///     Represents a VGA video mode.
 /// </summary>

--- a/src/Spice86.Core/Emulator/InterruptHandlers/VGA/VgaBios.cs
+++ b/src/Spice86.Core/Emulator/InterruptHandlers/VGA/VgaBios.cs
@@ -24,7 +24,6 @@ public class VgaBios : InterruptHandler, IVideoInt10Handler {
     /// <summary>
     ///     VGA BIOS constructor.
     /// </summary>
-    /// <param name="machine">The machine hosting the bios.</param>
     /// <param name="vgaFunctions">Provides vga functionality to use by the interrupt handler</param>
     /// <param name="biosDataArea">Contains the global bios data values</param>
     /// <param name="loggerService">A logger</param>

--- a/src/Spice86.Core/Emulator/InterruptHandlers/VGA/VgaRom.cs
+++ b/src/Spice86.Core/Emulator/InterruptHandlers/VGA/VgaRom.cs
@@ -4,6 +4,8 @@ using Spice86.Core.Emulator.InterruptHandlers.VGA.Data;
 using Spice86.Core.Emulator.Memory;
 using Spice86.Shared.Emulator.Memory;
 
+using System.Collections.Frozen;
+
 public class VgaRom : IMemoryDevice {
     private const int BaseAddress = Segment << 4;
 

--- a/src/Spice86.Core/Emulator/InterruptHandlers/VGA/VideoModeChangedEventArgs.cs
+++ b/src/Spice86.Core/Emulator/InterruptHandlers/VGA/VideoModeChangedEventArgs.cs
@@ -5,7 +5,7 @@ using Spice86.Core.Emulator.InterruptHandlers.VGA.Records;
 /// <summary>
 ///     Event arguments for the video mode changed event.
 /// </summary>
-public class VideoModeChangedEventArgs : EventArgs {
+public readonly record struct VideoModeChangedEventArgs {
     /// <summary>
     ///     Instantiates a new instance of <see cref="VideoModeChangedEventArgs" />.
     /// </summary>
@@ -17,5 +17,5 @@ public class VideoModeChangedEventArgs : EventArgs {
     /// <summary>
     ///     The new video mode.
     /// </summary>
-    public VgaMode NewMode { get; }
+    public VgaMode NewMode { get; init; }
 }

--- a/src/Spice86.Core/Emulator/Sound/Blaster/Dsp.cs
+++ b/src/Spice86.Core/Emulator/Sound/Blaster/Dsp.cs
@@ -1,14 +1,10 @@
 ﻿namespace Spice86.Core.Emulator.Sound.Blaster;
 
-using Spice86.Core.Emulator.Devices.ExternalInput;
 using Spice86.Core.Emulator.Devices.Sound;
+using Spice86.Core.Emulator.Memory;
 
 using System;
 using System.Threading;
-
-using Spice86.Core.Emulator.Memory;
-
-using Spice86.Core.Emulator.VM;
 
 /// <summary>
 /// Emulates the Sound Blaster 16 DSP.
@@ -20,9 +16,7 @@ public sealed class Dsp {
     /// Initializes a new instance of the Digital Signal Processor.
     /// </summary>
     /// <param name="soundCard">The host sound-card, used to raise interrupts.</param>
-    /// <param name="dma8">8-bit DMA channel for the DSP device.</param>
-    /// <param name="dma16">16-bit DMA channel for the DSP device.</param>
-    public Dsp(DmaChannel eightBitDmaChannel, DmaChannel sixteenBitDmaChannel, IRequestInterrupt soundCard, int dma8, int dma16) {
+    public Dsp(DmaChannel eightBitDmaChannel, DmaChannel sixteenBitDmaChannel, IRequestInterrupt soundCard) {
         dmaChannel8 = eightBitDmaChannel;
         dmaChannel16 = sixteenBitDmaChannel;
         SampleRate = 22050;

--- a/src/Spice86/Infrastructure/AvaloniaKeyScanCodeConverter.cs
+++ b/src/Spice86/Infrastructure/AvaloniaKeyScanCodeConverter.cs
@@ -2,6 +2,7 @@
 
 using Spice86.Shared.Emulator.Keyboard;
 
+using System.Collections.Frozen;
 using System.Collections.Generic;
 
 /// <inheritdoc cref="IAvaloniaKeyScanCodeConverter" />
@@ -9,12 +10,12 @@ public class AvaloniaKeyScanCodeConverter : IAvaloniaKeyScanCodeConverter {
     /// <summary>
     /// A dictionary that maps <see cref="Key"/> values to their corresponding keyboard scan codes.
     /// </summary>
-    private static readonly Dictionary<Key, byte> _keyPressedScanCode;
+    private static readonly FrozenDictionary<Key, byte> _keyPressedScanCode;
     
     /// <summary>
     /// A dictionary that maps keyboard scan codes to their corresponding ASCII codes.
     /// </summary>
-    private static readonly Dictionary<byte, byte> _scanCodeToAscii;
+    private static readonly FrozenDictionary<byte, byte> _scanCodeToAscii;
 
     /// <summary>
     /// Initializes static members of the <see cref="AvaloniaKeyScanCodeConverter"/> class.
@@ -108,7 +109,7 @@ public class AvaloniaKeyScanCodeConverter : IAvaloniaKeyScanCodeConverter {
             {Key.Delete, 0x53},
             //{Key.D5, 0x4C}, ?
             {Key.Multiply, 0x37},
-        };
+        }.ToFrozenDictionary();
         _scanCodeToAscii = new Dictionary<byte, byte>()
         {
             {0x01, 0x1B},
@@ -167,7 +168,7 @@ public class AvaloniaKeyScanCodeConverter : IAvaloniaKeyScanCodeConverter {
             {0x4A, 0x2D},
             {0x4C, 0x35},
             {0x4E, 0x2B},
-        };
+        }.ToFrozenDictionary();
     }
 
     /// <inheritdoc />


### PR DESCRIPTION
### Description of Changes

Introduces Frozen collections (new in .NET 8) for lookup tables in the YM7128B module (unused, for the Adlib Gold) and the UI's Keyboard converter. Those new Frozen collections are made for lookup tables, and are supposed to be very fast. They are also truly immutable and cannot be changed after program initialization, unlike previous ReadOnlyList (you could access the underlying List via a simple cast) or Immutable (it accepted Add/Remove operations, but returned a new separated instance. It also was way too slow for lookup tables) collection types.

It also adds a few readonly record structs in the VGA namespace, removes a few unused arguments, unused imports, and obsolete XML documentation.

### Rationale behind Changes

Prepares the future Adlib Gold PR for Dune, which will use the YM7128B module.

### Suggested Testing Steps

I already tested this on my end with Dune and saw no regressions, either in performance or functionality.