### PR TITLE
Relieve some GC pressure by making SegmentedAddress a value type

### DIFF
--- a/src/Spice86.Core/Emulator/CPU/CPU.cs
+++ b/src/Spice86.Core/Emulator/CPU/CPU.cs
@@ -12,6 +12,7 @@ using Spice86.Core.Emulator.InterruptHandlers.Common.Callback;
 using Spice86.Core.Emulator.IOPorts;
 using Spice86.Core.Emulator.Memory;
 using Spice86.Core.Emulator.VM;
+using Spice86.Logging;
 using Spice86.Shared.Emulator.Memory;
 using Spice86.Shared.Interfaces;
 using Spice86.Shared.Utils;
@@ -97,8 +98,7 @@ public class Cpu : IDebuggableComponent {
     public void ExecuteNextInstruction() {
         _internalIp = State.IP;
 
-        _loggerService.LoggerPropertyBag.CsIp.Segment = State.CS;
-        _loggerService.LoggerPropertyBag.CsIp.Offset = State.IP;
+        _loggerService.LoggerPropertyBag.CsIp = new(State.CS, State.IP);
 
         ExecutionFlowRecorder.RegisterExecutedInstruction(State.CS, _internalIp);
         byte opcode = ProcessPrefixes();

--- a/src/Spice86.Core/Emulator/Function/FunctionHandler.cs
+++ b/src/Spice86.Core/Emulator/Function/FunctionHandler.cs
@@ -270,8 +270,8 @@ public class FunctionHandler {
         }
 
         // Record the unexpected behaviour. Generated code will see this as well.
-        _executionFlowRecorder.RegisterUnalignedReturn(_state.CS, _state.IP, actualReturnAddress.Segment,
-            actualReturnAddress.Offset);
+        _executionFlowRecorder.RegisterUnalignedReturn(_state.CS, _state.IP, actualReturnAddress.Value.Segment,
+            actualReturnAddress.Value.Offset);
         FunctionInformation? currentFunctionInformation = GetFunctionInformation(currentFunctionCall);
         if (_loggerService.IsEnabled(LogEventLevel.Verbose) && currentFunctionInformation != null
             && !currentFunctionInformation.UnalignedReturns.ContainsKey(currentFunctionReturn)) {

--- a/src/Spice86.Core/Emulator/Function/FunctionInformation.cs
+++ b/src/Spice86.Core/Emulator/Function/FunctionInformation.cs
@@ -161,6 +161,6 @@ public record FunctionInformation : IComparable<FunctionInformation> {
             addresses = new HashSet<SegmentedAddress>();
             returnsMap.Add(functionReturn, addresses);
         }
-        addresses.Add(target);
+        addresses.Add(target.Value);
     }
 }

--- a/src/Spice86.Core/Emulator/InterruptHandlers/Common/MemoryWriter/InMemoryAddressSwitcher.cs
+++ b/src/Spice86.Core/Emulator/InterruptHandlers/Common/MemoryWriter/InMemoryAddressSwitcher.cs
@@ -46,6 +46,6 @@ public class InMemoryAddressSwitcher {
             return;
         }
 
-        SetAddress(DefaultAddress.Segment, DefaultAddress.Offset);
+        SetAddress(DefaultAddress.Value.Segment, DefaultAddress.Value.Offset);
     }
 }

--- a/src/Spice86.Core/Emulator/InterruptHandlers/Common/MemoryWriter/MemoryAsmWriter.cs
+++ b/src/Spice86.Core/Emulator/InterruptHandlers/Common/MemoryWriter/MemoryAsmWriter.cs
@@ -76,7 +76,7 @@ public class MemoryAsmWriter : MemoryWriter {
         if (inMemoryAddressSwitcher.DefaultAddress is null) {
             throw new UnrecoverableException("Cannot write a FAR call to a null address.");
         }
-        inMemoryAddressSwitcher.PhysicalLocation = WriteFarCall(inMemoryAddressSwitcher.DefaultAddress).ToPhysical();
+        inMemoryAddressSwitcher.PhysicalLocation = WriteFarCall(inMemoryAddressSwitcher.DefaultAddress.Value).ToPhysical();
     }
 
     /// <summary>

--- a/src/Spice86.Core/Emulator/InterruptHandlers/Common/MemoryWriter/MemoryWriter.cs
+++ b/src/Spice86.Core/Emulator/InterruptHandlers/Common/MemoryWriter/MemoryWriter.cs
@@ -38,7 +38,7 @@ public class MemoryWriter {
     /// <param name="b">data to write</param>
     public void WriteUInt8(byte b) {
         _memory.UInt8[CurrentAddress.Segment, CurrentAddress.Offset] = b;
-        CurrentAddress.Offset++;
+        CurrentAddress = new SegmentedAddress(CurrentAddress.Segment, (ushort)(CurrentAddress.Offset + 1));
     }
 
     /// <summary>
@@ -47,7 +47,7 @@ public class MemoryWriter {
     /// <param name="w">data to write</param>
     public void WriteUInt16(ushort w) {
         _memory.UInt16[CurrentAddress.Segment, CurrentAddress.Offset] = w;
-        CurrentAddress.Offset += 2;
+        CurrentAddress = new SegmentedAddress(CurrentAddress.Segment, (ushort)(CurrentAddress.Offset + 2));
     }
 
     /// <summary>
@@ -56,7 +56,7 @@ public class MemoryWriter {
     /// <param name="dw">data to write</param>
     public void WriteUInt32(uint dw) {
         _memory.UInt32[CurrentAddress.Segment, CurrentAddress.Offset] = dw;
-        CurrentAddress.Offset += 4;
+        CurrentAddress = new SegmentedAddress(CurrentAddress.Segment, (ushort)(CurrentAddress.Offset + 4));
     }
 
     /// <summary>
@@ -66,7 +66,7 @@ public class MemoryWriter {
     /// <param name="address">data to write</param>
     public void WriteSegmentedAddress(SegmentedAddress address) {
         _memory.SegmentedAddressValue[CurrentAddress.Segment, CurrentAddress.Offset] = (address.Segment, address.Offset);
-        CurrentAddress.Offset += 4;
+        CurrentAddress = new SegmentedAddress(CurrentAddress.Segment, (ushort)(CurrentAddress.Offset + 4));
     }
 
 }

--- a/src/Spice86.Core/Emulator/InterruptHandlers/VGA/VgaFunctionality.cs
+++ b/src/Spice86.Core/Emulator/InterruptHandlers/VGA/VgaFunctionality.cs
@@ -1166,7 +1166,7 @@ public class VgaFunctionality : IVgaFunctionality {
         } else {
             address = GetInterruptVectorAddress(0x43);
         }
-        address.Offset += (ushort)(character * characterHeight);
+        address = new SegmentedAddress(address.Segment, (ushort)(address.Offset + (ushort)(character * characterHeight)));
         return address;
     }
 

--- a/src/Spice86.Shared/Emulator/Memory/SegmentedAddress.cs
+++ b/src/Spice86.Shared/Emulator/Memory/SegmentedAddress.cs
@@ -8,7 +8,7 @@ using System.Text.Json.Serialization;
 /// <summary>
 /// An address that is represented with a real mode segment and an offset.
 /// </summary>
-public class SegmentedAddress : IComparable<SegmentedAddress> {
+public readonly record struct SegmentedAddress : IComparable<SegmentedAddress> {
     /// <summary>
     /// Initializes a new instance of the SegmentedAddress class from another instance, creating a copy.
     /// </summary>
@@ -39,39 +39,43 @@ public class SegmentedAddress : IComparable<SegmentedAddress> {
     /// </summary>
     /// <param name="other">The SegmentedAddress to compare with the current SegmentedAddress.</param>
     /// <returns>A value that indicates the relative order of the objects being compared.</returns>
-    public int CompareTo(SegmentedAddress? other) {
-        if (other == null) {
-            return 1;
-        }
+    public int CompareTo(SegmentedAddress other) {
         uint x = ToPhysical();
         uint y = other.ToPhysical();
         return x < y ? -1 : x == y ? 0 : 1;
     }
 
     /// <summary>
+    /// Compares the current SegmentedAddress object with another SegmentedAddress object.
+    /// </summary>
+    /// <param name="other">The SegmentedAddress to compare with the current SegmentedAddress.</param>
+    /// <returns>A value that indicates the relative order of the objects being compared.</returns>
+    public int CompareTo(SegmentedAddress? other) {
+        if (other == null) {
+            return 1;
+        }
+        uint x = ToPhysical();
+        uint y = other.Value.ToPhysical();
+        return x < y ? -1 : x == y ? 0 : 1;
+    }
+
+    /// <summary>
     /// Determines whether the current SegmentedAddress object is equal to another SegmentedAddress object.
     /// </summary>
-    /// <param name="obj">The object to compare with the current SegmentedAddress object.</param>
+    /// <param name="other">The object to compare with the current SegmentedAddress object.</param>
     /// <returns>true if the objects are equal; otherwise, false.</returns>
-    public override bool Equals(object? obj) {
-        if (this == obj) {
-            return true;
-        }
-        if (obj is not SegmentedAddress other) {
-            return false;
-        }
+    public readonly bool Equals(SegmentedAddress other) {
         return MemoryUtils.ToPhysicalAddress(Segment, Offset) == MemoryUtils.ToPhysicalAddress(other.Segment, other.Offset);
     }
 
     /// <summary>
-    /// Adds the offset to the current SegmentedAddress object and returns the result as a new SegmentedAddress object.
+    /// Adds the offset to a new SegmentedAddress instance.
     /// </summary>
-    /// <param name="x">The SegmentedAddress to add the offset to.</param>
+    /// <param name="x">The original SegmentedAddress.</param>
     /// <param name="y">The value to add to the offset of the SegmentedAddress.</param>
-    /// <returns>A new SegmentedAddress object that represents the result of the addition.</returns>
+    /// <returns>A new SegmentedAddress instance that represents the result of the addition.</returns>
     public static SegmentedAddress operator +(SegmentedAddress x, ushort y) {
-        x.Offset += y;
-        return x;
+        return new SegmentedAddress(x.Segment, (ushort)(x.Offset + y));
     }
 
     /// <summary>
@@ -85,18 +89,18 @@ public class SegmentedAddress : IComparable<SegmentedAddress> {
     /// <summary>
     /// Gets or sets the offset value of the address.
     /// </summary>
-    public ushort Offset { get; set; }
+    public ushort Offset { get; init; }
 
     /// <summary>
     /// Gets or sets the segment value of the address.
     /// </summary>
-    public ushort Segment { get; set; }
+    public ushort Segment { get; init; }
     
     /// <summary>
     /// Converts the SegmentedAddress object to a 32-bit physical address.
     /// </summary>
     /// <returns>A 32-bit physical address.</returns>
-    public uint ToPhysical() {
+    public readonly uint ToPhysical() {
         return MemoryUtils.ToPhysicalAddress(Segment, Offset);
     }
 
@@ -104,7 +108,7 @@ public class SegmentedAddress : IComparable<SegmentedAddress> {
     /// Returns a string representation of the SegmentedAddress object in the form of a segment and offset value.
     /// </summary>
     /// <returns>A string representation of the SegmentedAddress object in the form of a segment and offset value.</returns>
-    public string ToSegmentOffsetRepresentation() {
+    public readonly string ToSegmentOffsetRepresentation() {
         return ConvertUtils.ToSegmentedAddressRepresentation(Segment, Offset);
     }
 
@@ -121,10 +125,9 @@ public class SegmentedAddress : IComparable<SegmentedAddress> {
     /// </summary>
     /// <returns>A string representation of the SegmentedAddress object, or "null" if input was <c>null</c>.</returns>
     public static string ToString(SegmentedAddress? segmentedAddress) {
-        if (segmentedAddress is not null) {
-            return segmentedAddress.ToString();
+        if (segmentedAddress == null) {
+            return "null";
         }
-
-        return "null";
+        return segmentedAddress.Value.ToString();
     }
 }


### PR DESCRIPTION
### Description of Changes

The SegmentedAddress is now an immutable (readonly) record struct.

### Rationale behind Changes

This removes some negligible GC pressure. But it also prepares the arrival of the new CFG CPU, which will create SegmentedAddress by the truckload for code flow analysis at runtime.

### Suggested Testing Steps

Already tested with Dune, however it's interesting to see if Krondor or other game will have a speed boost or not with this PR.
