### PR TITLE
ExecutionFlowRecorder: Fixed mini GC Storm

### DIFF
--- a/src/Spice86.Core/Emulator/VM/Breakpoint/BreakPoint.cs
+++ b/src/Spice86.Core/Emulator/VM/Breakpoint/BreakPoint.cs
@@ -20,7 +20,7 @@ public abstract class BreakPoint {
     /// <summary>
     /// The action to take when the breakpoint is reached.
     /// </summary>
-    public Action<BreakPoint> OnReached { get; private set; }
+    public Action<BreakPoint> OnReached { get; set; }
 
     /// <summary>
     /// The type of the breakpoint.


### PR DESCRIPTION
### Description of Changes

I know this is going to be replaced by the CFG CPU, but:

We cache the action in a static field, this allows the onReached action to be a static lambda. This avoid a lot of Actions being created on the GC Heap to be reclamed by the GC later.

We also don't pass the AddressBreakPoint as a parameter, as it is being created. The only way to pass it would be to make the action non static, and we don't want that.

We discard the paramater ("_" is the discard action in C#) of the Invoke method, since we *are* creating the breakpoint.

To allow this change, BreakPoint.Action has become mutable (get; set; instead of get; private set;).

### Rationale behind Changes

GC pressure or GC storms is what kills performance in an application.

Before:

![image](https://github.com/OpenRakis/Spice86/assets/1087524/2a4a176f-24ab-48ac-a2d4-a0c0efa11930)

After:

![image](https://github.com/OpenRakis/Spice86/assets/1087524/a687a522-fccf-43f5-86d1-d02cae212988)


### Suggested Testing Steps

Test that the dump created on disk by the ExecutionFlowRecorder in the same before and after the change. It should be.