### PR TITLE
Fix: UI crash on app exit and refactor: UI _drawAction became a method

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -1,4 +1,4 @@
-name: Test and Publish NuGet
+name: Run tests
 
 # Trigger the workflow on PRs
 on:

--- a/src/Spice86/ViewModels/MainWindowViewModel.cs
+++ b/src/Spice86/ViewModels/MainWindowViewModel.cs
@@ -54,6 +54,7 @@ public sealed partial class MainWindowViewModel : ViewModelBase, IPauseStatus, I
     [ObservableProperty]
     private Configuration _configuration;
     private bool _disposed;
+    private bool _renderingTimerInitialized;
     private bool _drawingSemaphoreSlimDisposed;
     private Thread? _emulatorThread;
     private bool _isSettingResolution;
@@ -332,7 +333,11 @@ public sealed partial class MainWindowViewModel : ViewModelBase, IPauseStatus, I
     [RelayCommand]
     public void ResetTimeMultiplier() => TimeMultiplier = Configuration.TimeMultiplier;
 
-    private void InitializeRenderingThread() {
+    private void InitializeRenderingTimer() {
+        if (_renderingTimerInitialized) {
+            return;
+        }
+        _renderingTimerInitialized = true;
         _drawTimer.Elapsed += (_, _) => DrawScreen();
         _drawTimer.Start();
     }
@@ -448,7 +453,7 @@ public sealed partial class MainWindowViewModel : ViewModelBase, IPauseStatus, I
             }
         }
         _isSettingResolution = false;
-        InitializeRenderingThread();
+        InitializeRenderingTimer();
     }, DispatcherPriority.MaxValue);
 
     public event EventHandler<UIRenderEventArgs>? RenderScreen;


### PR DESCRIPTION
This PR contains a bug fix for a crash on app exit, and the start of the MainWindowsViewModel split up into several ViewModels (as the class is too big)

The second part will follow later in another PR.