### PR TITLE
Simple support for additionnal windows from users

### DIFF
--- a/src/Spice86.Shared/Spice86.Shared.csproj
+++ b/src/Spice86.Shared/Spice86.Shared.csproj
@@ -24,6 +24,7 @@
 		<ContinuousIntegrationBuild Condition="'$(GITHUB_ACTIONS)' == 'true'">true</ContinuousIntegrationBuild>
 	</PropertyGroup>
 	<ItemGroup>
+		<PackageReference Include="Avalonia" Version="11.0.7" />
 		<PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All" />
 		<PackageReference Include="DotNet.ReproducibleBuilds" Version="1.1.1">
 			<PrivateAssets>all</PrivateAssets>

--- a/src/Spice86.Shared/UI/AdditionalWindow.cs
+++ b/src/Spice86.Shared/UI/AdditionalWindow.cs
@@ -1,0 +1,27 @@
+namespace Spice86.Shared.UI;
+
+using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Controls.ApplicationLifetimes;
+using Avalonia.Threading;
+
+/// <summary>
+/// The static class for additional windows that can be added to the UI by user code.
+/// </summary>
+public static class AdditionalWindow {
+    /// <summary>
+    /// Brings the window to the forefront.
+    /// </summary>
+    public static void Show(WindowBase window) {
+        Dispatcher.UIThread.Post(() => {
+            if (Application.Current?.ApplicationLifetime is not IClassicDesktopStyleApplicationLifetime desktop || desktop.MainWindow is null) {
+                return;
+            }
+            if (desktop.Windows.Any(x => x == window)) {
+                window.Activate();
+            } else {
+                window.Show();
+            }
+        });
+    }
+}


### PR DESCRIPTION
Tested successfully with Cryogenic.

This is to display anything from user code in a new custom window (or several).

Cryogenic will display live savegame data while Dune runs. And certainly other things later.