### PR TITLE
Release: Spice86 v6.4.0

### DIFF
--- a/.github/workflows/nuget.yml
+++ b/.github/workflows/nuget.yml
@@ -34,20 +34,20 @@ jobs:
 
     - name: Upload NuGet Bufdio.Spice86
       working-directory: ./src/Bufdio.Spice86/bin/Release
-      run: nuget push Bufdio.Spice86.6.3.0.nupkg ${{secrets.NUGET_API_KEY}} -Source 'https://api.nuget.org/v3/index.json' -SkipDuplicate
+      run: nuget push Bufdio.Spice86.6.4.0.nupkg ${{secrets.NUGET_API_KEY}} -Source 'https://api.nuget.org/v3/index.json' -SkipDuplicate
 
     - name: Upload NuGet Spice86.Shared
       working-directory: ./src/Spice86.Shared/bin/Release
-      run: nuget push Spice86.Shared.6.3.0.nupkg ${{secrets.NUGET_API_KEY}} -Source 'https://api.nuget.org/v3/index.json' -SkipDuplicate
+      run: nuget push Spice86.Shared.6.4.0.nupkg ${{secrets.NUGET_API_KEY}} -Source 'https://api.nuget.org/v3/index.json' -SkipDuplicate
 
     - name: Upload NuGet Spice86.Logging
       working-directory: ./src/Spice86.Logging/bin/Release
-      run: nuget push Spice86.Logging.6.3.0.nupkg ${{secrets.NUGET_API_KEY}} -Source 'https://api.nuget.org/v3/index.json' -SkipDuplicate
+      run: nuget push Spice86.Logging.6.4.0.nupkg ${{secrets.NUGET_API_KEY}} -Source 'https://api.nuget.org/v3/index.json' -SkipDuplicate
 
     - name: Upload NuGet Spice86.Core
       working-directory: ./src/Spice86.Core/bin/Release
-      run: nuget push Spice86.Core.6.3.0.nupkg ${{secrets.NUGET_API_KEY}} -Source 'https://api.nuget.org/v3/index.json' -SkipDuplicate
+      run: nuget push Spice86.Core.6.4.0.nupkg ${{secrets.NUGET_API_KEY}} -Source 'https://api.nuget.org/v3/index.json' -SkipDuplicate
 
     - name: Upload NuGet Spice86
       working-directory: ./src/Spice86/bin/Release
-      run: nuget push Spice86.6.3.0.nupkg ${{secrets.NUGET_API_KEY}} -Source 'https://api.nuget.org/v3/index.json' -SkipDuplicate
+      run: nuget push Spice86.6.4.0.nupkg ${{secrets.NUGET_API_KEY}} -Source 'https://api.nuget.org/v3/index.json' -SkipDuplicate

--- a/src/Bufdio.Spice86/Bufdio.Spice86.csproj
+++ b/src/Bufdio.Spice86/Bufdio.Spice86.csproj
@@ -12,7 +12,7 @@
   <!-- Properties geared towards NuGet -->
 	<PropertyGroup>
 		<GenerateDocumentationFile>true</GenerateDocumentationFile>
-		<version>6.3.0</version>
+		<version>6.4.0</version>
 		<Authors>Luthfi Tri Atmaja, Kevin Ferrare, Maximilien Noal, Joris van Eijden, Artjom Vejsel</Authors>
 		<PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
 		<Description>Reverse engineer and rewrite real mode dos programs</Description>

--- a/src/Spice86.Core/Spice86.Core.csproj
+++ b/src/Spice86.Core/Spice86.Core.csproj
@@ -16,7 +16,7 @@
 	<!-- Properties geared towards NuGet -->
 	<PropertyGroup>
 		<GenerateDocumentationFile>true</GenerateDocumentationFile>
-		<version>6.3.0</version>
+		<version>6.4.0</version>
 		<Authors>Kevin Ferrare, Maximilien Noal, Joris van Eijden, Artjom Vejsel</Authors>
 		<PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
 		<Description>Reverse engineer and rewrite real mode dos programs</Description>

--- a/src/Spice86.Logging/Spice86.Logging.csproj
+++ b/src/Spice86.Logging/Spice86.Logging.csproj
@@ -8,7 +8,7 @@
   <!-- Properties geared towards NuGet -->
   <PropertyGroup>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
-    <version>6.3.0</version>
+    <version>6.4.0</version>
     <Authors>Kevin Ferrare, Maximilien Noal, Joris van Eijden, Artjom Vejsel</Authors>
     <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
     <Description>Reverse engineer and rewrite real mode dos programs</Description>

--- a/src/Spice86.Shared/Spice86.Shared.csproj
+++ b/src/Spice86.Shared/Spice86.Shared.csproj
@@ -9,7 +9,7 @@
 	<!-- Properties geared towards NuGet -->
 	<PropertyGroup>
 		<GenerateDocumentationFile>true</GenerateDocumentationFile>
-		<version>6.3.0</version>
+		<version>6.4.0</version>
 		<Authors>Kevin Ferrare, Maximilien Noal, Joris van Eijden, Artjom Vejsel</Authors>
 		<PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
 		<Description>Reverse engineer and rewrite real mode dos programs</Description>

--- a/src/Spice86/Spice86.csproj
+++ b/src/Spice86/Spice86.csproj
@@ -18,8 +18,8 @@
 		<NoWarn>CS1591</NoWarn>
 		<PackageId>Spice86</PackageId>
 		<GenerateDocumentationFile>true</GenerateDocumentationFile>
-		<version>6.3.0</version>
-		<PackageReleaseNotes>Fixed CRT timing issues.</PackageReleaseNotes>
+		<version>6.4.0</version>
+		<PackageReleaseNotes>Added Sound Software Mixer, a very simple SB Hardware Mixer, and the AdditionalWindow API.</PackageReleaseNotes>
         <Authors>Kevin Ferrare, Maximilien Noal, Joris van Eijden, Artjom Vejsel</Authors>
 		<PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
 		<Description>Reverse engineer and rewrite real mode DOS programs</Description>


### PR DESCRIPTION
Software Mixer, SB Hardware Mixer, AdditionalWindows API for user code.

The merge of this release will trigger the creation of a new version of the Nuget packages.

The reason behind this release is to make the latest features usable with Cryogenic, most notably to work on Dune savegames.