### PR TITLE
Feature/cfg_cpu_debug_ui

### DIFF
--- a/src/Spice86.Core/Emulator/CPU/CfgCpu/CfgCpu.cs
+++ b/src/Spice86.Core/Emulator/CPU/CfgCpu/CfgCpu.cs
@@ -30,6 +30,7 @@ public class CfgCpu : IDebuggableComponent {
 
     public void Accept<T>(T emulatorDebugger) where T : IInternalDebugger {
         emulatorDebugger.Visit(this);
+        _state.Accept(emulatorDebugger);
         CurrentExecutionContext.Accept(emulatorDebugger);
     }
 

--- a/src/Spice86/ViewModels/CfgCpuViewModel.cs
+++ b/src/Spice86/ViewModels/CfgCpuViewModel.cs
@@ -11,12 +11,25 @@ using Spice86.Core.Emulator.CPU.CfgCpu.ControlFlowGraph;
 using Spice86.Core.Emulator.CPU.CfgCpu.Linker;
 using Spice86.Core.Emulator.InternalDebugger;
 using Spice86.Infrastructure;
+using Spice86.Interfaces;
+using Spice86.Shared.Diagnostics;
+using Spice86.Shared.Interfaces;
+
+using System.Diagnostics;
 
 public partial class CfgCpuViewModel : ViewModelBase, IInternalDebugger {
     private ExecutionContext? ExecutionContext { get; set; }
 
     [ObservableProperty]
     private Graph? _graph;
+    
+    [ObservableProperty]
+    private long _numberOfNodes = 0;
+
+    [ObservableProperty]
+    private long _averageNodeTime = 0;
+
+    private readonly IPauseStatus? _pauseStatus;
 
     public CfgCpuViewModel() {
         if(!Design.IsDesignMode) {
@@ -24,36 +37,66 @@ public partial class CfgCpuViewModel : ViewModelBase, IInternalDebugger {
         }
     }
 
-    public CfgCpuViewModel(IUIDispatcherTimer dispatcherTimer) {
+    public CfgCpuViewModel(IUIDispatcherTimer dispatcherTimer, IPauseStatus pauseStatus) {
+        _pauseStatus = pauseStatus;
         dispatcherTimer.StartNew(TimeSpan.FromMilliseconds(400), DispatcherPriority.Normal, UpdateCurrentGraph);
     }
+    
+    private readonly IPerformanceMeasurer _performanceMeasurer = new PerformanceMeasurer();
 
     private void UpdateCurrentGraph(object? sender, EventArgs e)
     {
-        ICfgNode? nodeRoot = ExecutionContext?.LastExecuted;
-        if (nodeRoot?.Predecessors.Count is null or 0) {
+        if (_pauseStatus?.IsPaused is false or null)
+        {
             return;
         }
+        ICfgNode? nodeRoot = ExecutionContext?.LastExecuted;
+        if (nodeRoot is null)
+        {
+            return;
+        }
+
+        NumberOfNodes = 0;
         Graph currentGraph = new();
-        // Flatten the recursive Predecessors structure into an array
-        List<ICfgNode> flattenedPredecessors = new();
-        Stack<ICfgNode> stack = new();
-        stack.Push(nodeRoot);
-        ICfgNode? previousNode = nodeRoot;
-        while (stack.Count > 0) {
-            ICfgNode node = stack.Pop();
-            flattenedPredecessors.Add(node);
-            if (previousNode != null) {
+        Queue<ICfgNode> queue = new();
+        queue.Enqueue(nodeRoot);
+        HashSet<ICfgNode> visitedNodes = new();
+        var stopwatch = Stopwatch.StartNew();
+        while (queue.Count > 0)
+        {
+            ICfgNode node = queue.Dequeue();
+            if (visitedNodes.Contains(node))
+            {
+                continue;
+            }
+            visitedNodes.Add(node);
+            stopwatch.Restart();
+            foreach (ICfgNode successor in node.Successors)
+            {
                 currentGraph.Edges.Add(new Edge(
-                    $"{node.Address} {Environment.NewLine} {node.GetType()}",
-                    $"{previousNode.Address} {Environment.NewLine} {previousNode.GetType()}"));
+                    $"{node.Address} {Environment.NewLine} {node.GetType().Name}",
+                    $"{successor.Address} {Environment.NewLine} {successor.GetType().Name}"));
+                if (!visitedNodes.Contains(successor))
+                {
+                    queue.Enqueue(successor);
+                }
             }
-            foreach (ICfgNode predecessor in node.Predecessors) {
-                stack.Push(predecessor);
+            foreach (ICfgNode predecessor in node.Predecessors)
+            {
+                currentGraph.Edges.Add(new Edge(
+                    $"{predecessor.Address} {Environment.NewLine} {predecessor.GetType().Name}",
+                    $"{node.Address} {Environment.NewLine} {node.GetType().Name}"));
+                if (!visitedNodes.Contains(predecessor))
+                {
+                    queue.Enqueue(predecessor);
+                }
             }
-            previousNode = node;
+            stopwatch.Stop();
+            _performanceMeasurer.UpdateValue(stopwatch.ElapsedMilliseconds);
+            NumberOfNodes++;
         }
         Graph = currentGraph;
+        AverageNodeTime = _performanceMeasurer.ValuePerMillisecond;
     }
 
     public void Visit<T>(T component) where T : IDebuggableComponent {

--- a/src/Spice86/ViewModels/MainWindowViewModel.cs
+++ b/src/Spice86/ViewModels/MainWindowViewModel.cs
@@ -327,6 +327,14 @@ public sealed partial class MainWindowViewModel : ViewModelBase, IPauseStatus, I
             _windowActivator.ActivateDebugWindow(_uiDispatcherTimer, _programExecutor, this);
         }
     }
+    
+    [RelayCommand]
+    public void ShowDebugWindowOnError() {
+        if(_programExecutor is not null) {
+            IsPaused = true;
+            ShowDebugWindow();
+        }
+    }
 
     [RelayCommand(CanExecute = nameof(IsMachineRunning))]
     public void ShowColorPalette() {

--- a/src/Spice86/Views/CfgCpuView.axaml
+++ b/src/Spice86/Views/CfgCpuView.axaml
@@ -3,14 +3,26 @@
         <viewModels:CfgCpuViewModel />
     </Design.DataContext>
     <ScrollViewer>
-        <Grid>
-            <agc:GraphPanel Graph="{Binding Graph}" LayoutMethod="SugiyamaScheme">
-                <agc:GraphPanel.DataTemplates>
-                    <DataTemplate DataType="{x:Type models:CfgNodeInfo}">
-                        <agc:TextSticker Padding="30,10" Shape="RoundedRectangle" Text="{Binding Address}" />
-                    </DataTemplate>
-                </agc:GraphPanel.DataTemplates>
-            </agc:GraphPanel>
+        <Grid RowDefinitions="Auto, *">
+            <UniformGrid Grid.Row="0">
+                <StackPanel Orientation="Vertical">
+                    <Label>Number of nodes</Label>
+                    <TextBlock Text="{Binding NumberOfNodes}" />
+                </StackPanel>
+                <StackPanel Orientation="Vertical">
+                    <Label>Average time (ms) for adding a node</Label>
+                    <TextBlock Text="{Binding AverageNodeTime}" />
+                </StackPanel>
+            </UniformGrid>
+            <Border Grid.Row="1" Background="White">
+                <agc:GraphPanel Graph="{Binding Graph}" LayoutMethod="SugiyamaScheme">
+                    <agc:GraphPanel.DataTemplates>
+                        <DataTemplate DataType="{x:Type models:CfgNodeInfo}">
+                            <agc:TextSticker Padding="30,10" Shape="RoundedRectangle" Text="{Binding Address}" />
+                        </DataTemplate>
+                    </agc:GraphPanel.DataTemplates>
+                </agc:GraphPanel>
+            </Border>
         </Grid>
     </ScrollViewer>
 </UserControl>

--- a/src/Spice86/Views/MainWindow.axaml
+++ b/src/Spice86/Views/MainWindow.axaml
@@ -107,7 +107,7 @@
                     </Grid>
                     <Grid ColumnDefinitions="Auto,Auto" DockPanel.Dock="Bottom">
                         <Button Grid.Column="0" MaxWidth="100" Margin="5" Command="{Binding EndProgramCommand}" Content="OK" />
-                        <Button Grid.Column="1" MaxWidth="100" Margin="5" Command="{Binding ShowDebugWindowCommand}" Content="Debug" />
+                        <Button Grid.Column="1" MaxWidth="100" Margin="5" Command="{Binding ShowDebugWindowOnErrorCommand}" Content="Debug" />
                     </Grid>
                 </DockPanel>
             </WrapPanel>


### PR DESCRIPTION
The debugger now also visits the CPU State, the successors for the graph, and tries to
disasm the current instructions.

Also the graph is not rendered if the emulator is not paused.

And it should work with loops.

Finally, it displays some meta informations about the graph.

Oh, and the graph has a white background, even in dark mode for now.

Signed-off-by: Maximilien Noal <noal.maximilien@gmail.com>

