### PR TITLE
Spice86: v7.0.0

### DIFF
--- a/.github/workflows/nuget.yml
+++ b/.github/workflows/nuget.yml
@@ -34,20 +34,20 @@ jobs:
 
     - name: Upload NuGet Bufdio.Spice86
       working-directory: ./src/Bufdio.Spice86/bin/Release
-      run: nuget push Bufdio.Spice86.6.4.2.nupkg ${{secrets.NUGET_API_KEY}} -Source 'https://api.nuget.org/v3/index.json' -SkipDuplicate
+      run: nuget push Bufdio.Spice86.7.0.0.nupkg ${{secrets.NUGET_API_KEY}} -Source 'https://api.nuget.org/v3/index.json' -SkipDuplicate
 
     - name: Upload NuGet Spice86.Shared
       working-directory: ./src/Spice86.Shared/bin/Release
-      run: nuget push Spice86.Shared.6.4.2.nupkg ${{secrets.NUGET_API_KEY}} -Source 'https://api.nuget.org/v3/index.json' -SkipDuplicate
+      run: nuget push Spice86.Shared.7.0.0.nupkg ${{secrets.NUGET_API_KEY}} -Source 'https://api.nuget.org/v3/index.json' -SkipDuplicate
 
     - name: Upload NuGet Spice86.Logging
       working-directory: ./src/Spice86.Logging/bin/Release
-      run: nuget push Spice86.Logging.6.4.2.nupkg ${{secrets.NUGET_API_KEY}} -Source 'https://api.nuget.org/v3/index.json' -SkipDuplicate
+      run: nuget push Spice86.Logging.7.0.0.nupkg ${{secrets.NUGET_API_KEY}} -Source 'https://api.nuget.org/v3/index.json' -SkipDuplicate
 
     - name: Upload NuGet Spice86.Core
       working-directory: ./src/Spice86.Core/bin/Release
-      run: nuget push Spice86.Core.6.4.2.nupkg ${{secrets.NUGET_API_KEY}} -Source 'https://api.nuget.org/v3/index.json' -SkipDuplicate
+      run: nuget push Spice86.Core.7.0.0.nupkg ${{secrets.NUGET_API_KEY}} -Source 'https://api.nuget.org/v3/index.json' -SkipDuplicate
 
     - name: Upload NuGet Spice86
       working-directory: ./src/Spice86/bin/Release
-      run: nuget push Spice86.6.4.2.nupkg ${{secrets.NUGET_API_KEY}} -Source 'https://api.nuget.org/v3/index.json' -SkipDuplicate
+      run: nuget push Spice86.7.0.0.nupkg ${{secrets.NUGET_API_KEY}} -Source 'https://api.nuget.org/v3/index.json' -SkipDuplicate

--- a/src/Bufdio.Spice86/Bufdio.Spice86.csproj
+++ b/src/Bufdio.Spice86/Bufdio.Spice86.csproj
@@ -12,7 +12,7 @@
   <!-- Properties geared towards NuGet -->
 	<PropertyGroup>
 		<GenerateDocumentationFile>true</GenerateDocumentationFile>
-		<version>6.4.2</version>
+		<version>7.0.0</version>
 		<Authors>Luthfi Tri Atmaja, Kevin Ferrare, Maximilien Noal, Joris van Eijden, Artjom Vejsel</Authors>
 		<PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
 		<Description>Reverse engineer and rewrite real mode dos programs</Description>

--- a/src/Spice86.Core/Spice86.Core.csproj
+++ b/src/Spice86.Core/Spice86.Core.csproj
@@ -16,7 +16,7 @@
 	<!-- Properties geared towards NuGet -->
 	<PropertyGroup>
 		<GenerateDocumentationFile>true</GenerateDocumentationFile>
-		<version>6.4.2</version>
+		<version>7.0.0</version>
 		<Authors>Kevin Ferrare, Maximilien Noal, Joris van Eijden, Artjom Vejsel</Authors>
 		<PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
 		<Description>Reverse engineer and rewrite real mode dos programs</Description>

--- a/src/Spice86.Logging/Spice86.Logging.csproj
+++ b/src/Spice86.Logging/Spice86.Logging.csproj
@@ -8,7 +8,7 @@
   <!-- Properties geared towards NuGet -->
   <PropertyGroup>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
-    <version>6.4.2</version>
+    <version>7.0.0</version>
     <Authors>Kevin Ferrare, Maximilien Noal, Joris van Eijden, Artjom Vejsel</Authors>
     <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
     <Description>Reverse engineer and rewrite real mode dos programs</Description>

--- a/src/Spice86.Shared/Spice86.Shared.csproj
+++ b/src/Spice86.Shared/Spice86.Shared.csproj
@@ -9,7 +9,7 @@
 	<!-- Properties geared towards NuGet -->
 	<PropertyGroup>
 		<GenerateDocumentationFile>true</GenerateDocumentationFile>
-		<version>6.4.2</version>
+		<version>7.0.0</version>
 		<Authors>Kevin Ferrare, Maximilien Noal, Joris van Eijden, Artjom Vejsel</Authors>
 		<PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
 		<Description>Reverse engineer and rewrite real mode dos programs</Description>

--- a/src/Spice86/Spice86.csproj
+++ b/src/Spice86/Spice86.csproj
@@ -18,8 +18,8 @@
 		<NoWarn>CS1591</NoWarn>
 		<PackageId>Spice86</PackageId>
 		<GenerateDocumentationFile>true</GenerateDocumentationFile>
-		<version>6.4.2</version>
-		<PackageReleaseNotes>Fixed PCM audio performance.</PackageReleaseNotes>
+		<version>7.0.0</version>
+		<PackageReleaseNotes>Some breaking API changes (SegmentRegisters.cs), WIP new CFG_CPU, addtionnal memory/disasm views to the internal debugger, replaced UI DI framework with Microsoft.DI.</PackageReleaseNotes>
         <Authors>Kevin Ferrare, Maximilien Noal, Joris van Eijden, Artjom Vejsel</Authors>
 		<PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
 		<Description>Reverse engineer and rewrite real mode DOS programs</Description>


### PR DESCRIPTION


For usage with Cryogenic or Krondor or other project via Nuget.

There are some breaking API changes (for Cryogenic, at least), hence the SemVer jump to v7.0.0
