### PR TITLE
Theming tweaks

### DIFF
--- a/src/Spice86/App.axaml
+++ b/src/Spice86/App.axaml
@@ -4,16 +4,19 @@
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:dialogHostAvalonia="clr-namespace:DialogHostAvalonia;assembly=DialogHost.Avalonia"
     RequestedThemeVariant="Default">
+
     <Application.Resources>
         <FontFamily x:Key="RobotoMonoFont">avares://Spice86/Assets#Roboto Mono</FontFamily>
         <FontFamily x:Key="ConsolasFont">Consolas</FontFamily>
     </Application.Resources>
-    <!--  "Default" ThemeVariant follows system theme variant. "Dark" or "Light" are other available options.  -->
+
     <Application.Styles>
-        <FluentTheme DensityStyle="Compact" />
         <dialogHostAvalonia:DialogHostStyles />
-        <StyleInclude Source="avares://Avalonia.Controls.DataGrid/Themes/Fluent.xaml" />
-        <StyleInclude Source="avares://Semi.Avalonia/Themes/Index.axaml" />
         <StyleInclude Source="avares://AvaloniaHex/Themes/Simple/AvaloniaHex.axaml" />
+        <StyleInclude Source="avares://Semi.Avalonia/Themes/Index.axaml" />
+        <StyleInclude Source="avares://Semi.Avalonia.DataGrid/Index.axaml" />
+        <StyleInclude Source="avares://Semi.Avalonia.TreeDataGrid/Index.axaml" />
+        <StyleInclude Source="Styles/Spice86.axaml" />
     </Application.Styles>
+
 </Application>

--- a/src/Spice86/Spice86.csproj
+++ b/src/Spice86/Spice86.csproj
@@ -59,6 +59,8 @@
 		<PackageReference Include="Avalonia.Controls.DataGrid" Version="11.0.11" />
 		<PackageReference Include="Iced" Version="1.21.0" />
 		<PackageReference Include="Semi.Avalonia" Version="11.0.7.3" />
+        <PackageReference Include="Semi.Avalonia.DataGrid" Version="11.0.7.2" />
+        <PackageReference Include="Semi.Avalonia.TreeDataGrid" Version="11.0.1" />
 		<PackageReference Include="bodong.Avalonia.PropertyGrid" Version="11.0.10.1" />
 		<PackageReference Include="Ben.Demystifier" Version="0.4.1" />
 		<PackageReference Include="CommunityToolkit.Mvvm" Version="8.2.2" />
@@ -67,7 +69,6 @@
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>
 		<PackageReference Include="Avalonia" Version="11.0.11" />
-		<PackageReference Include="Avalonia.Themes.Fluent" Version="11.0.11" />
 		<PackageReference Include="Avalonia.Desktop" Version="11.0.11" />
 		<PackageReference Include="Avalonia.Fonts.Inter" Version="11.0.11" />
 		<!--Condition below is needed to remove Avalonia.Diagnostics package from build output in Release configuration.-->

--- a/src/Spice86/Spice86.csproj
+++ b/src/Spice86/Spice86.csproj
@@ -59,8 +59,8 @@
 		<PackageReference Include="Avalonia.Controls.DataGrid" Version="11.0.11" />
 		<PackageReference Include="Iced" Version="1.21.0" />
 		<PackageReference Include="Semi.Avalonia" Version="11.0.7.3" />
-        <PackageReference Include="Semi.Avalonia.DataGrid" Version="11.0.7.2" />
-        <PackageReference Include="Semi.Avalonia.TreeDataGrid" Version="11.0.1" />
+		<PackageReference Include="Semi.Avalonia.DataGrid" Version="11.0.7.2" />
+		<PackageReference Include="Semi.Avalonia.TreeDataGrid" Version="11.0.1" />
 		<PackageReference Include="bodong.Avalonia.PropertyGrid" Version="11.0.10.1" />
 		<PackageReference Include="Ben.Demystifier" Version="0.4.1" />
 		<PackageReference Include="CommunityToolkit.Mvvm" Version="8.2.2" />

--- a/src/Spice86/Styles/Spice86.axaml
+++ b/src/Spice86/Styles/Spice86.axaml
@@ -1,0 +1,37 @@
+<Styles xmlns="https://github.com/avaloniaui"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+
+    <Design.PreviewWith>
+        <ThemeVariantScope RequestedThemeVariant="Dark">
+            <Border Padding="20">
+                <StackPanel>
+                    <Button Content="This is a &quot;hyperlink&quot;" Classes="hyperlink" />
+                    <TextBlock Foreground="{DynamicResource HighlightColor}">This is highlighted</TextBlock>
+                </StackPanel>
+            </Border>
+        </ThemeVariantScope>
+    </Design.PreviewWith>
+
+    <Style Selector="Button.hyperlink">
+        <Setter Property="Template">
+            <ControlTemplate>
+                <TextBlock Text="{TemplateBinding Content}" Foreground="{StaticResource SystemAccentColor}" TextDecorations="Underline">
+                    <TextBlock.Styles>
+                        <Style Selector="TextBlock:pointerover">
+                            <Setter Property="Foreground" Value="{StaticResource SystemAccentColorLight1}" />
+                        </Style>
+                    </TextBlock.Styles>
+                </TextBlock>
+            </ControlTemplate>
+        </Setter>
+        <Setter Property="Background" Value="Transparent" />
+        <Setter Property="BorderThickness" Value="0" />
+    </Style>
+
+    <Style>
+        <Style.Resources>
+            <SolidColorBrush x:Key="HighlightColor">Yellow</SolidColorBrush>
+        </Style.Resources>
+    </Style>
+
+</Styles>


### PR DESCRIPTION
### Description of Changes
- Replace Fluent theme with Semi for data grids
- Fix selection highlighting in hex-editor
- Centralize Spice86 theming additions and overrides.
- Add hyperlink style

### Rationale behind Changes
Just some things I ran into when developing the structure viewer. Didn't want to bloat that branch too much so I thought I'd do a separate small PR for it.

### Suggested Testing Steps
Run emulator, view dissassembly and memory views.
