### PR TITLE
Fix CfgCpu bug where self modifying code changing just an instruction field would result in instruction change not beeing detected

### DIFF
--- a/src/Spice86.Core/Emulator/CPU/CfgCpu/Feeder/DiscriminatorReducer.cs
+++ b/src/Spice86.Core/Emulator/CPU/CfgCpu/Feeder/DiscriminatorReducer.cs
@@ -11,29 +11,63 @@ public class DiscriminatorReducer {
         _instructionReplacers = instructionReplacers;
     }
 
+    private IDictionary<Type, List<CfgInstruction>> GroupByType(List<CfgInstruction> instructions) {
+        IEnumerable<IGrouping<Type, CfgInstruction>> grouped =
+            instructions.GroupBy(i => i.GetType());
+        return grouped.ToDictionary(
+            g => g.Key, 
+            g => g.ToList()
+        );
+    }
+
     public IList<CfgInstruction> ReduceAll(List<CfgInstruction> instructions) {
-        IDictionary<Discriminator, List<CfgInstruction>> groupedByDiscriminator =
-            GroupByDiscriminator(instructions);
+        IDictionary<Type, List<CfgInstruction>> groupByType =
+            GroupByType(instructions);
         List<CfgInstruction> res = new();
-        foreach (var entry in groupedByDiscriminator) {
-            res.Add(ReduceAllWithSameDiscriminator(entry.Value));
+        foreach (var entry in groupByType) {
+            res.AddRange(ReduceAllWithSameType(entry.Value));
         }
 
         return res;
     }
 
-    private CfgInstruction ReduceAllWithSameDiscriminator(IList<CfgInstruction> instructions) {
-        // The instructions in input all have the same discriminator
-        // So they are all functionally the same except for some fields that are changing.
-        // We keep the first one and get rid of the other.
+    private IList<CfgInstruction> ReduceAllWithSameType(IList<CfgInstruction> instructions) {
+        // Group by a discriminator composed of only final fields.
+        // Each list here is reducible since diverging fields are non final.
+        IDictionary<Discriminator, List<CfgInstruction>> groupedByDiscriminatorFinal =
+            GroupByDiscriminatorWithOnlyFinal(instructions);
+        List<CfgInstruction> res = new();
+        foreach (var entry in groupedByDiscriminatorFinal) {
+            res.Add(ReduceAllWithSameDiscriminatorFinal(entry.Value));
+        }
+        return res;
+    }
+    
+    
+    private IDictionary<Discriminator, List<CfgInstruction>> GroupByDiscriminatorWithOnlyFinal(
+        IList<CfgInstruction> instructions) {
+        IEnumerable<IGrouping<Discriminator, CfgInstruction>> grouped =
+            instructions.GroupBy(i => i.DiscriminatorFinal);
+        return grouped.ToDictionary(
+            g => g.Key, 
+            g => g.ToList()
+        );
+    }
+
+    private CfgInstruction ReduceAllWithSameDiscriminatorFinal(IList<CfgInstruction> instructions) {
+        // The instructions in input all have the final fields and the same grammar
+        // So they are all functionally the same except for some value fields that are changing.
+        // We keep the first one and get rid of the other, and we determine in the one we keep which fields are changing.
         CfgInstruction res = instructions.First();
-        ReduceFieldValues(res, instructions);
+        ReduceNonFinalFields(res, instructions);
         // unlink other instructions and make the graph point to new instruction. Make sure other instructions are not in the caches.
         ReplaceWithReference(res, instructions);
         return res;
     }
 
-    private void ReduceFieldValues(CfgInstruction reference, IList<CfgInstruction> instructions) {
+    private void ReduceNonFinalFields(CfgInstruction reference, IList<CfgInstruction> instructions) {
+        // Reference instruction is the result.
+        // Goal is to check in the list which fields differ, and if so make discriminator of result null and tell it to use the value
         for (int i = 0; i < reference.FieldsInOrder.Count; i++) {
             FieldWithValue referenceField = reference.FieldsInOrder[i];
             bool same = IsFieldValueSame(referenceField, instructions, i);
@@ -41,10 +75,12 @@ public class DiscriminatorReducer {
             if (!same) {
                 // Can't use direct value, need to refer to what is in memory since it may have changed between now and parsing time.
                 referenceField.UseValue = false;
+                referenceField.NullifyDiscriminator();
             }
         }
     }
-
+    
+    
     private bool IsFieldValueSame(FieldWithValue reference, IList<CfgInstruction> instructions, int fieldIndex) {
         foreach (CfgInstruction instruction in instructions) {
             FieldWithValue instructionField = instruction.FieldsInOrder[fieldIndex];
@@ -68,13 +104,4 @@ public class DiscriminatorReducer {
         }
     }
 
-    private IDictionary<Discriminator, List<CfgInstruction>> GroupByDiscriminator(
-        List<CfgInstruction> instructions) {
-        IEnumerable<IGrouping<Discriminator, CfgInstruction>> grouped =
-            instructions.GroupBy(i => i.Discriminator);
-        return grouped.ToDictionary(
-            g => g.Key, 
-            g => g.ToList()
-        );
-    }
 }

--- a/src/Spice86.Core/Emulator/CPU/CfgCpu/InstructionExecutor/ModRmComputer.cs
+++ b/src/Spice86.Core/Emulator/CPU/CfgCpu/InstructionExecutor/ModRmComputer.cs
@@ -15,7 +15,7 @@ public class ModRmComputer {
         _state = state;
         _instructionFieldValueRetriever = instructionFieldValueRetriever;
         // Dummy value
-        ModRmContext = new ModRmContext(new InstructionField<byte>(0,0,0,0,ImmutableList.CreateRange(new []{(byte?)0})), 0, 0, 0, BitWidth.WORD_16, MemoryOffsetType.NONE, MemoryAddressType.NONE, null, null, null, null, null, null);
+        ModRmContext = new ModRmContext(new InstructionField<byte>(0,0,0,0,ImmutableList.CreateRange(new []{(byte?)0}), true), 0, 0, 0, BitWidth.WORD_16, MemoryOffsetType.NONE, MemoryAddressType.NONE, null, null, null, null, null, null);
     }
 
     public ModRmContext ModRmContext { get; set; }

--- a/src/Spice86.Core/Emulator/CPU/CfgCpu/Linker/NodeLinker.cs
+++ b/src/Spice86.Core/Emulator/CPU/CfgCpu/Linker/NodeLinker.cs
@@ -30,7 +30,7 @@ public class NodeLinker : IInstructionReplacer<ICfgNode> {
         }
 
         if (!ReferenceEquals(shouldBeNext, next)) {
-            throw new UnhandledCfgDiscrepancyException("Current node has already a successor at next node address but it is not the next node. This should never happen.");
+            throw new UnhandledCfgDiscrepancyException($"Current node has already a successor at next node address but it is not the next node. This should never happen. Tried to attach {next}, found {shouldBeNext} in successors at this address.");
         }
     }
 

--- a/src/Spice86.Core/Emulator/CPU/CfgCpu/ParsedInstruction/CfgInstruction.cs
+++ b/src/Spice86.Core/Emulator/CPU/CfgCpu/ParsedInstruction/CfgInstruction.cs
@@ -82,12 +82,28 @@ public abstract class CfgInstruction : CfgNode {
     /// </summary>
     public Discriminator Discriminator {
         get {
-            ImmutableList<byte?> discriminatorBytes = FieldsInOrder
-                    .Select(field => field.DiscriminatorValue)
-                    .SelectMany(i => i)
-                    .ToImmutableList();
+            ImmutableList<byte?> discriminatorBytes = ComputeDiscriminatorBytes(FieldsInOrder);
             return new Discriminator(discriminatorBytes);
         }
     }
-    // Equals and HashCode to use the discriminator and super methods
+
+    /// <summary>
+    /// Same as Discriminator but only aggregates final fields, ignoring those that can change.
+    /// </summary>
+    public Discriminator DiscriminatorFinal {
+        get {
+            ImmutableList<byte?> discriminatorBytes = ComputeDiscriminatorBytes(FieldsInOrder
+                .Where(field => field.Final));
+            return new Discriminator(discriminatorBytes);
+        }
+    }
+
+    private ImmutableList<byte?> ComputeDiscriminatorBytes(IEnumerable<FieldWithValue> bytes) {
+        return bytes
+            .Select(field => field.DiscriminatorValue)
+            .SelectMany(i => i)
+            .ToImmutableList();
+    }
+
+// Equals and HashCode to use the discriminator and super methods
 }

--- a/src/Spice86.Core/Emulator/CPU/CfgCpu/ParsedInstruction/Discriminator.cs
+++ b/src/Spice86.Core/Emulator/CPU/CfgCpu/ParsedInstruction/Discriminator.cs
@@ -17,7 +17,19 @@ public class Discriminator : IComparable<Discriminator> {
     /// <summary>
     /// Value of the discriminator
     /// </summary>
-    public ImmutableList<byte?> DiscriminatorValue { get; }
+    public ImmutableList<byte?> DiscriminatorValue { get; private set; }
+
+    public void NullifyDiscriminator() {
+        DiscriminatorValue = GenerateNullBytes(DiscriminatorValue.Count);
+    }
+    
+    private static ImmutableList<byte?> GenerateNullBytes(int size) {
+        List<byte?> res = new List<byte?>();
+        for (int i = 0; i < size; i++) {
+            res.Add(null);
+        }
+        return ImmutableList.CreateRange(res);
+    }
 
     /// <inheritdoc/>
     public int CompareTo(Discriminator? other) {

--- a/src/Spice86.Core/Emulator/CPU/CfgCpu/ParsedInstruction/FieldWithValue.cs
+++ b/src/Spice86.Core/Emulator/CPU/CfgCpu/ParsedInstruction/FieldWithValue.cs
@@ -3,8 +3,8 @@ namespace Spice86.Core.Emulator.CPU.CfgCpu.ParsedInstruction;
 using System.Collections.Immutable;
 
 public abstract class FieldWithValue : Discriminator {
-    public FieldWithValue(ImmutableList<byte?> discriminatorValue) : base(discriminatorValue)
-    {
+    public FieldWithValue(ImmutableList<byte?> discriminatorValue, bool final) : base(discriminatorValue) {
+        Final = final;
     }
 
     /// <summary>
@@ -24,4 +24,9 @@ public abstract class FieldWithValue : Discriminator {
     /// Length of this field
     /// </summary>
     public int Length { get; init;  }
+    
+    /// <summary>
+    /// True means if the value of this field changes, enclosing instruction is not the same instruction anymore
+    /// </summary>
+    public bool Final { get; }
 }

--- a/src/Spice86.Core/Emulator/CPU/CfgCpu/ParsedInstruction/InstructionField.cs
+++ b/src/Spice86.Core/Emulator/CPU/CfgCpu/ParsedInstruction/InstructionField.cs
@@ -17,7 +17,7 @@ public class InstructionField<T> : FieldWithValue {
     public int IndexInInstruction { get; }
 
     public InstructionField(int indexInInstruction, int length, uint physicalAddress, T value,
-        ImmutableList<byte?> discriminatorValue) : base(discriminatorValue) {
+        ImmutableList<byte?> discriminatorValue, bool final) : base(discriminatorValue, final) {
         IndexInInstruction = indexInInstruction;
         Length = length;
         PhysicalAddress = physicalAddress;

--- a/src/Spice86.Core/Emulator/CPU/CfgCpu/Parser/FieldReader/InstructionFieldReader.cs
+++ b/src/Spice86.Core/Emulator/CPU/CfgCpu/Parser/FieldReader/InstructionFieldReader.cs
@@ -37,9 +37,9 @@ public abstract class InstructionFieldReader<T> {
     /// <returns></returns>
     public virtual InstructionField<T> PeekField(bool finalValue) {
         T value = PeekValue();
-        ImmutableList<byte?> bytes = PeekDataOrNullList(FieldSize(), finalValue);
+        ImmutableList<byte?> bytes = PeekData(FieldSize());
         return new InstructionField<T>(AddressSource.IndexInInstruction, FieldSize(),
-            CurrentAddress.ToPhysical(), value, bytes);
+            CurrentAddress.ToPhysical(), value, bytes, finalValue);
     }
 
     /// <summary>
@@ -51,21 +51,6 @@ public abstract class InstructionFieldReader<T> {
         InstructionField<T> res = PeekField(finalValue);
         Advance();
         return res;
-    }
-
-    private ImmutableList<byte?> PeekDataOrNullList(int size, bool data) {
-        if (data) {
-            return PeekData(size);
-        }
-        return GenerateNullBytes(size);
-    }
-    
-    private static ImmutableList<byte?> GenerateNullBytes(int size) {
-        List<byte?> res = new List<byte?>();
-        for (int i = 0; i < size; i++) {
-            res.Add(null);
-        }
-        return ImmutableList.CreateRange(res);
     }
 
     private ImmutableList<byte?> PeekData(int size) {

--- a/tests/Spice86.Tests/CfgCpu/InstructionsFeederTest.cs
+++ b/tests/Spice86.Tests/CfgCpu/InstructionsFeederTest.cs
@@ -45,9 +45,9 @@ public class InstructionsFeederTest {
     }
 
     private JmpNearImm8 CreateReplacementInstruction() {
-        var opcodeField = new InstructionField<ushort>(0, 1, 0, 0xEB, ImmutableList.Create<byte?>(0xEB));
+        var opcodeField = new InstructionField<ushort>(0, 1, 0, 0xEB, ImmutableList.Create<byte?>(0xEB), true);
         // Replacement has a null discriminator byte for offset field -> will not be taken into account when comparing with ram
-        var offsetField = new InstructionField<sbyte>(1, 1, 1, -2, ImmutableList.Create((byte?)null));
+        var offsetField = new InstructionField<sbyte>(1, 1, 1, -2, ImmutableList.Create((byte?)null), false);
         JmpNearImm8 res = new JmpNearImm8(ZeroAddress, opcodeField, new List<InstructionPrefix>(), offsetField);
         res.PostInit();
         return res;


### PR DESCRIPTION
All games seem to work apart for some crashes linked to discriminated node.