### PR TITLE
refactor: removed unused enricher Serilog.Exceptions from logger

### DIFF
--- a/src/Spice86.Logging/LoggerService.cs
+++ b/src/Spice86.Logging/LoggerService.cs
@@ -3,7 +3,6 @@
 using Serilog;
 using Serilog.Core;
 using Serilog.Events;
-using Serilog.Exceptions;
 
 using Spice86.Shared.Interfaces;
 
@@ -55,7 +54,6 @@ public class LoggerService : ILoggerService {
     public LoggerConfiguration CreateLoggerConfiguration() {
         return new LoggerConfiguration()
             .Enrich.FromLogContext()
-            .Enrich.WithExceptionDetails()
             .WriteTo.Console(outputTemplate: LogFormat)
             .WriteTo.Debug(outputTemplate: LogFormat);
     }

--- a/src/Spice86.Logging/Spice86.Logging.csproj
+++ b/src/Spice86.Logging/Spice86.Logging.csproj
@@ -45,7 +45,6 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Serilog.Exceptions" Version="8.4.0" />
     <PackageReference Include="ErrorProne.NET.CoreAnalyzers" Version="0.1.2">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/src/Spice86.Shared/Spice86.Shared.csproj
+++ b/src/Spice86.Shared/Spice86.Shared.csproj
@@ -48,7 +48,6 @@
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>
-		<PackageReference Include="Serilog.Exceptions" Version="8.4.0" />
 		<PackageReference Include="ErrorProne.NET.CoreAnalyzers" Version="0.1.2">
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>


### PR DESCRIPTION
We didn't use it after all.