### PR TITLE
Fix brush <-> color bug.

### DIFF
--- a/src/Spice86/Styles/Spice86.axaml
+++ b/src/Spice86/Styles/Spice86.axaml
@@ -29,7 +29,7 @@
     <Style>
         <Style.Resources>
             <ResourceDictionary>
-                <SolidColorBrush x:Key="HighlightColor" Color="Yellow" />
+                <Color x:Key="HighlightColor">#80FFFF00</Color>
                 <ResourceDictionary.ThemeDictionaries>
                     <ResourceDictionary x:Key="Light">
                         <SolidColorBrush x:Key="HyperlinkButtonForeground" Color="#1C1F23" />


### PR DESCRIPTION
### Description of Changes
Make the hex view highlight color a color and not a brush.

### Rationale behind Changes
This was something that was "allowed" in Avalonia 11.0 and below, but no longer accepted in 11.1 and above.

### Suggested Testing Steps
1. Run Spice86
2. Pause
3. Open Internal Debugger
4. Open Memeory View
5. Select some bytes
6. See yellow highlight color
