### PR TITLE
chore: upgraded CommunityToolkit MVVM Nuget package

### DIFF
--- a/src/Spice86.Core/Spice86.Core.csproj
+++ b/src/Spice86.Core/Spice86.Core.csproj
@@ -48,7 +48,7 @@
 	</ItemGroup>
 
 	<ItemGroup>
-		<PackageReference Include="CommunityToolkit.HighPerformance" Version="8.2.2" />
+		<PackageReference Include="CommunityToolkit.HighPerformance" Version="8.3.0" />
 		<PackageReference Include="JetBrains.Annotations" Version="2024.2.0" />
 		<PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
 		<PackageReference Include="Roslynator.Analyzers" Version="4.12.4">

--- a/src/Spice86/Spice86.csproj
+++ b/src/Spice86/Spice86.csproj
@@ -58,7 +58,7 @@
         <PackageReference Include="AvaloniaHex" Version="0.1.3" />
         <PackageReference Include="bodong.Avalonia.PropertyGrid" Version="11.1.1.1" />
         <PackageReference Include="bodong.PropertyModels" Version="11.1.1.1" />
-        <PackageReference Include="CommunityToolkit.Mvvm" Version="8.2.2"/>
+        <PackageReference Include="CommunityToolkit.Mvvm" Version="8.3.0" />
         <PackageReference Include="DialogHost.Avalonia" Version="0.8.1" />
         <PackageReference Include="DotNet.ReproducibleBuilds" Version="1.2.4">
             <PrivateAssets>all</PrivateAssets>


### PR DESCRIPTION
Because dependabot is still broken.
