### PR TITLE
Fix/performance measurer high samples

### DIFF
--- a/src/Spice86.Shared/Diagnostics/PerformanceMeasurer.cs
+++ b/src/Spice86.Shared/Diagnostics/PerformanceMeasurer.cs
@@ -44,7 +44,7 @@ public class PerformanceMeasurer : IPerformanceMeasurer {
         _lastTimeInMilliseconds = newTimeInMilliseconds;
         long valueDelta = newMeasure - _measure;
         _measure = newMeasure;
-        ValuePerMillisecond = valueDelta / Math.Max(millisecondsDelta, 1);
+        ValuePerMillisecond = valueDelta / millisecondsDelta;
         AverageValuePerSecond = ApproxRollingAverage(AverageValuePerSecond, ValuePerSecond, _sampledMetricsCount++);
     }
 

--- a/src/Spice86.Shared/Diagnostics/PerformanceMeasurer.cs
+++ b/src/Spice86.Shared/Diagnostics/PerformanceMeasurer.cs
@@ -22,7 +22,7 @@ public class PerformanceMeasurer : IPerformanceMeasurer {
     /// </summary>
     public PerformanceMeasurer() => _lastTimeInMilliseconds = GetCurrentTime();
 
-    private long _firstMeasureTimeInTicks = 0;
+    private long _firstMeasureTimeInMilliseconds = 0;
 
     private const int WindowSizeInSeconds = 30;
 
@@ -32,7 +32,7 @@ public class PerformanceMeasurer : IPerformanceMeasurer {
     public void UpdateValue(long newMeasure) {
         long newTimeInMilliseconds = GetCurrentTime();
         if (IsFirstMeasurement()) {
-            _firstMeasureTimeInTicks = newTimeInMilliseconds;
+            _firstMeasureTimeInMilliseconds = newTimeInMilliseconds;
         } else if (IsLastMeasurementExpired(newTimeInMilliseconds)) {
             ResetMetrics(newTimeInMilliseconds);
         }
@@ -49,17 +49,17 @@ public class PerformanceMeasurer : IPerformanceMeasurer {
     }
 
     private bool IsFirstMeasurement() {
-        return _firstMeasureTimeInTicks == 0;
+        return _firstMeasureTimeInMilliseconds == 0;
     }
 
     private void ResetMetrics(long newTimeInMilliseconds) {
-        _firstMeasureTimeInTicks = newTimeInMilliseconds;
+        _firstMeasureTimeInMilliseconds = newTimeInMilliseconds;
         _sampledMetricsCount = 0;
         AverageValuePerSecond = 0;
     }
 
     private bool IsLastMeasurementExpired(long newTimeInMilliseconds) {
-        return (TimeSpan.FromTicks(newTimeInMilliseconds) - TimeSpan.FromTicks(_firstMeasureTimeInTicks)).TotalSeconds >= WindowSizeInSeconds;
+        return (TimeSpan.FromTicks(newTimeInMilliseconds) - TimeSpan.FromTicks(_firstMeasureTimeInMilliseconds)).TotalSeconds >= WindowSizeInSeconds;
     }
 
     private static long ApproxRollingAverage(long measureAverage, long valuePerSecond, long sampledMetricsCount) {

--- a/src/Spice86.Shared/Diagnostics/PerformanceMeasurer.cs
+++ b/src/Spice86.Shared/Diagnostics/PerformanceMeasurer.cs
@@ -58,9 +58,8 @@ public class PerformanceMeasurer : IPerformanceMeasurer {
         AverageValuePerSecond = 0;
     }
 
-    private bool IsLastMeasurementExpired(long newTimeInMilliseconds) {
-        return (TimeSpan.FromTicks(newTimeInMilliseconds) - TimeSpan.FromTicks(_firstMeasureTimeInMilliseconds)).TotalSeconds >= WindowSizeInSeconds;
-    }
+    private bool IsLastMeasurementExpired(long newTimeInMilliseconds) =>
+        newTimeInMilliseconds - _firstMeasureTimeInMilliseconds > WindowSizeInSeconds * 1000;
 
     private static long ApproxRollingAverage(long measureAverage, long valuePerSecond, long sampledMetricsCount) {
         measureAverage -= measureAverage / Math.Max(sampledMetricsCount, 1);

--- a/src/Spice86/Spice86DependencyInjection.cs
+++ b/src/Spice86/Spice86DependencyInjection.cs
@@ -160,7 +160,7 @@ public class Spice86DependencyInjection : IDisposable {
                 emulatorStateSerializer);
             mainWindowViewModel = new MainWindowViewModel(
                 timer, uiThreadDispatcher, hostStorageProvider, textClipboard, configuration,
-                loggerService, pauseHandler);
+                loggerService, pauseHandler, performanceViewModel);
         }
 
         VgaCard vgaCard = new(mainWindowViewModel, vgaRenderer, loggerService);

--- a/src/Spice86/ViewModels/MainWindowViewModel.cs
+++ b/src/Spice86/ViewModels/MainWindowViewModel.cs
@@ -33,6 +33,7 @@ public sealed partial class MainWindowViewModel : ViewModelWithErrorDialog, IGui
     private readonly AvaloniaKeyScanCodeConverter _avaloniaKeyScanCodeConverter;
     private readonly IPauseHandler _pauseHandler;
     private readonly ITimeMultiplier _pit;
+    private readonly PerformanceViewModel _performanceViewModel;
 
     [ObservableProperty]
     private bool _canUseInternalDebugger;
@@ -59,8 +60,9 @@ public sealed partial class MainWindowViewModel : ViewModelWithErrorDialog, IGui
 
     public MainWindowViewModel(
         ITimeMultiplier pit, IUIDispatcher uiDispatcher, IHostStorageProvider hostStorageProvider, ITextClipboard textClipboard,
-        Configuration configuration, ILoggerService loggerService, IPauseHandler pauseHandler) : base(textClipboard) {
+        Configuration configuration, ILoggerService loggerService, IPauseHandler pauseHandler, PerformanceViewModel performanceViewModel) : base(textClipboard) {
         _pit = pit;
+        _performanceViewModel = performanceViewModel;
         _avaloniaKeyScanCodeConverter = new AvaloniaKeyScanCodeConverter();
         Configuration = configuration;
         _loggerService = loggerService;
@@ -71,8 +73,13 @@ public sealed partial class MainWindowViewModel : ViewModelWithErrorDialog, IGui
         _pauseHandler.Resumed += OnResumed;
         TimeMultiplier = Configuration.TimeMultiplier;
         CanUseInternalDebugger = configuration.GdbPort is null;
+        DispatcherTimerStarter.StartNewDispatcherTimer(TimeSpan.FromSeconds(1.0 / 30.0), DispatcherPriority.MaxValue, (_, _) => UpdateCpuInstructionsPerMillisecondsInMainWindowTitle());
     }
-    
+
+    private void UpdateCpuInstructionsPerMillisecondsInMainWindowTitle() {
+        SetMainTitle(_performanceViewModel.InstructionsPerMillisecond);
+    }
+
     [RelayCommand]
     public void SetLogLevelToSilent() => SetLogLevel("Silent");
 
@@ -228,14 +235,15 @@ public sealed partial class MainWindowViewModel : ViewModelWithErrorDialog, IGui
 
     [RelayCommand(CanExecute = nameof(IsEmulatorRunning))]
     private async Task DumpEmulatorStateToFile() {
-        //TODO: refactor this
         await _hostStorageProvider.DumpEmulatorStateToFile().ConfigureAwait(false);
     }
 
     [RelayCommand(CanExecute = nameof(CanPause))]
     public void Pause() => _pauseHandler.RequestPause("Pause button pressed in main window");
 
-    private void SetMainTitle() => MainTitle = $"{nameof(Spice86)} {Configuration.Exe}";
+    private void SetMainTitle(double instructionsPerMillisecond) {
+        MainTitle = $"{nameof(Spice86)} {Configuration.Exe} - {instructionsPerMillisecond:N0} cycles/ms";
+    }
 
     [ObservableProperty]
     private string? _mainTitle;
@@ -303,7 +311,7 @@ public sealed partial class MainWindowViewModel : ViewModelWithErrorDialog, IGui
             _ => "ASM code overrides: none."
         };
         SetLogLevel(Configuration.SilencedLogs ? "Silent" : _loggerService.LogLevelSwitch.MinimumLevel.ToString());
-        SetMainTitle();
+        SetMainTitle(_performanceViewModel.InstructionsPerMillisecond);
         StartEmulatorThread();
     }
 

--- a/src/Spice86/ViewModels/MainWindowViewModel.cs
+++ b/src/Spice86/ViewModels/MainWindowViewModel.cs
@@ -242,7 +242,7 @@ public sealed partial class MainWindowViewModel : ViewModelWithErrorDialog, IGui
     public void Pause() => _pauseHandler.RequestPause("Pause button pressed in main window");
 
     private void SetMainTitle(double instructionsPerMillisecond) {
-        MainTitle = $"{nameof(Spice86)} {Configuration.Exe} - {instructionsPerMillisecond:N0} cycles/ms";
+        MainTitle = $"{nameof(Spice86)} {Configuration.Exe} - cycles/ms: {instructionsPerMillisecond,7:N0}";
     }
 
     [ObservableProperty]

--- a/src/Spice86/ViewModels/PerformanceViewModel.cs
+++ b/src/Spice86/ViewModels/PerformanceViewModel.cs
@@ -37,7 +37,11 @@ public partial class PerformanceViewModel : ViewModelBase {
         InstructionsExecuted = _state.Cycles;
         _performanceMeasurer.UpdateValue(_state.Cycles);
         AverageInstructionsPerSecond = _performanceMeasurer.AverageValuePerSecond;
+        InstructionsPerMillisecond = _performanceMeasurer.ValuePerMillisecond;
     }
+
+    [ObservableProperty]
+    private double _instructionsPerMillisecond;
 
     [ObservableProperty]
     private double _instructionsExecuted;


### PR DESCRIPTION
### Description of Changes

Fixes performances measurements which were incorrectly measured as 0 if samples were given with a time resolution below one millisecond to the PerformanceMeasurer class.

Also makes the EmulationLoop uses the PerformanceMeasurer to record and calculate performance measures, instead of recreating the function by itself.

### Rationale behind Changes

Just a small fix I came across.

### Suggested Testing Steps

Already tested. Nothing changed.
