### PR TITLE
chore: CA1859, CA1860 warnings fix

### DIFF
--- a/src/Spice86.Core/Emulator/Devices/Video/Renderer.cs
+++ b/src/Spice86.Core/Emulator/Devices/Video/Renderer.cs
@@ -10,7 +10,7 @@ using System.Diagnostics;
 /// <inheritdoc cref="IVgaRenderer" />
 public class Renderer : IVgaRenderer {
     private static readonly object RenderLock = new();
-    private readonly IVideoMemory _memory;
+    private readonly VideoMemory _memory;
     private readonly IVideoState _state;
 
     /// <summary>
@@ -194,7 +194,10 @@ public class Renderer : IVgaRenderer {
         return memoryWidthMode;
     }
 
-    private (byte plane0, byte plane1, byte plane2, byte plane3) ReadVideoMemory(MemoryWidth memoryWidthMode, int memoryAddressCounter, bool scanLineBit0ForAddressBit13, int scanline, bool scanLineBit0ForAddressBit14, IReadOnlyList<bool> planesEnabled) {
+    private (byte plane0, byte plane1, byte plane2, byte plane3) ReadVideoMemory(
+        MemoryWidth memoryWidthMode, int memoryAddressCounter,
+        bool scanLineBit0ForAddressBit13, int scanline,
+        bool scanLineBit0ForAddressBit14, ReadOnlySpan<bool> planesEnabled) {
         // Convert logical address to physical address.
         ushort physicalAddress = memoryWidthMode switch {
             MemoryWidth.Byte => (ushort)memoryAddressCounter,

--- a/src/Spice86.Core/Emulator/Devices/Video/VideoMemory.cs
+++ b/src/Spice86.Core/Emulator/Devices/Video/VideoMemory.cs
@@ -142,7 +142,7 @@ public class VideoMemory : IVideoMemory {
         }
     }
 
-    private void HandleWriteMode1(Register8 planeEnable, IReadOnlyList<bool> writePlane, uint offset) {
+    private void HandleWriteMode1(Register8 planeEnable, ReadOnlySpan<bool> writePlane, uint offset) {
         // Foreach plane
         for (int plane = 0; plane < 4; plane++) {
             if (planeEnable[plane] && writePlane[plane]) {
@@ -151,7 +151,8 @@ public class VideoMemory : IVideoMemory {
         }
     }
 
-    private void HandleWriteMode0(byte value, Register8 planeEnable, IReadOnlyList<bool> writePlane, Register8 setResetEnable, Register8 setReset, uint offset) {
+    private void HandleWriteMode0(byte value, Register8 planeEnable,
+        ReadOnlySpan<bool> writePlane, Register8 setResetEnable, Register8 setReset, uint offset) {
         Debug.Assert(offset < 0x10000);
         if (_state.GraphicsControllerRegisters.DataRotateRegister.RotateCount != 0) {
             value.Ror(_state.GraphicsControllerRegisters.DataRotateRegister.RotateCount);

--- a/src/Spice86.Core/Emulator/Gdb/GdbCommandHandler.cs
+++ b/src/Spice86.Core/Emulator/Gdb/GdbCommandHandler.cs
@@ -135,12 +135,12 @@ public class GdbCommandHandler {
 
     private Tuple<string, object> ParseSupportedQuery(string item) {
         Tuple<string, object> res;
-        if (item.EndsWith("+")) {
+        if (item.EndsWith('+')) {
             res = Tuple.Create(item[0..^1], (object)true);
-        } else if (item.EndsWith("-")) {
+        } else if (item.EndsWith('-')) {
             res = Tuple.Create(item[0..^1], (object)false);
         } else {
-            string[] split = item.Split("=");
+            string[] split = item.Split('=');
             res = Tuple.Create(split[0], new object());
             if (split.Length == 2) {
                 res = Tuple.Create(split[0], (object)split[1]);
@@ -171,12 +171,12 @@ public class GdbCommandHandler {
             return _gdbIo.GenerateResponse("");
         }
 
-        if (command.StartsWith("L")) {
+        if (command.StartsWith('L')) {
             string nextthread = command[4..];
             return _gdbIo.GenerateResponse($"qM011{nextthread}00000001");
         }
 
-        if (command.StartsWith("P")) {
+        if (command.StartsWith('P')) {
             return _gdbIo.GenerateResponse("");
         }
 

--- a/src/Spice86.Core/Emulator/InterruptHandlers/Common/MemoryWriter/MemoryAsmWriter.cs
+++ b/src/Spice86.Core/Emulator/InterruptHandlers/Common/MemoryWriter/MemoryAsmWriter.cs
@@ -30,7 +30,7 @@ public class MemoryAsmWriter : MemoryWriter {
     /// <param name="callbackNumber">Callback index</param>
     /// <param name="runnable">Action to run when this callback is executed by the CPU</param>
     public void RegisterAndWriteCallback(byte callbackNumber, Action runnable) {
-        ICallback callback = new Callback(callbackNumber, runnable, GetCurrentAddressCopy());
+        Callback callback = new Callback(callbackNumber, runnable, GetCurrentAddressCopy());
         _callbackHandler.AddCallback(callback);
         WriteCallback(callback.Index);
     }

--- a/src/Spice86.Core/Emulator/InterruptHandlers/Dos/DosInt21Handler.cs
+++ b/src/Spice86.Core/Emulator/InterruptHandlers/Dos/DosInt21Handler.cs
@@ -32,7 +32,7 @@ public class DosInt21Handler : InterruptHandler {
 
     private StringBuilder _displayOutputBuilder = new();
     private readonly DosFileManager _dosFileManager;
-    private readonly IList<IVirtualDevice> _devices;
+    private readonly List<IVirtualDevice> _devices;
     private readonly Dos _dos;
     private readonly KeyboardInt16Handler _keyboardInt16Handler;
     private readonly IVgaFunctionality _vgaFunctionality;

--- a/src/Spice86.Core/Emulator/InterruptHandlers/VGA/VgaFunctionality.cs
+++ b/src/Spice86.Core/Emulator/InterruptHandlers/VGA/VgaFunctionality.cs
@@ -792,9 +792,9 @@ public class VgaFunctionality : IVgaFunctionality {
         return new SegmentedAddress(_interruptVectorTable[vector]);
     }
 
-    private int MemCmp(IReadOnlyList<byte> bytes, ushort segment, ushort offset, int length) {
+    private int MemCmp(ReadOnlySpan<byte> bytes, ushort segment, ushort offset, int length) {
         int i = 0;
-        while (length-- > 0 && i < bytes.Count) {
+        while (length-- > 0 && i < bytes.Length) {
             int difference = bytes[i] - _memory.UInt8[segment, offset];
             if (difference != 0) {
                 return difference < 0 ? -1 : 1;
@@ -1245,7 +1245,7 @@ public class VgaFunctionality : IVgaFunctionality {
         WriteByteToIoPort(value, VgaPort.AttributeAddress);
     }
 
-    private void WriteToDac(IReadOnlyList<byte> palette, byte startIndex, int count) {
+    private void WriteToDac(ReadOnlySpan<byte> palette, byte startIndex, int count) {
         WriteByteToIoPort(startIndex, VgaPort.DacAddressWriteIndex);
         int i = 0;
         while (count > 0) {
@@ -1333,26 +1333,26 @@ public class VgaFunctionality : IVgaFunctionality {
         WriteToMiscellaneousOutput(miscellaneousRegisterValue);
     }
 
-    private void SetCrtControllerRegisters(VgaPort crtControllerPort, IReadOnlyList<byte> videoModeCrtControllerRegisterValues) {
+    private void SetCrtControllerRegisters(VgaPort crtControllerPort, ReadOnlySpan<byte> videoModeCrtControllerRegisterValues) {
         for (byte i = 0; i <= 0x18; i++) {
             WriteToCrtController(crtControllerPort, i, videoModeCrtControllerRegisterValues[i]);
         }
     }
 
-    private void SetGraphicsControllerRegisters(IReadOnlyList<byte> videoModeGraphicsControllerRegisterValues) {
-        for (byte i = 0; i < videoModeGraphicsControllerRegisterValues.Count; i++) {
+    private void SetGraphicsControllerRegisters(ReadOnlySpan<byte> videoModeGraphicsControllerRegisterValues) {
+        for (byte i = 0; i < videoModeGraphicsControllerRegisterValues.Length; i++) {
             WriteToGraphicsController(i, videoModeGraphicsControllerRegisterValues[i]);
         }
     }
 
-    private void SetSequencerRegisters(IReadOnlyList<byte> videoModeSequencerRegisterValues) {
-        for (byte i = 0; i < videoModeSequencerRegisterValues.Count; i++) {
+    private void SetSequencerRegisters(ReadOnlySpan<byte> videoModeSequencerRegisterValues) {
+        for (byte i = 0; i < videoModeSequencerRegisterValues.Length; i++) {
             WriteToSequencer(i, videoModeSequencerRegisterValues[i]);
         }
     }
 
-    private void SetAttributeControllerRegisters(IReadOnlyList<byte> videoModeAttributeControllerRegisterValues) {
-        for (byte i = 0; i < videoModeAttributeControllerRegisterValues.Count; i++) {
+    private void SetAttributeControllerRegisters(ReadOnlySpan<byte> videoModeAttributeControllerRegisterValues) {
+        for (byte i = 0; i < videoModeAttributeControllerRegisterValues.Length; i++) {
             WriteToAttributeController(i, videoModeAttributeControllerRegisterValues[i]);
         }
     }

--- a/src/Spice86.Core/Emulator/OperatingSystem/DosPathResolver.cs
+++ b/src/Spice86.Core/Emulator/OperatingSystem/DosPathResolver.cs
@@ -41,7 +41,7 @@ internal class DosPathResolver {
     /// </summary>
     public DosFileOperationResult GetCurrentDosDirectory(byte driveNumber, out string currentDir) {
         //0 = default drive
-        if (driveNumber == 0 && _driveMap.Any()) {
+        if (driveNumber == 0 && _driveMap.Count > 0) {
             MountedFolder mountedFolder = _driveMap[_currentDrive];
             currentDir = mountedFolder.CurrentDosDirectory;
             return DosFileOperationResult.NoValue();


### PR DESCRIPTION
Changes private signatures and private variables to use concrete types instead of interfaces when possible.

Some lines replace the usage of LINQ with direct collection properties, such as the Any extension method begin replaced with List.Count

Doesn't measurably improves performance, but makes VS shut up about it.