### PR TITLE
chore: v8.0.0 Nuget Release

### DIFF
--- a/.github/workflows/nuget.yml
+++ b/.github/workflows/nuget.yml
@@ -34,20 +34,20 @@ jobs:
 
     - name: Upload NuGet Bufdio.Spice86
       working-directory: ./src/Bufdio.Spice86/bin/Release
-      run: nuget push Bufdio.Spice86.7.0.0.nupkg ${{secrets.NUGET_API_KEY}} -Source 'https://api.nuget.org/v3/index.json' -SkipDuplicate
+      run: nuget push Bufdio.Spice86.8.0.0.nupkg ${{secrets.NUGET_API_KEY}} -Source 'https://api.nuget.org/v3/index.json' -SkipDuplicate
 
     - name: Upload NuGet Spice86.Shared
       working-directory: ./src/Spice86.Shared/bin/Release
-      run: nuget push Spice86.Shared.7.0.0.nupkg ${{secrets.NUGET_API_KEY}} -Source 'https://api.nuget.org/v3/index.json' -SkipDuplicate
+      run: nuget push Spice86.Shared.8.0.0.nupkg ${{secrets.NUGET_API_KEY}} -Source 'https://api.nuget.org/v3/index.json' -SkipDuplicate
 
     - name: Upload NuGet Spice86.Logging
       working-directory: ./src/Spice86.Logging/bin/Release
-      run: nuget push Spice86.Logging.7.0.0.nupkg ${{secrets.NUGET_API_KEY}} -Source 'https://api.nuget.org/v3/index.json' -SkipDuplicate
+      run: nuget push Spice86.Logging.8.0.0.nupkg ${{secrets.NUGET_API_KEY}} -Source 'https://api.nuget.org/v3/index.json' -SkipDuplicate
 
     - name: Upload NuGet Spice86.Core
       working-directory: ./src/Spice86.Core/bin/Release
-      run: nuget push Spice86.Core.7.0.0.nupkg ${{secrets.NUGET_API_KEY}} -Source 'https://api.nuget.org/v3/index.json' -SkipDuplicate
+      run: nuget push Spice86.Core.8.0.0.nupkg ${{secrets.NUGET_API_KEY}} -Source 'https://api.nuget.org/v3/index.json' -SkipDuplicate
 
     - name: Upload NuGet Spice86
       working-directory: ./src/Spice86/bin/Release
-      run: nuget push Spice86.7.0.0.nupkg ${{secrets.NUGET_API_KEY}} -Source 'https://api.nuget.org/v3/index.json' -SkipDuplicate
+      run: nuget push Spice86.8.0.0.nupkg ${{secrets.NUGET_API_KEY}} -Source 'https://api.nuget.org/v3/index.json' -SkipDuplicate

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -16,8 +16,8 @@
 	</PropertyGroup>
 	<!-- Nuget package info-->
 	<PropertyGroup>
-		<Version>7.0.0</Version>
-		<PackageReleaseNotes>Some breaking API changes (SegmentRegisters.cs), WIP new CFG_CPU, addtionnal memory/disasm views to the internal debugger, replaced UI DI framework with Microsoft.DI.</PackageReleaseNotes>
+		<Version>8.0.0</Version>
+		<PackageReleaseNotes>Some breaking API changes (replaced Microosft.DI with compile-time DI, see Spice86DependencyInjection), Breakpoint support in Internal Debugger, SegmentRegisters replaced by SegmentRegisterIndex, and dependendencies to the Machine class have been replaced with direct dependencies in all classes, which is also a breaking change for projects using Spice86 compared to Nuget v7.0.0.</PackageReleaseNotes>
 		<Authors>Kevin Ferrare, Maximilien Noal, Joris van Eijden, Artjom Vejsel</Authors>
 		<PackageTags>reverse-engineering;avalonia;debugger;assembly;emulator;cross-platform</PackageTags>
 		<Description>Reverse engineer and rewrite real mode dos programs</Description>

--- a/src/Spice86/Views/DebugWindow.axaml
+++ b/src/Spice86/Views/DebugWindow.axaml
@@ -61,7 +61,8 @@
 					</LayoutTransformControl>
 				</controls:HotKeyTabItem.Header>
 			</controls:HotKeyTabItem>
-			<controls:HotKeyTabItem HotKeyManager.HotKey="Alt+F2"
+			<!-- Commented out until CFGCPU is used in production -->
+			<!--controls:HotKeyTabItem HotKeyManager.HotKey="Alt+F2"
 				Content="{Binding CfgCpuViewModel}">
 				<controls:HotKeyTabItem.Header>
 					<LayoutTransformControl>
@@ -71,7 +72,7 @@
 						<TextBlock Margin="5,0,0,5" Text="Code Flow" ToolTip.Tip="Alt-F2" />
 					</LayoutTransformControl>
 				</controls:HotKeyTabItem.Header>
-			</controls:HotKeyTabItem>
+			</controls:HotKeyTabItem-->
 			<controls:HotKeyTabItem HotKeyManager.HotKey="Alt+F3">
 				<controls:HotKeyTabItem.Header>
 					<LayoutTransformControl>


### PR DESCRIPTION
### Description of Changes

v8.0.0 of the Spice86 Nuget Package for Cryogenic and people who want to use a Release version of Spice86 via Nuget.

### Rationale behind Changes

There has been a lot of breaking changes for users around dependency injection, a lot of new features for the internal debugger, justifying a new Nuget release.

### Suggested Testing Steps

Cryogenic already has a branch set up to use the latest Spice86 code. It still works.