### PR TITLE
fix: Off by one error

### DIFF
--- a/src/Spice86/MemoryWrappers/DataMemoryDocument.cs
+++ b/src/Spice86/MemoryWrappers/DataMemoryDocument.cs
@@ -5,6 +5,7 @@ using Spice86.Core.Emulator.Memory;
 
 using System;
 
+/// <inheritdoc cref="IBinaryDocument" />
 public sealed class DataMemoryDocument : IBinaryDocument {
     private readonly IMemory _memory;
     private readonly uint _startAddress;
@@ -17,7 +18,7 @@ public sealed class DataMemoryDocument : IBinaryDocument {
         _startAddress = startAddress;
         _endAddress = endAddress;
         _memory = memory;
-        ValidRanges = new MemoryReadOnlyBitRangeUnion(0, _endAddress + 1 - _startAddress);
+        ValidRanges = new MemoryReadOnlyBitRangeUnion(0, _endAddress - _startAddress);
     }
 
     public event Action<Exception>? MemoryReadInvalidOperation;

--- a/src/Spice86/MemoryWrappers/MemoryReadOnlyBitRangeUnion.cs
+++ b/src/Spice86/MemoryWrappers/MemoryReadOnlyBitRangeUnion.cs
@@ -17,7 +17,7 @@ internal class MemoryReadOnlyBitRangeUnion : IReadOnlyBitRangeUnion {
     /// Initializes a new instance of the <see cref="MemoryReadOnlyBitRangeUnion"/> class.
     /// </summary>
     /// <param name="startAddress">The start address of tha range of memory.</param>
-    /// <param name="endAddress">The end address of the range of memory. This end address is not included in the range.</param>
+    /// <param name="endAddress">The end address of the range of memory.</param>
     public MemoryReadOnlyBitRangeUnion(uint startAddress, uint endAddress) {
         _startAddress = startAddress;
         _endAddress = endAddress;


### PR DESCRIPTION
This code was generating an IndexOutOfRangeException error when scrolling at the end of the Memory document in the Internal Debugger's memory tab.