### PR TITLE
chore: Spice86 Nuget v8.0.2 hotfix

### DIFF
--- a/.github/workflows/nuget.yml
+++ b/.github/workflows/nuget.yml
@@ -34,20 +34,20 @@ jobs:
 
     - name: Upload NuGet Bufdio.Spice86
       working-directory: ./src/Bufdio.Spice86/bin/Release
-      run: nuget push Bufdio.Spice86.8.0.1.nupkg ${{secrets.NUGET_API_KEY}} -Source 'https://api.nuget.org/v3/index.json' -SkipDuplicate
+      run: nuget push Bufdio.Spice86.8.0.2.nupkg ${{secrets.NUGET_API_KEY}} -Source 'https://api.nuget.org/v3/index.json' -SkipDuplicate
 
     - name: Upload NuGet Spice86.Shared
       working-directory: ./src/Spice86.Shared/bin/Release
-      run: nuget push Spice86.Shared.8.0.1.nupkg ${{secrets.NUGET_API_KEY}} -Source 'https://api.nuget.org/v3/index.json' -SkipDuplicate
+      run: nuget push Spice86.Shared.8.0.2.nupkg ${{secrets.NUGET_API_KEY}} -Source 'https://api.nuget.org/v3/index.json' -SkipDuplicate
 
     - name: Upload NuGet Spice86.Logging
       working-directory: ./src/Spice86.Logging/bin/Release
-      run: nuget push Spice86.Logging.8.0.1.nupkg ${{secrets.NUGET_API_KEY}} -Source 'https://api.nuget.org/v3/index.json' -SkipDuplicate
+      run: nuget push Spice86.Logging.8.0.2.nupkg ${{secrets.NUGET_API_KEY}} -Source 'https://api.nuget.org/v3/index.json' -SkipDuplicate
 
     - name: Upload NuGet Spice86.Core
       working-directory: ./src/Spice86.Core/bin/Release
-      run: nuget push Spice86.Core.8.0.1.nupkg ${{secrets.NUGET_API_KEY}} -Source 'https://api.nuget.org/v3/index.json' -SkipDuplicate
+      run: nuget push Spice86.Core.8.0.2.nupkg ${{secrets.NUGET_API_KEY}} -Source 'https://api.nuget.org/v3/index.json' -SkipDuplicate
 
     - name: Upload NuGet Spice86
       working-directory: ./src/Spice86/bin/Release
-      run: nuget push Spice86.8.0.1.nupkg ${{secrets.NUGET_API_KEY}} -Source 'https://api.nuget.org/v3/index.json' -SkipDuplicate
+      run: nuget push Spice86.8.0.2.nupkg ${{secrets.NUGET_API_KEY}} -Source 'https://api.nuget.org/v3/index.json' -SkipDuplicate

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -16,8 +16,8 @@
 	</PropertyGroup>
 	<!-- Nuget package info-->
 	<PropertyGroup>
-		<Version>8.0.1</Version>
-		<PackageReleaseNotes>fix: General MIDI soundfont did not load, preventing Spice86 from loading.</PackageReleaseNotes>
+		<Version>8.0.2</Version>
+		<PackageReleaseNotes>fix: Off by one error generating an IndexOutOfRangeException in the internal debugger Memory tab.</PackageReleaseNotes>
 		<Authors>Kevin Ferrare, Maximilien Noal, Joris van Eijden, Artjom Vejsel</Authors>
 		<PackageTags>reverse-engineering;avalonia;debugger;assembly;emulator;cross-platform</PackageTags>
 		<Description>Reverse engineer and rewrite real mode dos programs</Description>


### PR DESCRIPTION
Following the off-by-one-error hotfix, this ensures that a new Nuget (v8.0.2) is published