### PR TITLE
fix: Rider has build issues with .NET 9

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -63,7 +63,7 @@ jobs:
     - name: Setup .NET
       uses: actions/setup-dotnet@v1
       with:
-        dotnet-version: '9.0.x'
+        dotnet-version: '8.0.x'
 
     - run: |
         echo "running custom build action..."

--- a/.github/workflows/nuget.yml
+++ b/.github/workflows/nuget.yml
@@ -22,7 +22,7 @@ jobs:
     - name: Setup .NET
       uses: actions/setup-dotnet@v1
       with:
-        dotnet-version: '9.0.x'
+        dotnet-version: '8.0.x'
 
     - name: Test with dotnet
       working-directory: ./src

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -20,7 +20,7 @@ jobs:
     - name: Setup .NET
       uses: actions/setup-dotnet@v1
       with:
-        dotnet-version: '9.0.x'
+        dotnet-version: '8.0.x'
 
     - name: Test with dotnet
       working-directory: ./src

--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -16,7 +16,7 @@ jobs:
        - name: Setup .NET
          uses: actions/setup-dotnet@v1
          with:
-           dotnet-version: '9.0.x'
+           dotnet-version: '8.0.x'
 
        - name: Install zip
          uses: montudor/action-zip@v1

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Pre-releases are also available [on the Release page](https://github.com/OpenRak
 
 NOTE: This is a port, and a continuation from the [original Java Spice86](https://github.com/kevinferrare/spice86).
 
-It requires [.NET 9](https://dotnet.microsoft.com/en-us/download/dotnet/9.0) and runs on Windows, macOS, and Linux.
+It requires [.NET 8](https://dotnet.microsoft.com/en-us/download/dotnet/8.0) and runs on Windows, macOS, and Linux.
 
 ## Approach
 Rewriting a program from only the binary is a hard task.
@@ -344,7 +344,7 @@ Compatibility list available [here](COMPATIBILITY.md).
 
 ### How to build on your machine
 
-- Install the [.NET 9 SDK](https://dotnet.microsoft.com/en-us/download/dotnet/9.0) (once)
+- Install the [.NET 8 SDK](https://dotnet.microsoft.com/en-us/download/dotnet/8.0) (once)
 - clone the repo
 - run this where Spice86.sln is located:
 

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -1,6 +1,6 @@
 <Project>
 	<PropertyGroup>
-		<TargetFramework>net9.0</TargetFramework>
+		<TargetFramework>net8.0</TargetFramework>
 		<ImplicitUsings>enable</ImplicitUsings>
 		<Nullable>enable</Nullable>
 		<EnablePackageValidation>true</EnablePackageValidation>

--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -11,17 +11,17 @@
     <PackageVersion Include="Avalonia.Desktop" Version="11.2.3" />
     <PackageVersion Include="Avalonia.Diagnostics" Version="11.2.3" />
     <PackageVersion Include="Avalonia.Fonts.Inter" Version="11.2.3" />
-    <PackageVersion Include="Avalonia.Xaml.Behaviors" Version="11.2.0.1" />
+    <PackageVersion Include="Avalonia.Xaml.Behaviors" Version="11.2.0.7" />
     <PackageVersion Include="AvaloniaGraphControl" Version="0.6.1" />
     <PackageVersion Include="AvaloniaHex" Version="0.1.6" />
-    <PackageVersion Include="bodong.Avalonia.PropertyGrid" Version="11.1.4.2" />
-    <PackageVersion Include="bodong.PropertyModels" Version="11.1.4.2" />
+    <PackageVersion Include="bodong.Avalonia.PropertyGrid" Version="11.2.3.4" />
+    <PackageVersion Include="bodong.PropertyModels" Version="11.2.3.4" />
     <PackageVersion Include="CommandLineParser" Version="2.9.1" />
     <PackageVersion Include="CommunityToolkit.HighPerformance" Version="8.4.0" />
     <PackageVersion Include="CommunityToolkit.Mvvm" Version="8.4.0" />
     <PackageVersion Include="coverlet.collector" Version="6.0.2" />
     <PackageVersion Include="Deadpikle.AvaloniaProgressRing" Version="0.10.10" />
-    <PackageVersion Include="DialogHost.Avalonia" Version="0.8.1" />
+    <PackageVersion Include="DialogHost.Avalonia" Version="0.9.1" />
     <PackageVersion Include="ErrorProne.NET.CoreAnalyzers" Version="0.1.2" />
     <PackageVersion Include="FluentIcons.Avalonia.Fluent" Version="1.1.271" />
     <PackageVersion Include="Iced" Version="1.21.0" />
@@ -35,8 +35,8 @@
     <PackageVersion Include="NSubstitute.Analyzers.CSharp" Version="1.0.17" />
     <PackageVersion Include="Roslynator.Analyzers" Version="4.12.9" />
     <PackageVersion Include="Roslynator.CodeAnalysis.Analyzers" Version="4.12.9" />
-    <PackageVersion Include="Semi.Avalonia" Version="11.2.1.2" />
-    <PackageVersion Include="Semi.Avalonia.DataGrid" Version="11.2.1.2" />
+    <PackageVersion Include="Semi.Avalonia" Version="11.2.1.3" />
+    <PackageVersion Include="Semi.Avalonia.DataGrid" Version="11.2.1.3" />
     <PackageVersion Include="Semi.Avalonia.TreeDataGrid" Version="11.0.10.1" />
     <PackageVersion Include="Serilog" Version="4.2.0" />
     <PackageVersion Include="Serilog.Sinks.Console" Version="6.0.0" />
@@ -46,8 +46,8 @@
     <PackageVersion Include="System.IO" Version="4.3.0" />
     <PackageVersion Include="System.IO.UnmanagedMemoryStream" Version="4.3.0" />
     <PackageVersion Include="System.Memory" Version="4.6.0" />
-    <PackageVersion Include="System.Memory.Data" Version="9.0.0" />
-    <PackageVersion Include="System.Text.Encoding.CodePages" Version="9.0.0" />
-    <PackageVersion Include="System.Text.Json" Version="9.0.0" />
+    <PackageVersion Include="System.Memory.Data" Version="9.0.1" />
+    <PackageVersion Include="System.Text.Encoding.CodePages" Version="9.0.1" />
+    <PackageVersion Include="System.Text.Json" Version="9.0.1" />
   </ItemGroup>
 </Project>

--- a/tests/Directory.Packages.props
+++ b/tests/Directory.Packages.props
@@ -4,17 +4,17 @@
     <CentralPackageTransitivePinningEnabled>true</CentralPackageTransitivePinningEnabled>
   </PropertyGroup>
   <ItemGroup>
-    <PackageVersion Include="coverlet.collector" Version="6.0.2" />
+    <PackageVersion Include="coverlet.collector" Version="6.0.3" />
     <PackageVersion Include="ErrorProne.NET.CoreAnalyzers" Version="0.1.2" />
-    <PackageVersion Include="FluentAssertions" Version="7.0.0" />
+    <PackageVersion Include="FluentAssertions" Version="8.0.0" />
     <PackageVersion Include="JetBrains.Annotations" Version="2024.3.0" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
     <PackageVersion Include="NSubstitute" Version="5.3.0" />
     <PackageVersion Include="NSubstitute.Analyzers.CSharp" Version="1.0.17" />
     <PackageVersion Include="Roslynator.Analyzers" Version="4.12.10" />
     <PackageVersion Include="Roslynator.CodeAnalysis.Analyzers" Version="4.12.10" />
-    <PackageVersion Include="System.Text.Json" Version="9.0.0" />
-    <PackageVersion Include="xunit" Version="2.9.2" />
-    <PackageVersion Include="xunit.runner.visualstudio" Version="3.0.0" />
+    <PackageVersion Include="System.Text.Json" Version="9.0.1" />
+    <PackageVersion Include="xunit" Version="2.9.3" />
+    <PackageVersion Include="xunit.runner.visualstudio" Version="3.0.1" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
# Description 

.NET 9 prevents Rider (at least on some machines) from building Spice86. Those machines include @kevinferrare 's machine, and it is a blocking issue and not acceptable.

The problem is documented on the JetBrains' side of things, but in the meantime going back to .NET 8 is an easy fix.

# Testing

Try to build the solution with Rider. It should build with .NET 8.

'dotnet build' works either way, the issue is with .NET 9 support from JetBrains Rider itself.