### PR TITLE
Fix: Betrayal at Krondor SOUND BLASTER driver support (SNDBLAST.DRV)

### DIFF
--- a/src/Spice86.Core/Emulator/Devices/Sound/Blaster/SoundBlaster.cs
+++ b/src/Spice86.Core/Emulator/Devices/Sound/Blaster/SoundBlaster.cs
@@ -217,6 +217,8 @@ public class SoundBlaster : DefaultIOPortHandler, IDmaDevice8, IDmaDevice16, IRe
                 return (byte)_ctMixer.CurrentAddress;
             case DspPorts.MixerData:
                 return _ctMixer.ReadData();
+            case DspPorts.DspReset:
+                return 0xFF;
             default:
                 return base.ReadByte(port);
         }

--- a/src/Spice86.Core/Emulator/Memory/DmaChannel.cs
+++ b/src/Spice86.Core/Emulator/Memory/DmaChannel.cs
@@ -19,8 +19,10 @@ public sealed class DmaChannel {
     private byte _addressHighByte;
     private int _transferRate;
     private readonly Stopwatch _transferTimer = new();
+    private readonly IMemory _memory;
 
-    internal DmaChannel() {
+    internal DmaChannel(IMemory memory) {
+        _memory = memory;
     }
 
     /// <summary>
@@ -192,11 +194,10 @@ public sealed class DmaChannel {
     /// <summary>
     /// Performs a DMA transfer.
     /// </summary>
-    /// <param name="memory">The memory bus.</param>
     /// <remarks>
     /// This method should only be called if the channel is active.
     /// </remarks>
-    internal bool Transfer(IMemory memory) {
+    internal bool Transfer() {
         if (!MustTransferData) {
             return false;
         }
@@ -209,7 +210,7 @@ public sealed class DmaChannel {
 
         int count = Math.Min(TransferChunkSize, TransferBytesRemaining);
         int startAddress = (int)(memoryAddress + sourceOffset);
-        Span<byte> source = memory.GetSpan(startAddress, count);
+        Span<byte> source = _memory.GetSpan(startAddress, count);
 
         count = device.WriteBytes(source);
         TransferBytesRemaining -= count;

--- a/src/Spice86.Core/Emulator/OperatingSystem/Dos.cs
+++ b/src/Spice86.Core/Emulator/OperatingSystem/Dos.cs
@@ -114,12 +114,23 @@ public class Dos {
         _vgaFunctionality = vgaFunctionality;
         _keyboardStreamedInput = new KeyboardStreamedInput(keyboardInt16Handler);
         AddDefaultDevices();
-        FileManager = new DosFileManager(_memory, cDriveFolderPath, executablePath, _loggerService, this.Devices);
+        DosSwappableDataArea dosSwappableDataArea = new(_memory,
+            MemoryUtils.ToPhysicalAddress(0xb2, 0));
+
+        FileManager = new DosFileManager(_memory, cDriveFolderPath, executablePath,
+            _loggerService, this.Devices);
         MemoryManager = new DosMemoryManager(_memory, _loggerService);
-        DosInt20Handler = new DosInt20Handler(_memory, cpu, _loggerService);
-        DosInt21Handler = new DosInt21Handler(_memory, cpu, keyboardInt16Handler, _vgaFunctionality, this, _loggerService);
-        DosInt2FHandler = new DosInt2fHandler(_memory, cpu, _loggerService);
-        DosInt28Handler = new DosInt28Handler(_memory, cpu, _loggerService);
+        DosInt20Handler = new DosInt20Handler(_memory, cpu, 
+            _loggerService);
+        DosInt21Handler = new DosInt21Handler(_memory, cpu,
+            keyboardInt16Handler, _vgaFunctionality, this,
+            dosSwappableDataArea,
+            _loggerService);
+        DosInt2FHandler = new DosInt2fHandler(_memory, cpu,
+            _loggerService);
+        DosInt28Handler = new DosInt28Handler(_memory, cpu, 
+            _loggerService);
+
         if (_loggerService.IsEnabled(LogEventLevel.Verbose)) {
             _loggerService.Verbose("Initializing DOS");
         }

--- a/src/Spice86.Core/Emulator/OperatingSystem/Structures/DosSwappableDataArea.cs
+++ b/src/Spice86.Core/Emulator/OperatingSystem/Structures/DosSwappableDataArea.cs
@@ -1,0 +1,29 @@
+﻿namespace Spice86.Core.Emulator.OperatingSystem.Structures;
+
+using Spice86.Core.Emulator.Memory.ReaderWriter;
+using Spice86.Core.Emulator.ReverseEngineer.DataStructure;
+
+
+/// <summary>
+/// Represents the DOS swappable data area.
+/// </summary>
+public class DosSwappableDataArea : MemoryBasedDataStructure {
+    public const ushort BaseSegment = 0xB2;
+
+    public DosSwappableDataArea(IByteReaderWriter byteReaderWriter, uint baseAddress) : base(byteReaderWriter, baseAddress) {
+        InDosFlag = 0;
+    }
+
+    /// <summary>
+    /// The offset in bytes where the InDOS flag is located.
+    /// </summary>
+    public const int InDosFlagOffset = 0x01;
+
+    /// <summary>
+    /// Gets or sets the InDOS flag.
+    /// </summary>
+    public byte InDosFlag {
+        get => UInt8[InDosFlagOffset];
+        set => UInt8[InDosFlagOffset] = value;
+    }
+}

--- a/src/Spice86.Core/Emulator/ProgramExecutor.cs
+++ b/src/Spice86.Core/Emulator/ProgramExecutor.cs
@@ -7,6 +7,7 @@ using Serilog.Events;
 using Spice86.Core.CLI;
 using Spice86.Core.Emulator.CPU;
 using Spice86.Core.Emulator.CPU.CfgCpu;
+using Spice86.Core.Emulator.Devices.DirectMemoryAccess;
 using Spice86.Core.Emulator.Devices.Timer;
 using Spice86.Core.Emulator.Function;
 using Spice86.Core.Emulator.Gdb;
@@ -55,18 +56,24 @@ public sealed class ProgramExecutor : IDisposable {
     /// <param name="executionFlowRecorder">The class that records machine code execution flow.</param>
     /// <param name="pauseHandler">The object responsible for pausing an resuming the emulation.</param>
     /// <param name="screenPresenter">The user interface class that displays video output in a dedicated thread.</param>
+    /// <param name="dmaController">The Direct Memory Access controller chip.</param>
     /// <param name="loggerService">The logging service to use.</param>
     public ProgramExecutor(Configuration configuration,
         EmulatorBreakpointsManager emulatorBreakpointsManager, EmulatorStateSerializer emulatorStateSerializer,
         IMemory memory, Cpu cpu, CfgCpu cfgCpu, State state, Timer timer, Dos dos,
         CallbackHandler callbackHandler, FunctionHandler functionHandler,
-        ExecutionFlowRecorder executionFlowRecorder, IPauseHandler pauseHandler, IScreenPresenter? screenPresenter, ILoggerService loggerService) {
+        ExecutionFlowRecorder executionFlowRecorder, IPauseHandler pauseHandler,
+        IScreenPresenter? screenPresenter, DmaController dmaController,
+        ILoggerService loggerService) {
         _configuration = configuration;
         _loggerService = loggerService;
         _emulatorStateSerializer = emulatorStateSerializer;
         _pauseHandler = pauseHandler;
-        _emulationLoop = new EmulationLoop(_loggerService, functionHandler, configuration.CfgCpu ? cfgCpu : cpu, state,
-            timer, emulatorBreakpointsManager, pauseHandler);
+        _emulationLoop = new EmulationLoop(_loggerService,
+            functionHandler, configuration.CfgCpu ? cfgCpu : cpu,
+            state, timer, emulatorBreakpointsManager,
+            dmaController,
+            pauseHandler);
         if (configuration.GdbPort.HasValue) {
             _gdbServer = CreateGdbServer(configuration, memory, cpu, state, callbackHandler, functionHandler,
                 executionFlowRecorder, emulatorBreakpointsManager, pauseHandler, _loggerService);

--- a/src/Spice86.Core/Emulator/VM/Machine.cs
+++ b/src/Spice86.Core/Emulator/VM/Machine.cs
@@ -275,7 +275,6 @@ public sealed class Machine : IDisposable {
             if (disposing) {
                 MidiDevice.Dispose();
                 SoundBlaster.Dispose();
-                DmaController.Dispose();
                 OPL3FM.Dispose();
                 PcSpeaker.Dispose();
                 SoftwareMixer.Dispose();

--- a/src/Spice86/Spice86DependencyInjection.cs
+++ b/src/Spice86/Spice86DependencyInjection.cs
@@ -201,6 +201,7 @@ public class Spice86DependencyInjection : IDisposable {
             emulatorStateSerializer, memory, cpu, cfgCpu, state,
             timer, dos, callbackHandler, functionHandler, executionFlowRecorder, pauseHandler,
             mainWindowViewModel,
+            dmaController,
             loggerService);
 
         if (configuration.InitializeDOS is not false) {


### PR DESCRIPTION
### Description of Changes

Implements:

- The DOS INDOS flag (described as 'number of calls to INT21H' in DOSBox source code).
 -> DOSBox doesnt increment it ever, so we don't either.
 Reason: DOS INT21H 0x34 (Get INDOS flag address) is called by SNDBLAST.DRV

Changes:
- Removes the DMA  Thread Loop
 -> This did not impact performance. I guess my current PC is... current. And not from 2016.
 -> So it manages Dune's intro, Dune's ingame, and Krondor intro and ingame voices without this ugly hack.
 -> A DMA Thread has always been a crazy thing.
 -> With it, the SNDBLAST.DRV made an infinite loop. Without it, the game started.
 -> With it, it seems that the site of the crash was always random in Release mode. INT8H, INT2F, Unitialized Vector error, somewhere else...

Adds:
- 0xFF is returned when DspPort.Reset (0x266) is read from the Sound Blaster.
 -> Same implementation as in DOSBox. Makes the SNDBLAST.DRV module happy.

### Rationale behind Changes

Fixes the SNDBLAST.DRV from Krondor.
It works with DOSBox, it should work with Spice86.

### Suggested Testing Steps

Already tested with Dune and Krondor successfully.

### How to test

Use SNDBLAST.DRV in the _resource.cfg_ file of Betrayal at Krondor.

```
 soundDrv  = SNDBLAST.DRV
 mouseDrv = none
 memoryDrv = none
 joyDrv    = none
	minEMS = 1024
	minCPU = 386
	minDOS = 500
	size = 15000
	cd=yes
 nonrotatingmap = 1
 

```

The stock GOG installation uses MT32.DRV for some reason.

Arguments for Spice86:

`-f -w --Ems -d false -e "D:\Data\Betrayal at Krondor\KRONDOR.EXE"`