### PR TITLE
fix: Always mark DOS critical sections

### DIFF
--- a/src/Spice86.Core/Emulator/InterruptHandlers/Dos/DosInt20Handler.cs
+++ b/src/Spice86.Core/Emulator/InterruptHandlers/Dos/DosInt20Handler.cs
@@ -3,20 +3,23 @@
 using Spice86.Core.Emulator.CPU;
 using Spice86.Core.Emulator.InterruptHandlers;
 using Spice86.Core.Emulator.Memory;
+using Spice86.Core.Emulator.OperatingSystem.Structures;
 using Spice86.Core.Emulator.VM;
 using Spice86.Shared.Interfaces;
 
 /// <summary>
 /// Reimplementation of int20
 /// </summary>
-public class DosInt20Handler : InterruptHandler {
+public class DosInt20Handler : DosInterruptHandler {
     /// <summary>
     /// Initializes a new instance.
     /// </summary>
     /// <param name="memory">The memory bus.</param>
     /// <param name="cpu">The emulated CPU.</param>
+    /// <param name="dosSwappableDataArea">The DOS structure holding global information, such as the INDOS flag.</param>
     /// <param name="loggerService">The logger service implementation.</param>
-    public DosInt20Handler(IMemory memory, Cpu cpu, ILoggerService loggerService) : base(memory, cpu, loggerService) {
+    public DosInt20Handler(IMemory memory, Cpu cpu, DosSwappableDataArea dosSwappableDataArea, ILoggerService loggerService) :
+        base(memory, cpu, dosSwappableDataArea, loggerService) {
     }
 
     /// <inheritdoc />
@@ -24,7 +27,9 @@ public class DosInt20Handler : InterruptHandler {
 
     /// <inheritdoc />
     public override void Run() {
-        LoggerService.Verbose("PROGRAM TERMINATE");
-        State.IsRunning = false;
+        RunCriticalSection(() => {
+            LoggerService.Verbose("PROGRAM TERMINATE");
+            State.IsRunning = false;
+        });
     }
 }

--- a/src/Spice86.Core/Emulator/InterruptHandlers/Dos/DosInt28Handler.cs
+++ b/src/Spice86.Core/Emulator/InterruptHandlers/Dos/DosInt28Handler.cs
@@ -3,20 +3,23 @@
 using Spice86.Core.Emulator.CPU;
 using Spice86.Core.Emulator.InterruptHandlers;
 using Spice86.Core.Emulator.Memory;
+using Spice86.Core.Emulator.OperatingSystem.Structures;
 using Spice86.Shared.Interfaces;
 
 /// <summary>
 /// <para>Reimplementation of int28</para>
 /// <para>This is a way of letting DOS know that the application is idle and that it can perform other tasks.</para>
 /// </summary>
-public class DosInt28Handler : InterruptHandler {
+public class DosInt28Handler : DosInterruptHandler {
     /// <summary>
     /// Initializes a new instance.
     /// </summary>
     /// <param name="memory">The memory bus.</param>
     /// <param name="cpu">The emulated CPU.</param>
+    /// <param name="dosSwappableDataArea">The DOS structure holding global information, such as the INDOS flag.</param>
     /// <param name="loggerService">The logger service implementation.</param>
-    public DosInt28Handler(IMemory memory, Cpu cpu, ILoggerService loggerService) : base(memory, cpu, loggerService) {
+    public DosInt28Handler(IMemory memory, Cpu cpu, DosSwappableDataArea dosSwappableDataArea, ILoggerService loggerService)
+        : base(memory, cpu, dosSwappableDataArea, loggerService) {
     }
 
     /// <inheritdoc />
@@ -24,6 +27,8 @@ public class DosInt28Handler : InterruptHandler {
 
     /// <inheritdoc />
     public override void Run() {
-        LoggerService.Verbose("DOS IDLE");
+        RunCriticalSection(() => {
+            LoggerService.Verbose("DOS IDLE");
+        });
     }
 }

--- a/src/Spice86.Core/Emulator/InterruptHandlers/Dos/DosInt2fHandler.cs
+++ b/src/Spice86.Core/Emulator/InterruptHandlers/Dos/DosInt2fHandler.cs
@@ -3,22 +3,24 @@ namespace Spice86.Core.Emulator.InterruptHandlers.Dos;
 using Serilog.Events;
 
 using Spice86.Core.Emulator.CPU;
-using Spice86.Core.Emulator.InterruptHandlers;
 using Spice86.Core.Emulator.Memory;
+using Spice86.Core.Emulator.OperatingSystem.Structures;
 using Spice86.Shared.Interfaces;
 using Spice86.Shared.Utils;
 
 /// <summary>
 /// Reimplementation of int2f
 /// </summary>
-public class DosInt2fHandler : InterruptHandler {
+public class DosInt2fHandler : DosInterruptHandler {
     /// <summary>
     /// Initializes a new instance of the <see cref="DosInt2fHandler"/> class.
     /// </summary>
     /// <param name="memory">The memory bus.</param>
     /// <param name="cpu">The emulated CPU.</param>
+    /// <param name="dosSwappableDataArea">The DOS structure holding global information, such as the INDOS flag.</param>
     /// <param name="loggerService">The logger service implementation.</param>
-    public DosInt2fHandler(IMemory memory, Cpu cpu, ILoggerService loggerService) : base(memory, cpu, loggerService) {
+    public DosInt2fHandler(IMemory memory, Cpu cpu, DosSwappableDataArea dosSwappableDataArea, ILoggerService loggerService)
+        : base(memory, cpu, dosSwappableDataArea, loggerService) {
         FillDispatchTable();
     }
 
@@ -27,8 +29,10 @@ public class DosInt2fHandler : InterruptHandler {
 
     /// <inheritdoc />
     public override void Run() {
-        byte operation = State.AH;
-        Run(operation);
+        RunCriticalSection(() => {
+            byte operation = State.AH;
+            Run(operation);
+        });
     }
 
     private void FillDispatchTable() {

--- a/src/Spice86.Core/Emulator/InterruptHandlers/Dos/DosInterruptHandler.cs
+++ b/src/Spice86.Core/Emulator/InterruptHandlers/Dos/DosInterruptHandler.cs
@@ -1,0 +1,22 @@
+﻿namespace Spice86.Core.Emulator.InterruptHandlers.Dos;
+
+using Spice86.Core.Emulator.CPU;
+using Spice86.Core.Emulator.Memory;
+using Spice86.Core.Emulator.OperatingSystem.Structures;
+using Spice86.Shared.Interfaces;
+using Spice86.Shared.Utils;
+
+using System;
+
+public abstract class DosInterruptHandler : InterruptHandler {
+    protected readonly DosSwappableDataArea _dosSwappableDataArea;
+    protected DosInterruptHandler(IMemory memory, Cpu cpu, DosSwappableDataArea dosSwappableDataArea, ILoggerService loggerService) : base(memory, cpu, loggerService) {
+        _dosSwappableDataArea = dosSwappableDataArea;
+    }
+
+    protected void RunCriticalSection(Action action) {
+        _dosSwappableDataArea.EnterCriticalSection();
+        action();
+        _dosSwappableDataArea.LeaveCriticalSection();
+    }
+}

--- a/src/Spice86.Core/Emulator/OperatingSystem/Dos.cs
+++ b/src/Spice86.Core/Emulator/OperatingSystem/Dos.cs
@@ -107,28 +107,31 @@ public class Dos {
     /// <param name="initializeDos">Whether to open default file handles, install EMS if set, and set the environment variables.</param>
     /// <param name="enableEms">Whether to create and install the EMS driver.</param>
     public Dos(IMemory memory, Cpu cpu, KeyboardInt16Handler keyboardInt16Handler,
-        IVgaFunctionality vgaFunctionality, string? cDriveFolderPath, string? executablePath, bool initializeDos, bool enableEms, IDictionary<string, string> envVars, ILoggerService loggerService) {
+        IVgaFunctionality vgaFunctionality, string? cDriveFolderPath,
+        string? executablePath, bool initializeDos, bool enableEms,
+        IDictionary<string, string> envVars, ILoggerService loggerService) {
         _loggerService = loggerService;
         _memory = memory;
         _state = cpu.State;
         _vgaFunctionality = vgaFunctionality;
         _keyboardStreamedInput = new KeyboardStreamedInput(keyboardInt16Handler);
         AddDefaultDevices();
-        DosSwappableDataArea dosSwappableDataArea = new(_memory,
-            MemoryUtils.ToPhysicalAddress(0xb2, 0));
 
         FileManager = new DosFileManager(_memory, cDriveFolderPath, executablePath,
             _loggerService, this.Devices);
         MemoryManager = new DosMemoryManager(_memory, _loggerService);
-        DosInt20Handler = new DosInt20Handler(_memory, cpu, 
+
+        DosSwappableDataArea dosSwappableDataArea = new(memory,
+            MemoryUtils.ToPhysicalAddress(DosSwappableDataArea.BaseSegment, 0));
+        DosInt20Handler = new DosInt20Handler(_memory, cpu, dosSwappableDataArea,
             _loggerService);
         DosInt21Handler = new DosInt21Handler(_memory, cpu,
             keyboardInt16Handler, _vgaFunctionality, this,
             dosSwappableDataArea,
             _loggerService);
-        DosInt2FHandler = new DosInt2fHandler(_memory, cpu,
+        DosInt2FHandler = new DosInt2fHandler(_memory, cpu, dosSwappableDataArea,
             _loggerService);
-        DosInt28Handler = new DosInt28Handler(_memory, cpu, 
+        DosInt28Handler = new DosInt28Handler(_memory, cpu, dosSwappableDataArea,
             _loggerService);
 
         if (_loggerService.IsEnabled(LogEventLevel.Verbose)) {
@@ -142,7 +145,7 @@ public class Dos {
         OpenDefaultFileHandles();
 
         if (enableEms) {
-            Ems = new(_memory, cpu, this, _loggerService);
+            Ems = new(_memory, cpu, this, dosSwappableDataArea, _loggerService);
         }
 
         foreach (KeyValuePair<string, string> envVar in envVars) {

--- a/src/Spice86.Core/Emulator/OperatingSystem/Structures/DosSwappableDataArea.cs
+++ b/src/Spice86.Core/Emulator/OperatingSystem/Structures/DosSwappableDataArea.cs
@@ -3,6 +3,8 @@
 using Spice86.Core.Emulator.Memory.ReaderWriter;
 using Spice86.Core.Emulator.ReverseEngineer.DataStructure;
 
+using System;
+
 
 /// <summary>
 /// Represents the DOS swappable data area.
@@ -25,5 +27,19 @@ public class DosSwappableDataArea : MemoryBasedDataStructure {
     public byte InDosFlag {
         get => UInt8[InDosFlagOffset];
         set => UInt8[InDosFlagOffset] = value;
+    }
+
+    /// <summary>
+    /// Increments the InDOS flag.
+    /// </summary>
+    public void EnterCriticalSection() {
+        InDosFlag++;
+    }
+
+    /// <summary>
+    /// Decrements the InDOS flag.
+    /// </summary>
+    public void LeaveCriticalSection() {
+        InDosFlag--;
     }
 }


### PR DESCRIPTION
Seems to make Betrayal at Krondor consistently *not* crash with its SNDBLAST.DRV driver on startup.
