### PR TITLE
Feature/small emulation fixes

### DIFF
--- a/src/Spice86.Core/Emulator/Devices/Sound/Blaster/SoundBlaster.cs
+++ b/src/Spice86.Core/Emulator/Devices/Sound/Blaster/SoundBlaster.cs
@@ -37,6 +37,11 @@ public class SoundBlaster : DefaultIOPortHandler, IDmaDevice8, IDmaDevice16, IRe
     public const int DSP_RESET_PORT_NUMBER = 0x226;
 
     /// <summary>
+    /// An undocumented port that is ignored by the 'Hardware Programming Guide' and only logged by DOSBox Staging's Sound Blaster implementation.
+    /// </summary>
+    public const int IGNORE_PORT = 0x0227;
+
+    /// <summary>
     /// The port number for checking the status of the DSP write buffer.
     /// </summary>
     public const int DSP_WRITE_BUFFER_STATUS_PORT_NUMBER = 0x22C;
@@ -282,6 +287,12 @@ public class SoundBlaster : DefaultIOPortHandler, IDmaDevice8, IDmaDevice16, IRe
             case DspPorts.MixerAddress:
                 _ctMixer.CurrentAddress = value;
                 break;
+            case IGNORE_PORT:
+                if(_loggerService.IsEnabled(LogEventLevel.Debug)) {
+                    _loggerService.Debug("Sound Blaster ignored port write {PortNumber:X2} with value {alue:X2}", 
+                        port, value);
+                }
+                break;
             default:
                 base.WriteByte(port, value);
                 break;
@@ -308,7 +319,8 @@ public class SoundBlaster : DefaultIOPortHandler, IDmaDevice8, IDmaDevice16, IRe
     /// The list of input ports.
     /// </summary>
     public FrozenSet<int> InputPorts => new int[] {
-        DspPorts.DspReadData, DspPorts.DspWrite, DspPorts.DspReadBufferStatus, DspPorts.MixerAddress, DspPorts.MixerData
+        DspPorts.DspReadData, DspPorts.DspWrite, DspPorts.DspReadBufferStatus, DspPorts.MixerAddress, DspPorts.MixerData, DspPorts.DspReset,
+        IGNORE_PORT
     }.ToFrozenSet();
 
     /// <summary>
@@ -360,6 +372,7 @@ public class SoundBlaster : DefaultIOPortHandler, IDmaDevice8, IDmaDevice16, IRe
         ioPortDispatcher.AddIOPortHandler(RIGHT_SPEAKER_DATA_PORT_NUMBER, this);
         ioPortDispatcher.AddIOPortHandler(FM_MUSIC_STATUS_PORT_NUMBER, this);
         ioPortDispatcher.AddIOPortHandler(FM_MUSIC_DATA_PORT_NUMBER, this);
+        ioPortDispatcher.AddIOPortHandler(IGNORE_PORT, this);
         // Those are managed by OPL3FM class.
         //ioPortDispatcher.AddIOPortHandler(FM_MUSIC_STATUS_PORT_NUMBER_2, this);
         //ioPortDispatcher.AddIOPortHandler(FM_MUSIC_DATA_PORT_NUMBER_2, this);

--- a/src/Spice86.Core/Emulator/InterruptHandlers/Input/Mouse/IMouseDriver.cs
+++ b/src/Spice86.Core/Emulator/InterruptHandlers/Input/Mouse/IMouseDriver.cs
@@ -108,6 +108,27 @@ public interface IMouseDriver : IAssemblyRoutineWriter {
     short GetDeltaYMickeys();
 
     /// <summary>
+    /// Gets the count of button presses since the last call.
+    /// </summary>
+    /// <param name="button">The button to query (0=left, 1=right, 2=center).</param>
+    /// <returns>The count of button presses.</returns>
+    int GetButtonPressCount(int button);
+
+    /// <summary>
+    /// Gets the last X position of the mouse when the button was pressed.
+    /// </summary>
+    /// <param name="button">0= Left, 1= right, 2= center</param>
+    /// <returns>The X part of the virtual coordinates.</returns>
+    double GetLastPressedX(int button);
+
+    /// <summary>
+    /// Gets the last Y position of the mouse when the button was pressed.
+    /// </summary>
+    /// <param name="button">0= Left, 1= right, 2= center</param>
+    /// <returns>The Y part of the virtual coordinates.</returns>
+    double GetLastPressedY(int button);
+
+    /// <summary>
     ///     Resets the mouse driver to default values.
     /// </summary>
     void Reset();

--- a/src/Spice86.Core/Emulator/InterruptHandlers/Input/Mouse/IMouseDriver.cs
+++ b/src/Spice86.Core/Emulator/InterruptHandlers/Input/Mouse/IMouseDriver.cs
@@ -2,6 +2,7 @@ namespace Spice86.Core.Emulator.InterruptHandlers.Input.Mouse;
 
 using Spice86.Core.Emulator.Devices.Input.Mouse;
 using Spice86.Core.Emulator.InterruptHandlers.Common.RoutineInstall;
+using Spice86.Shared.Emulator.Mouse;
 
 /// <summary>
 ///     Mouse driver interface.
@@ -112,21 +113,21 @@ public interface IMouseDriver : IAssemblyRoutineWriter {
     /// </summary>
     /// <param name="button">The button to query (0=left, 1=right, 2=center).</param>
     /// <returns>The count of button presses.</returns>
-    int GetButtonPressCount(int button);
+    int GetButtonPressCount(MouseButton button);
 
     /// <summary>
     /// Gets the last X position of the mouse when the button was pressed.
     /// </summary>
     /// <param name="button">0= Left, 1= right, 2= center</param>
     /// <returns>The X part of the virtual coordinates.</returns>
-    double GetLastPressedX(int button);
+    double GetLastPressedX(MouseButton button);
 
     /// <summary>
     /// Gets the last Y position of the mouse when the button was pressed.
     /// </summary>
     /// <param name="button">0= Left, 1= right, 2= center</param>
     /// <returns>The Y part of the virtual coordinates.</returns>
-    double GetLastPressedY(int button);
+    double GetLastPressedY(MouseButton button);
 
     /// <summary>
     ///     Resets the mouse driver to default values.

--- a/src/Spice86.Core/Emulator/InterruptHandlers/Input/Mouse/MouseDriver.cs
+++ b/src/Spice86.Core/Emulator/InterruptHandlers/Input/Mouse/MouseDriver.cs
@@ -10,12 +10,25 @@ using Spice86.Core.Emulator.InterruptHandlers.VGA;
 using Spice86.Core.Emulator.InterruptHandlers.VGA.Records;
 using Spice86.Core.Emulator.Memory.Indexable;
 using Spice86.Shared.Emulator.Memory;
+using Spice86.Shared.Emulator.Mouse;
 using Spice86.Shared.Interfaces;
+
+using System;
 
 /// <summary>
 ///     Driver for the mouse.
 /// </summary>
 public class MouseDriver : IMouseDriver {
+    private int _leftButtonPressCount;
+    private int _rightButtonPressCount;
+    private int _middleButtonPressCount;
+    private double _leftButtonPressX;
+    private double _leftButtonPressY;
+    private double _rightButtonPressX;
+    private double _rightButtonPressY;
+    private double _middleButtonPressX;
+    private double _middleButtonPressY;
+
     private const byte BeforeUserHandlerExecutionCallbackNumber = 0xFE;
     private const byte AfterUserHandlerExecutionCallbackNumber = 0xFF;
     private const int VirtualScreenWidth = 640;
@@ -47,11 +60,31 @@ public class MouseDriver : IMouseDriver {
         _logger = loggerService;
         _mouseDevice = mouseDevice;
         _gui = gui;
+        if (_gui is not null) {
+            _gui.MouseButtonUp += OnMouseButtonUp;
+        }
         _vgaFunctions = vgaFunctions;
 
         _vgaFunctions.VideoModeChanged += OnVideoModeChanged;
         _userHandlerAddressSwitcher = new(memory);
         Reset();
+    }
+    private void OnMouseButtonUp(object? sender, MouseButtonEventArgs e) {
+        if (e.Button == MouseButton.Left) {
+            _leftButtonPressCount++;
+            _leftButtonPressX = _mouseDevice.MouseXRelative;
+            _leftButtonPressY = _mouseDevice.MouseYRelative;
+        }
+        if (e.Button == MouseButton.Right) {
+            _rightButtonPressCount++;
+            _rightButtonPressX = _mouseDevice.MouseXRelative;
+            _rightButtonPressY = _mouseDevice.MouseYRelative;
+        }
+        if (e.Button == MouseButton.Middle) {
+            _middleButtonPressCount++;
+            _middleButtonPressX = _mouseDevice.MouseXRelative;
+            _middleButtonPressY = _mouseDevice.MouseYRelative;
+        }
     }
 
     /// <inheritdoc />
@@ -172,6 +205,43 @@ public class MouseDriver : IMouseDriver {
     }
 
     /// <inheritdoc />
+    public int GetButtonPressCount(int button) {
+        int count = button switch {
+            0 => _leftButtonPressCount,
+            1 => _rightButtonPressCount,
+            2 => _middleButtonPressCount,
+            _ => 0
+        };
+
+        // Reset the count after reading
+        if (button == 0) _leftButtonPressCount = 0;
+        if (button == 1) _rightButtonPressCount = 0;
+        if (button == 2) _middleButtonPressCount = 0;
+
+        return count;
+    }
+
+    /// <inheritdoc />
+    public double GetLastPressedX(int button) {
+        return button switch {
+            0 => _leftButtonPressX,
+            1 => _rightButtonPressX,
+            2 => _middleButtonPressX,
+            _ => 0
+        };
+    }
+
+    /// <inheritdoc />
+    public double GetLastPressedY(int button) {
+        return button switch {
+            0 => _leftButtonPressY,
+            1 => _rightButtonPressY,
+            2 => _middleButtonPressY,
+            _ => 0
+        };
+    }
+
+    /// <inheritdoc />
     public int HorizontalMickeysPerPixel {
         get => _mouseDevice.HorizontalMickeysPerPixel;
         set => _mouseDevice.HorizontalMickeysPerPixel = value;
@@ -222,6 +292,16 @@ public class MouseDriver : IMouseDriver {
         HorizontalMickeysPerPixel = 8;
         VerticalMickeysPerPixel = 16;
         DoubleSpeedThreshold = 64;
+
+        _leftButtonPressCount = 0;
+        _rightButtonPressCount = 0;
+        _middleButtonPressCount = 0;
+        _leftButtonPressX = 0;
+        _leftButtonPressY = 0;
+        _rightButtonPressX = 0;
+        _rightButtonPressY = 0;
+        _middleButtonPressX = 0;
+        _middleButtonPressY = 0;
     }
 
     private void OnVideoModeChanged(object? sender, VideoModeChangedEventArgs e) {

--- a/src/Spice86.Core/Emulator/InterruptHandlers/Input/Mouse/MouseInt33Handler.cs
+++ b/src/Spice86.Core/Emulator/InterruptHandlers/Input/Mouse/MouseInt33Handler.cs
@@ -1,5 +1,10 @@
 ﻿namespace Spice86.Core.Emulator.InterruptHandlers.Input.Mouse;
 
+using Avalonia;
+using Avalonia.Controls;
+
+using MeltySynth;
+
 using Serilog.Events;
 
 using Spice86.Core.Emulator.CPU;
@@ -133,6 +138,37 @@ public class MouseInt33Handler : InterruptHandler {
         State.CX = (ushort)status.X;
         State.DX = (ushort)status.Y;
         State.BX = (ushort)status.ButtonFlags;
+    }
+
+    /// <summary>
+    /// Expects: BX Button to query (0=left, 1=right, 2=center) <br/>
+    /// Returns: <br/>
+    ///     AX    Button status: <br/>
+    ///         bit 0 = left button down   (BX &amp; 1) == 1 <br/>
+    ///         bit 1 = right button down  (BX &amp; 2) == 2 <br/>
+    ///         bit 2 = center button down (BX &amp; 4) == 4 <br/>
+    ///     BX    Count of times that button was pressed since last call <br/>
+    ///     CX    X coordinate (horizontal)    divide by 8 for text column <br/>
+    ///     DX    Y coordinate (vertical)      divide by 8 for text line <br/>
+    /// ────────────────────────────────────────────────────────────────── <br/>
+    /// Info: This obtains <br/>
+    /// * The current button status. <br/>
+    /// * The number of times the specified button (in BX) has been pressed since the last call to this function.. <br/>
+    /// * The X,Y coordinates of the pointer at the time of the most recent press of that button. <br/><br/>
+    ///
+    ///     You might use this to check for double-clicks, or periodically to
+    ///     check for the press of a particular button(e.g., if the right-button means to cancel). <br/><br/>
+    ///
+    /// Notes: All X,Y coordinates are virtual coordinates and when working with text mode, <br/>
+    ///        you must divide each value by 8 to get a character column,row. <br/>
+    /// </summary>
+    private void QueryButtonPressedCounter() {
+        int button = State.BX;
+        MouseStatus status = _mouseDriver.GetCurrentMouseStatus();
+        State.AX = (ushort)status.ButtonFlags;
+        State.BX = (ushort)_mouseDriver.GetButtonPressCount(button);
+        State.CX = (ushort)_mouseDriver.GetLastPressedX(button);
+        State.DX = (ushort)_mouseDriver.GetLastPressedY(button);
     }
 
     /// <summary>
@@ -460,6 +496,7 @@ public class MouseInt33Handler : InterruptHandler {
         AddAction(0x02, HideMouseCursor);
         AddAction(0x03, GetMousePositionAndStatus);
         AddAction(0x04, SetMouseCursorPosition);
+        AddAction(0x0005, QueryButtonPressedCounter);
         AddAction(0x07, SetMouseHorizontalMinMaxPosition);
         AddAction(0x08, SetMouseVerticalMinMaxPosition);
         AddAction(0x0B, GetMotionDistance);

--- a/src/Spice86.Core/Emulator/InterruptHandlers/Input/Mouse/MouseInt33Handler.cs
+++ b/src/Spice86.Core/Emulator/InterruptHandlers/Input/Mouse/MouseInt33Handler.cs
@@ -1,15 +1,11 @@
 ﻿namespace Spice86.Core.Emulator.InterruptHandlers.Input.Mouse;
 
-using Avalonia;
-using Avalonia.Controls;
-
-using MeltySynth;
-
 using Serilog.Events;
 
 using Spice86.Core.Emulator.CPU;
 using Spice86.Core.Emulator.Devices.Input.Mouse;
 using Spice86.Core.Emulator.Memory;
+using Spice86.Shared.Emulator.Mouse;
 using Spice86.Shared.Interfaces;
 
 /// <summary>
@@ -163,8 +159,21 @@ public class MouseInt33Handler : InterruptHandler {
     ///        you must divide each value by 8 to get a character column,row. <br/>
     /// </summary>
     private void QueryButtonPressedCounter() {
-        int button = State.BX;
+        ushort bx = State.BX;
         MouseStatus status = _mouseDriver.GetCurrentMouseStatus();
+        MouseButton button = bx switch {
+            0 => MouseButton.Left,
+            1 => MouseButton.Right,
+            2 => MouseButton.Middle,
+            _ => MouseButton.None
+        };
+        if(button == MouseButton.None) {
+            State.AX = 0;
+            State.BX = 0;
+            State.CX = 0;
+            State.DX = 0;
+            return;
+        }
         State.AX = (ushort)status.ButtonFlags;
         State.BX = (ushort)_mouseDriver.GetButtonPressCount(button);
         State.CX = (ushort)_mouseDriver.GetLastPressedX(button);


### PR DESCRIPTION
### INT 33H 0005H: Query Button-Pressed Counter to the Mouse (INT33H) handler.

This is now handled and emulated.

### SoundBlaster port 0x227

Add the handling of port 0x227 by the SoundBlaster. This port is undocumented, but handled by DOSBox (it produces logs).

Those two changes taken together make this game boot up: _The Secret of Monkey Island_, with working music and sound.

![image](https://github.com/user-attachments/assets/3e8f675f-bf42-4c68-b190-43b04becfc18)

(Although the game is way too fast, but that's not a problem I wish to solve, as it does not happen with _Dune_).