### PR TITLE
Delay the completion signal for single dma transfers

### DIFF
--- a/src/Spice86.Core/Emulator/Devices/DirectMemoryAccess/DmaController.cs
+++ b/src/Spice86.Core/Emulator/Devices/DirectMemoryAccess/DmaController.cs
@@ -29,7 +29,16 @@ public class DmaController : DefaultIOPortHandler {
             MaskRegister16,
             ClearBytePointerFlipFlop}.ToFrozenSet();
 
-    private static readonly int[] AllPorts = new int[] { 0x87, 0x00, 0x01, 0x83, 0x02, 0x03, 0x81, 0x04, 0x05, 0x82, 0x06, 0x07, 0x8F, 0xC0, 0xC2, 0x8B, 0xC4, 0xC6, 0x89, 0xC8, 0xCA, 0x8A, 0xCC, 0xCE };
+    private static readonly int[] AllPorts = [
+        0x87, 0x00, 0x01,
+        0x83, 0x02, 0x03,
+        0x81, 0x04, 0x05,
+        0x82, 0x06, 0x07,
+        0x8F, 0xC0, 0xC2,
+        0x8B, 0xC4, 0xC6,
+        0x89, 0xC8, 0xCA,
+        0x8A, 0xCC, 0xCE
+    ];
 
     /// <summary>
     /// Initializes a new instance of the <see cref="DmaController"/> class.
@@ -43,7 +52,7 @@ public class DmaController : DefaultIOPortHandler {
         ILoggerService loggerService) : base(state, failOnUnhandledPort, loggerService) {
         _memory = memory;
         for (int i = 0; i < 8; i++) {
-            DmaChannel channel = new DmaChannel(_memory);
+            DmaChannel channel = new DmaChannel(_memory, state);
             _channels.Add(channel);
         }
 
@@ -126,6 +135,12 @@ public class DmaController : DefaultIOPortHandler {
 
             case MaskRegister16:
                 _channels[(value & 3) + 4].IsMasked = (value & 4) != 0;
+                break;
+
+            case ClearBytePointerFlipFlop:
+                // clear byte pointer flip-flop.
+                // Any write clears the flip-flop so that the next write to any of the 16-bit registers is decoded as the low byte.
+                // The next is the high byte, then next is low, etc.
                 break;
 
             default:

--- a/src/Spice86.Core/Emulator/Memory/DmaChannel.cs
+++ b/src/Spice86.Core/Emulator/Memory/DmaChannel.cs
@@ -202,20 +202,20 @@ public sealed class DmaChannel {
     /// <remarks>
     /// This method should only be called if the channel is active.
     /// </remarks>
-    internal bool Transfer() {
+    internal void Transfer() {
         // Delayed signaling of operation completion to give certain programs time to detect it.
         if (_signalCompletionAfter.HasValue && _signalCompletionAfter.Value <= _state.Cycles) {
             _signalCompletionAfter = null;
             Device?.SingleCycleComplete();
 
-            return false;
+            return;
         }
         if (!MustTransferData) {
-            return false;
+            return;
         }
         IDmaDevice8? device = Device;
         if (device is null) {
-            return false;
+            return;
         }
         uint memoryAddress = (uint)Page << 16 | Address;
         uint sourceOffset = (uint)Count + 1 - (uint)TransferBytesRemaining;
@@ -236,6 +236,5 @@ public sealed class DmaChannel {
             }
         }
         _transferTimer.Restart();
-        return true;
     }
 }


### PR DESCRIPTION
### Description of Changes
Delay the completion signal for single dma transfers by CPU 20 cycles.

### Rationale behind Changes
It gives Krondor the chance to detect the IRQ used by the SoundBlaster.

### Suggested Testing Steps
Run games, check sounds.
