### PR TITLE
Fix program size

### DIFF
--- a/src/Spice86.Core/Emulator/LoadableFile/Dos/Exe/ExeFile.cs
+++ b/src/Spice86.Core/Emulator/LoadableFile/Dos/Exe/ExeFile.cs
@@ -21,9 +21,10 @@ public class ExeFile : MemoryBasedDataStructure {
     public string Signature => GetZeroTerminatedString(0, 2);
 
     /// <summary>
-    /// Number of extra bytes needed by the program.
+    /// Number of bytes in the final page (all previous pages have 512 Bytes).
+    /// If 0, all the 512 Bytes of the final page are also filled.
     /// </summary>
-    public ushort ExtraBytes => UInt16[0x02];
+    public ushort LenFinalPage => UInt16[0x02];
 
     /// <summary>
     /// Number of pages in the executable file.
@@ -111,7 +112,16 @@ public class ExeFile : MemoryBasedDataStructure {
     /// <summary>
     /// Size of the program code in the executable file.
     /// </summary>
-    public uint ProgramSize => ByteReaderWriter.Length - HeaderSizeInBytes;
+    public uint ProgramSize {
+        get {
+            uint result = Pages * 512U;
+            if (LenFinalPage != 0) {
+                result = result - 512 + LenFinalPage;
+            }
+            result -= HeaderSizeInBytes;
+            return result;
+        }
+    }
 
     /// <summary>
     /// True when represented EXE is valid.

--- a/src/Spice86.Core/Emulator/LoadableFile/Dos/Exe/ExeLoader.cs
+++ b/src/Spice86.Core/Emulator/LoadableFile/Dos/Exe/ExeLoader.cs
@@ -80,7 +80,7 @@ public class ExeLoader : DosFileLoader {
     /// <param name="startSegment">The starting segment for the program.</param>
     private void LoadExeFileInMemory(ExeFile exeFile, ushort startSegment) {
         uint physicalStartAddress = MemoryUtils.ToPhysicalAddress(startSegment, 0);
-        _memory.LoadData(physicalStartAddress, exeFile.ProgramImage);
+        _memory.LoadData(physicalStartAddress, exeFile.ProgramImage, (int) exeFile.ProgramSize);
         foreach (SegmentedAddress address in exeFile.RelocationTable) {
             // Read value from memory, add the start segment offset and write back
             uint addressToEdit = MemoryUtils.ToPhysicalAddress(address.Segment, address.Offset) + physicalStartAddress;


### PR DESCRIPTION
The size of the program image might not match the full size of the exe
file.

Calculate the correct size using the information in the MZ header.

Use the formula at
https://moddingwiki.shikadi.net/wiki/EXE_Format#Machine_code ,
except that (as opposed to what said in that page) the result is the
total size of header + code. To get the pure code length we still must
subtract the header size.
