### PR TITLE
fix: Notification of pauses from emulator to GDB client

### DIFF
--- a/src/Spice86.Core/Emulator/Gdb/GdbCommandHandler.cs
+++ b/src/Spice86.Core/Emulator/Gdb/GdbCommandHandler.cs
@@ -67,11 +67,6 @@ public class GdbCommandHandler {
     }
 
     /// <summary>
-    /// Executes a single CPU instruction.
-    /// </summary>
-    public void Step() => _gdbCommandBreakpointHandler.Step();
-
-    /// <summary>
     /// Runs a custom GDB command.
     /// </summary>
     /// <param name="command">The custom GDB command string</param>
@@ -99,7 +94,7 @@ public class GdbCommandHandler {
                 'P' => _gdbCommandRegisterHandler.WriteRegister(commandContent),
                 'm' => _gdbCommandMemoryHandler.ReadMemory(commandContent),
                 'M' => _gdbCommandMemoryHandler.WriteMemory(commandContent),
-                'T' => HandleThreadALive(),
+                'T' => HandleThreadAlive(),
                 'v' => ProcessVPacket(commandContent),
                 's' => _gdbCommandBreakpointHandler.Step(),
                 'z' => _gdbCommandBreakpointHandler.RemoveBreakpoint(commandContent),
@@ -125,7 +120,7 @@ public class GdbCommandHandler {
         return _gdbIo.GenerateResponse("");
     }
 
-    private string HandleThreadALive() {
+    private string HandleThreadAlive() {
         return _gdbIo.GenerateResponse("OK");
     }
 

--- a/src/Spice86.Core/Emulator/Gdb/GdbServer.cs
+++ b/src/Spice86.Core/Emulator/Gdb/GdbServer.cs
@@ -175,11 +175,4 @@ public sealed class GdbServer : IDisposable {
     private void OnConnect() {
         _waitFirstConnectionHandle?.Set();
     }
-
-    /// <summary>
-    /// Executes a single CPU instruction.
-    /// </summary>
-    public void StepInstruction() {
-        _gdbCommandHandler?.Step();
-    }
 }


### PR DESCRIPTION
This fixes notifications of pauses from the emulator to the gdb client.

That is, when one pauses the emulator from outside the GDB client (namely, the spice86 UI), GDB is notified.
This makes the GDB command prompt available again.

![image](https://github.com/user-attachments/assets/7b60c9a5-8dab-4871-81d4-bca82eb08ef2)
