### PR TITLE
Add a minimum number of ticks between activations for PIT8254 counters

### DIFF
--- a/src/Spice86.Core/Emulator/Devices/Timer/CounterActivator.cs
+++ b/src/Spice86.Core/Emulator/Devices/Timer/CounterActivator.cs
@@ -6,6 +6,7 @@ using Spice86.Core.Emulator.VM;
 /// Base class for counter activators
 /// </summary>
 public abstract class CounterActivator {
+    protected const int MinTicksBetweenActivation = 100;
     private readonly IPauseHandler _pauseHandler;
 
     /// <summary>
@@ -67,7 +68,7 @@ public abstract class CounterActivator {
         return Multiplier * desiredFrequency;
     }
 
-    private void UpdateFrequency() {
+    protected void UpdateFrequency() {
         double computedFrequency = ComputeActualFrequency(Frequency);
         if (computedFrequency == 0) {
             return;

--- a/src/Spice86.Core/Emulator/Devices/Timer/CyclesCounterActivator.cs
+++ b/src/Spice86.Core/Emulator/Devices/Timer/CyclesCounterActivator.cs
@@ -22,6 +22,8 @@ public class CyclesCounterActivator : CounterActivator {
     public CyclesCounterActivator(State state, IPauseHandler pauseHandler, long instructionsPerSecond, double multiplier) : base (pauseHandler, multiplier) {
         _state = state;
         _instructionsPerSecond = instructionsPerSecond;
+        // Once everything is setup, update the frequency
+        UpdateFrequency();
     }
 
     /// <inheritdoc />
@@ -44,5 +46,8 @@ public class CyclesCounterActivator : CounterActivator {
     /// <inheritdoc />
     protected override void UpdateNonZeroFrequency(double desiredFrequency) {
         _cyclesBetweenActivations = (long)(_instructionsPerSecond / desiredFrequency);
+        if(_cyclesBetweenActivations < MinTicksBetweenActivation) {
+            _cyclesBetweenActivations = MinTicksBetweenActivation;
+        }
     }
 }

--- a/src/Spice86.Core/Emulator/Devices/Timer/TimeCounterActivator.cs
+++ b/src/Spice86.Core/Emulator/Devices/Timer/TimeCounterActivator.cs
@@ -20,7 +20,7 @@ public class TimeCounterActivator : CounterActivator {
     public override bool IsActivated {
         get {
             _ticks++;
-            if (_ticks % 100 != 0) {
+            if (_ticks % MinTicksBetweenActivation != 0) {
                 // System.Diagnostics.Stopwatch.GetTimestamp is quite slow, let's not call it every time.
                 return false;
             }


### PR DESCRIPTION
### Description of Changes
PIT8254 counters will not be able to activate unless 100 CPU cycles have passed since last activation for both timer based and cycle based implementations.
This was only done for timer based implementations before, and for performances reason.

### Rationale behind Changes
Some games like stunts re-enable interrupts in INT8 handler. If another interrupt happens before current int8 is finished, it will fill the call stack and cause a stack overflow, and game will crash.

### Suggested Testing Steps
Dune looks happy