### PR TITLE
GdbCommandMemoryHandler: fix SearchMemory

### DIFF
--- a/src/Spice86.Core/Emulator/Gdb/GdbCommandMemoryHandler.cs
+++ b/src/Spice86.Core/Emulator/Gdb/GdbCommandMemoryHandler.cs
@@ -81,19 +81,15 @@ public class GdbCommandMemoryHandler {
         // read the bytes from the raw command as GDB does not send them as hex
         List<byte> rawCommand = _gdbIo.RawCommand;
 
-        // Extract the original hex sent by GDB, read from
-        // 3: +$q
-        // variable: header
-        // 2: ;
-        // variable 2 hex strings
-        int patternStartIndex = 3 + "Search:memory:".Length + 2 + parameters[0].Length + parameters[1].Length;
-        List<byte> patternBytesList = rawCommand.GetRange(patternStartIndex, rawCommand.Count - 1);
+        // Extract the original hex sent by GDB, read from rawCommand
+        int patternStartIndex = $"+$qSearch:memory:{parameters[0]};{parameters[1]};".Length;
+        int patternEndIndex = rawCommand.Count - patternStartIndex - "#".Length;
+        List<byte> patternBytesList = rawCommand.GetRange(patternStartIndex, patternEndIndex);
         uint? address = _memory.SearchValue(start, (int)end, patternBytesList);
         if (address == null) {
             return _gdbIo.GenerateResponse("0");
         }
-
-        return _gdbIo.GenerateResponse($"1,{_gdbFormatter.FormatValueAsHex32(address.Value)}");
+        return _gdbIo.GenerateResponse($"1,{address.Value:X}");
     }
 
     /// <summary>


### PR DESCRIPTION
### Description of Changes
* calculate the correct indexes for the pattern to search
* encode the output address correctly (do not swap endianness, since we are sending back text)

### Rationale behind Changes
The search was broken before; Spice86 would crash with a “index out of bounds” error and not return the correct addresses

### Suggested Testing Steps

#### Check byte read
Start executable with debug option, connect gdb and enter 
```
find /w3 0x0, 0xFFFFF, 0x00, 0x00
```

The expected output should be 
```
0x0
0x1
0x2
```

#### Check string read

Go to Spice86's debugger. Select Memory/Edit

Address: 0100:0000
Bytes: 6161610061616100

Connect gdb and type
```
find /2 0x0, 0xFFFF, "aaa"
```

The expected output is
```
0x1001
0x1005
```
Note that Spice86 has slightly misplaced the bytes -- this is anyway irrelevant, the important thing is that the search succeeds returning 2 results.

