### PR TITLE
GdbCommandHandler: reply to extended mode request with error message

### DIFF
--- a/src/Spice86.Core/Emulator/Gdb/GdbCommandHandler.cs
+++ b/src/Spice86.Core/Emulator/Gdb/GdbCommandHandler.cs
@@ -99,6 +99,7 @@ public class GdbCommandHandler {
                 's' => _gdbCommandBreakpointHandler.Step(),
                 'z' => _gdbCommandBreakpointHandler.RemoveBreakpoint(commandContent),
                 'Z' => _gdbCommandBreakpointHandler.AddBreakpoint(commandContent),
+                '!' => DeclineExtendedMode(),
                 _ => _gdbIo.GenerateUnsupportedResponse()
             };
             if (_loggerService.IsEnabled(Serilog.Events.LogEventLevel.Verbose)) {
@@ -112,6 +113,11 @@ public class GdbCommandHandler {
                 _pauseHandler.Resume();
             }
         }
+    }
+
+    private string DeclineExtendedMode() {
+        // Respond with an error response to indicate that extended mode is not supported.
+        return _gdbIo.GenerateResponse("E01"); // E01 is a generic error code.
     }
 
     private string Detach() {


### PR DESCRIPTION
If gdb tries to connect to Spice86 using `extended-remote` (instead of just `remote`), it will send a `!` command (request to activate extended mode).

The default answer of Spice86 is an empty response, which is not acknowledged by the gdb client as valid response to this request.

Change the command handler so that it outputs an error response (with an arbitrary error code). In this way, gdb recognizes that the extended mode is not supported, does not try to enable it and moves on in normal mode.

This fixes the connection problems with Seer, which uses extended-remote to connect.

### Suggested Testing Steps
Start Spice86 with `--GdbPort`, then start Seer. Configure Seer to connect to Spice86 (see https://github.com/OpenRakis/Spice86/pull/1071 for tips), then click launch. The connection should be almost instantaneous and the Spice86 console log should look like this (few milliseconds between `vMustReplyEmpty` and `Hg0` requests):

```
[2025-03-02 21:10:57.334 +01:00] [DBUG] [0000:0000] Received command from GDB vMustReplyEmpty
[2025-03-02 21:10:57.336 +01:00] [DBUG] [0000:0000] Received command from GDB !
[2025-03-02 21:10:57.338 +01:00] [DBUG] [0000:0000] Received command from GDB Hg0
```

Before this patch, the connection would require about 12 seconds, during which multiple `!` messages would be received.

