### PR TITLE
fix: semi-UI freeze

### DIFF
--- a/src/Spice86/ViewModels/MainWindowViewModel.cs
+++ b/src/Spice86/ViewModels/MainWindowViewModel.cs
@@ -71,7 +71,7 @@ public sealed partial class MainWindowViewModel : ViewModelWithErrorDialog, IGui
         _pauseHandler.Resumed += OnResumed;
         TimeMultiplier = Configuration.TimeMultiplier;
         CanUseInternalDebugger = configuration.GdbPort is null;
-        DispatcherTimerStarter.StartNewDispatcherTimer(TimeSpan.FromSeconds(1.0 / 30.0), DispatcherPriority.MaxValue, (_, _) => UpdateCpuInstructionsPerMillisecondsInMainWindowTitle());
+        DispatcherTimerStarter.StartNewDispatcherTimer(TimeSpan.FromSeconds(1.0 / 30.0), DispatcherPriority.Background, (_, _) => UpdateCpuInstructionsPerMillisecondsInMainWindowTitle());
     }
 
     private void UpdateCpuInstructionsPerMillisecondsInMainWindowTitle() {
@@ -218,7 +218,7 @@ public sealed partial class MainWindowViewModel : ViewModelWithErrorDialog, IGui
             }
             _isSettingResolution = false;
             InitializeRenderingTimer();
-        }, DispatcherPriority.MaxValue);
+        }, DispatcherPriority.Background);
     }
 
     public void HideMouseCursor() => _uiDispatcher.Post(() => ShowCursor = false);
@@ -288,12 +288,12 @@ public sealed partial class MainWindowViewModel : ViewModelWithErrorDialog, IGui
             using ILockedFramebuffer pixels = Bitmap.Lock();
             var uiRenderEventArgs = new UIRenderEventArgs(pixels.Address, pixels.RowBytes * pixels.Size.Height / 4);
             RenderScreen.Invoke(this, uiRenderEventArgs);
+            _uiDispatcher.Post(() => InvalidateBitmap?.Invoke(), DispatcherPriority.Background);
         } finally {
             if (!_disposed) {
                 _drawingSemaphoreSlim?.Release();
             }
         }
-        _uiDispatcher.Post(() => InvalidateBitmap?.Invoke(), DispatcherPriority.Render);
     }
 
     internal void StartEmulator() {

--- a/src/Spice86/ViewModels/PerformanceViewModel.cs
+++ b/src/Spice86/ViewModels/PerformanceViewModel.cs
@@ -26,7 +26,7 @@ public partial class PerformanceViewModel : ViewModelBase {
         _state = state;
         _isPaused = pauseHandler.IsPaused;
         _performanceMeasurer = new PerformanceMeasurer();
-        DispatcherTimerStarter.StartNewDispatcherTimer(TimeSpan.FromSeconds(1.0 / 30.0), DispatcherPriority.MaxValue, UpdatePerformanceInfo);
+        DispatcherTimerStarter.StartNewDispatcherTimer(TimeSpan.FromSeconds(1.0 / 30.0), DispatcherPriority.Background, UpdatePerformanceInfo);
     }
 
     private void UpdatePerformanceInfo(object? sender, EventArgs e) {


### PR DESCRIPTION
DispatcherPriority.MaxValue was bad and could freeze the UI in some cases.

Especially when the game was in a hot loop waiting for something.

Exemple with 'Where in the World is Carmen Sandiego (1989)':

Before:

![image](https://github.com/user-attachments/assets/49ec6ebf-5c2f-4146-839e-3f4750a0a191)

After:

![image](https://github.com/user-attachments/assets/a4a78029-4209-4001-9e94-251b1e39f72e)

