### PR TITLE
Memset16 is done twice in VGA BIOS

### DIFF
--- a/src/Spice86.Core/Emulator/InterruptHandlers/VGA/VgaFunctionality.cs
+++ b/src/Spice86.Core/Emulator/InterruptHandlers/VGA/VgaFunctionality.cs
@@ -1397,9 +1397,6 @@ public class VgaFunctionality : IVgaFunctionality {
         amount /= 2;
         uint address = MemoryUtils.ToPhysicalAddress(segment, offset);
         _memory.Memset16(address, value, (uint)amount);
-        for (int i = 0; i < amount; i += 2) {
-            _memory.UInt16[(uint)(address + i)] = value;
-        }
     }
 
     private void WriteMaskedToMiscellaneousRegister(byte offBits, byte onBits) {


### PR DESCRIPTION
### Description of Changes
VGA Bios is doing 2 memset to clear the screen, this doesnt sound right

### Suggested Testing Steps
Dune and stunts are working with that