### PR TITLE
Use device thread instead of duplicating thread implementation for each device that needs a thread

### DIFF
--- a/src/Spice86.Core/Emulator/Devices/DeviceThread.cs
+++ b/src/Spice86.Core/Emulator/Devices/DeviceThread.cs
@@ -34,6 +34,8 @@ public class DeviceThread : IDisposable {
         _loopBody = loopBody;
     }
 
+    public bool Active => _thread != null && !_deviceStopRequested;
+
     /// <summary>
     /// Pauses the device loop
     /// </summary>
@@ -52,7 +54,7 @@ public class DeviceThread : IDisposable {
     /// Start the thread and the loop. A new thread is created there if needed.
     /// </summary>
     public void StartThreadIfNeeded() {
-        if (_disposed || _thread != null || _deviceStopRequested) {
+        if (_thread != null || _disposed || _deviceStopRequested) {
             return;
         }
 

--- a/src/Spice86.Core/Emulator/Devices/Sound/Midi/Midi.cs
+++ b/src/Spice86.Core/Emulator/Devices/Sound/Midi/Midi.cs
@@ -55,9 +55,9 @@ public sealed class Midi : DefaultIOPortHandler, IDisposable {
         Mt32RomsPath = mt32RomsPath;
         // the external MIDI device (external General MIDI or external Roland MT-32).
         if (!string.IsNullOrWhiteSpace(Mt32RomsPath) && (Directory.Exists(Mt32RomsPath) || File.Exists(Mt32RomsPath))) {
-            _midiMapper = new Mt32MidiDevice(softwareMixer, Mt32RomsPath, loggerService);
+            _midiMapper = new Mt32MidiDevice(softwareMixer, Mt32RomsPath, pauseHandler, loggerService);
         } else {
-            _midiMapper = new GeneralMidiDevice(softwareMixer, loggerService, pauseHandler);
+            _midiMapper = new GeneralMidiDevice(softwareMixer, pauseHandler, loggerService);
         }
         InitPortHandlers(ioPortDispatcher);
     }


### PR DESCRIPTION
### Description of Changes
Devices that require threads were handling them on their own with duplicated code (all are sound devices).

This expands the use of DeviceThread class used for PC speaker.

### Rationale behind Changes
More robust thread handling in devices
Unified logging for device start
Sound threads all pause when the emulator pauses

### Suggested Testing Steps
Tested:
- midi and mt32 with dune
- soundblaster with dune
- pc speaker with prince of persia and stunts
- OPL3FM with prince of persia and krondor
