### PR TITLE
Fix pause events

### DIFF
--- a/src/Spice86.Core/Emulator/Gdb/GdbCommandBreakPointHandler.cs
+++ b/src/Spice86.Core/Emulator/Gdb/GdbCommandBreakPointHandler.cs
@@ -31,7 +31,7 @@ public class GdbCommandBreakpointHandler {
         _loggerService = loggerService.WithLogLevel(LogEventLevel.Verbose);
         _emulatorBreakpointsManager = emulatorBreakpointsManager;
         _pauseHandler = pauseHandler;
-        _pauseHandler.Pausing += OnPauseFromEmulator;
+        _pauseHandler.Paused += OnPauseFromEmulator;
         _gdbIo = gdbIo;
     }
 

--- a/src/Spice86.Core/Emulator/VM/IPauseHandler.cs
+++ b/src/Spice86.Core/Emulator/VM/IPauseHandler.cs
@@ -11,10 +11,16 @@ public interface IPauseHandler {
 
     /// <summary>
     /// Event triggered when a pause is requested on the emulator.
-    /// This allows other parts of the application to react to pauses,
-    /// such as stopping processing or updating UI elements.
+    /// This allows other parts of the application to stop their work.
     /// </summary>
     event Action? Pausing;
+
+    /// <summary>
+    /// Event triggered when a pause has taken effect.
+    /// This allows other parts of the application to react to pauses,
+    /// such as updating UI elements.
+    /// </summary>
+    event Action? Paused;
 
     /// <summary>
     /// Event triggered when a resume is requested on the emulator.

--- a/src/Spice86.Core/Emulator/VM/PauseHandler.cs
+++ b/src/Spice86.Core/Emulator/VM/PauseHandler.cs
@@ -49,6 +49,9 @@ public class PauseHandler : IDisposable, IPauseHandler {
     /// <inheritdoc />
     public event Action? Pausing;
 
+    /// <inheritdoc/>
+    public event Action? Paused;
+
     /// <inheritdoc />
     public event Action? Resumed;
 
@@ -59,6 +62,7 @@ public class PauseHandler : IDisposable, IPauseHandler {
         Pausing?.Invoke();
         _pausing = true;
         _manualResetEvent.Reset();
+        Paused?.Invoke();
     }
 
     /// <inheritdoc />

--- a/src/Spice86/ViewModels/CfgCpuViewModel.cs
+++ b/src/Spice86/ViewModels/CfgCpuViewModel.cs
@@ -38,7 +38,7 @@ public partial class CfgCpuViewModel : ViewModelBase {
         _performanceMeasurer = performanceMeasurer;
         IsCfgCpuEnabled = configuration.CfgCpu;
 
-        pauseHandler.Pausing += () => UpdateGraphCommand.Execute(null);
+        pauseHandler.Paused += () => UpdateGraphCommand.Execute(null);
     }
 
     [RelayCommand]

--- a/src/Spice86/ViewModels/CpuViewModel.cs
+++ b/src/Spice86/ViewModels/CpuViewModel.cs
@@ -28,7 +28,7 @@ public partial class CpuViewModel : ViewModelBase {
     public CpuViewModel(State state, IMemory memory, IPauseHandler pauseHandler, IUIDispatcher uiDispatcher) {
         _cpuState = state;
         _memory = memory;
-        pauseHandler.Pausing += () => uiDispatcher.Post(() => _isPaused = true);
+        pauseHandler.Paused += () => uiDispatcher.Post(() => _isPaused = true);
         _isPaused = pauseHandler.IsPaused;
         pauseHandler.Resumed += () => uiDispatcher.Post(() => _isPaused = false);
         DispatcherTimerStarter.StartNewDispatcherTimer(TimeSpan.FromMilliseconds(400), DispatcherPriority.Normal, UpdateValues);

--- a/src/Spice86/ViewModels/DebugWindowViewModel.cs
+++ b/src/Spice86/ViewModels/DebugWindowViewModel.cs
@@ -81,7 +81,7 @@ public partial class DebugWindowViewModel : ViewModelBase,
         StatusMessageViewModel = new(_uiDispatcher, _messenger);
         _pauseHandler = pauseHandler;
         IsPaused = pauseHandler.IsPaused;
-        pauseHandler.Pausing += () => uiDispatcher.Post(() => IsPaused = true);
+        pauseHandler.Paused += () => uiDispatcher.Post(() => IsPaused = true);
         pauseHandler.Resumed += () => uiDispatcher.Post(() => IsPaused = false);
         DisassemblyViewModel disassemblyVm = new(
             emulatorBreakpointsManager,
@@ -105,7 +105,7 @@ public partial class DebugWindowViewModel : ViewModelBase,
             canCloseTab: false, startAddress: stack.PhysicalAddress) {
             Title = "CPU Stack Memory"
         };
-        pauseHandler.Pausing += () => UpdateStackMemoryViewModel(stackMemoryViewModel, stack);
+        pauseHandler.Paused += () => UpdateStackMemoryViewModel(stackMemoryViewModel, stack);
         MemoryViewModels.Add(mainMemoryViewModel);
         MemoryViewModels.Add(stackMemoryViewModel);
         CfgCpuViewModel = new(configuration, executionContextManager,

--- a/src/Spice86/ViewModels/DisassemblyViewModel.cs
+++ b/src/Spice86/ViewModels/DisassemblyViewModel.cs
@@ -52,7 +52,7 @@ public partial class DisassemblyViewModel : ViewModelWithErrorDialog {
         _pauseHandler = pauseHandler;
         _instructionsDecoder = new(memory, state, functionsInformation, breakpointsViewModel);
         IsPaused = pauseHandler.IsPaused;
-        pauseHandler.Pausing += OnPausing;
+        pauseHandler.Paused += OnPaused;
         pauseHandler.Resumed += OnResumed;
         CanCloseTab = canCloseTab;
         breakpointsViewModel.BreakpointDeleted += OnBreakPointUpdateFromBreakpointsViewModel;
@@ -83,7 +83,7 @@ public partial class DisassemblyViewModel : ViewModelWithErrorDialog {
     [ObservableProperty]
     private AvaloniaList<FunctionInfo> _functions = new();
 
-    private void OnPausing() {
+    private void OnPaused() {
         _uiDispatcher.Post(() => {
             IsPaused = true;
             if (!_didCsIpGoOutOfCurrentListing) {

--- a/src/Spice86/ViewModels/MainWindowViewModel.cs
+++ b/src/Spice86/ViewModels/MainWindowViewModel.cs
@@ -64,7 +64,7 @@ public sealed partial class MainWindowViewModel : ViewModelWithErrorDialog, IGui
         _loggerService = loggerService;
         _hostStorageProvider = hostStorageProvider;
         _pauseHandler = pauseHandler;
-        _pauseHandler.Pausing += OnPausing;
+        _pauseHandler.Paused += OnPaused;
         _pauseHandler.Resumed += OnResumed;
         TimeMultiplier = Configuration.TimeMultiplier;
         DispatcherTimerStarter.StartNewDispatcherTimer(TimeSpan.FromSeconds(1.0 / 30.0), DispatcherPriority.Background, (_, _) => UpdateCpuInstructionsPerMillisecondsInMainWindowTitle());
@@ -320,7 +320,7 @@ public sealed partial class MainWindowViewModel : ViewModelWithErrorDialog, IGui
             _disposed = true;
             if (disposing) {
                 // Unsubscribe from PauseHandler events
-                _pauseHandler.Pausing -= OnPausing;
+                _pauseHandler.Paused -= OnPaused;
                 _pauseHandler.Resumed -= OnResumed;
 
                 _drawTimer.Stop();
@@ -346,7 +346,7 @@ public sealed partial class MainWindowViewModel : ViewModelWithErrorDialog, IGui
 
     private void OnResumed() => _uiDispatcher.Post(() => IsPaused = false, DispatcherPriority.Normal);
 
-    private void OnPausing() => _uiDispatcher.Post(() => IsPaused = true, DispatcherPriority.Normal);
+    private void OnPaused() => _uiDispatcher.Post(() => IsPaused = true, DispatcherPriority.Normal);
 
     [ObservableProperty]
     private string _currentLogLevel = "";

--- a/src/Spice86/ViewModels/MemoryViewModel.cs
+++ b/src/Spice86/ViewModels/MemoryViewModel.cs
@@ -37,7 +37,7 @@ public partial class MemoryViewModel : ViewModelWithErrorDialog {
         _state = state;
         _breakpointsViewModel = breakpointsViewModel;
         _memory = memory;
-        _pauseHandler.Pausing += OnPause;
+        _pauseHandler.Paused += OnPause;
         IsPaused = pauseHandler.IsPaused;
         pauseHandler.Resumed += () => _uiDispatcher.Post(() => IsPaused = false);
         _messenger = messenger;

--- a/src/Spice86/ViewModels/PerformanceViewModel.cs
+++ b/src/Spice86/ViewModels/PerformanceViewModel.cs
@@ -21,7 +21,7 @@ public partial class PerformanceViewModel : ViewModelBase {
     private bool _isPaused;
     
     public PerformanceViewModel(State state, IPauseHandler pauseHandler, IUIDispatcher uiDispatcher) {
-        pauseHandler.Pausing += () => uiDispatcher.Post(() => _isPaused = true);
+        pauseHandler.Paused += () => uiDispatcher.Post(() => _isPaused = true);
         pauseHandler.Resumed += () => uiDispatcher.Post(() => _isPaused = false);
         _state = state;
         _isPaused = pauseHandler.IsPaused;

--- a/src/Spice86/ViewModels/StructureViewModel.cs
+++ b/src/Spice86/ViewModels/StructureViewModel.cs
@@ -62,7 +62,7 @@ public partial class StructureViewModel : ViewModelBase, IDisposable {
         _availableStructures = new AvaloniaList<StructType>(structureInformation.Structs.Values);
         _isAddressableMemory = data is DataMemoryDocument;
         _pauseHandler = pauseHandler;
-        _pauseHandler.Pausing += OnPausing;
+        _pauseHandler.Paused += OnPaused;
         Source = InitializeSource();
     }
 
@@ -147,7 +147,7 @@ public partial class StructureViewModel : ViewModelBase, IDisposable {
     /// <summary>
     /// Update the view when the application is paused.
     /// </summary>
-    private void OnPausing() {
+    private void OnPaused() {
         Update();
     }
 
@@ -194,7 +194,7 @@ public partial class StructureViewModel : ViewModelBase, IDisposable {
     /// Disposes of the resources used by the <see cref="StructureViewModel" />.
     /// </summary>
     public void Dispose() {
-        _pauseHandler.Pausing -= OnPausing;
+        _pauseHandler.Paused -= OnPaused;
         Source.Dispose();
         GC.SuppressFinalize(this);
     }


### PR DESCRIPTION
### Description of Changes
Added "Paused" event for systems that want to react on the system finishing entering the paused state.
Moved UI systems from "Pausing" event (which signals the start of enetering the paused state) to "Paused".

### Rationale behind Changes
"Pausing" is for systems that need to do something before a pause can take full effect.
"Paused" is for systems that want to react to the system having become paused.
UI systems using Pausing could read values from the CPU while it was not yet paused. The debugger got confused when the values from the current cpu state did not match the values read when the Pausing event was handled.

### Suggested Testing Steps
Use the debugger to see if behaviour is consistent now.