### PR TITLE
Add Seer config file

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,25 +158,17 @@ Break at the end of the emulated program:
 ```
 
 ## Seer
-For a pleasing and productive experience with GDB, the [seerGDB](https://github.com/epasveer/seer) client is highly recommended.
+For a pleasing and productive experience with GDB, the
+[seerGDB](https://github.com/epasveer/seer) client is highly recommended.
 
-At best, create a configuration file `spice86.seer` with this content:
-```json
-{
-    "seerproject": {
-        "connectmode": { "gdbserver": "127.0.0.1:10000" },
-        "executable": "",
-        "postgdbcommands": [ "" ],
-        "pregdbcommands": [ "set architecture i8086" ],
-        "symbolfile": "",
-        "workingdirectory": ""
-    }
-}
+At best, use the configuration file `spice86.seer` provided in the `doc`
+directory ([here](doc/spice86.seer)): start Spice86 with `--GdbPort=10000`, and
+run Seer with `seergdb --project spice86.seer`.
 
-```
-and start Seer with `seergdb --project spice86.seer`.
+If you use a different port for gdb, adjust `spice86.seer` correspondingly.
 
-Also, while in Seer, set Settings/Configuration/Assembly/Disassembly Mode to “Length”, otherwise the Assembly View won't work.
+Also, while in Seer, set Settings/Configuration/Assembly/Disassembly Mode to
+“Length”, otherwise the Assembly View won't work.
 
 ## Reverse engineering process
 Concrete example with Cryo Dune [here](https://github.com/OpenRakis/Cryogenic).

--- a/doc/spice86.seer
+++ b/doc/spice86.seer
@@ -1,0 +1,17 @@
+{
+    "seerproject": {
+        "connectmode": {
+            "gdbserver": "127.0.0.1:10000",
+            "targettype": "remote"
+        },
+        "executable": "",
+        "postgdbcommands": [
+            ""
+        ],
+        "pregdbcommands": [
+            "set architecture i8086"
+        ],
+        "symbolfile": "",
+        "workingdirectory": ""
+    }
+}


### PR DESCRIPTION
### Description of Changes
Add a config file for Seer

### Rationale behind Changes
Provides an easy way to use Seer with Spice86

### Suggested Testing Steps
Start Spice86 with `--GdbPort=10000`, and Seer with `seergdb --project ${SPICE86ROOT}/doc/spice86.seer`