### PR TITLE
Segmented address improvements

### DIFF
--- a/src/Spice86.Core/Emulator/CPU/CfgCpu/ExecutionContextManager.cs
+++ b/src/Spice86.Core/Emulator/CPU/CfgCpu/ExecutionContextManager.cs
@@ -32,7 +32,7 @@ public class ExecutionContextManager : InstructionReplacer {
         CurrentExecutionContext = new(_currentDepth);
         if (expectedReturnAddress != null) {
             // breakpoint that deletes itself on reach. Should be triggered when the return address is reached and before it starts execution.
-            _emulatorBreakpointsManager.ToggleBreakPoint(new AddressBreakPoint(BreakPointType.CPU_EXECUTION_ADDRESS, expectedReturnAddress.Value.ToPhysical(), (_) => {
+            _emulatorBreakpointsManager.ToggleBreakPoint(new AddressBreakPoint(BreakPointType.CPU_EXECUTION_ADDRESS, expectedReturnAddress.Value.Linear, (_) => {
                 // Restore previous execution context and depth
                 CurrentExecutionContext = previousExecutionContext;
                 _currentDepth--;

--- a/src/Spice86.Core/Emulator/CPU/CfgCpu/Feeder/CurrentInstructions.cs
+++ b/src/Spice86.Core/Emulator/CPU/CfgCpu/Feeder/CurrentInstructions.cs
@@ -59,7 +59,7 @@ public class CurrentInstructions : InstructionReplacer {
         SegmentedAddress instructionAddress = instruction.Address;
         List<AddressBreakPoint> breakpoints = new();
         _breakpointsForInstruction.Add(instructionAddress, breakpoints);
-        uint instructionPhysicalAddress = instructionAddress.ToPhysical();
+        uint instructionPhysicalAddress = instructionAddress.Linear;
         for (uint byteAddress = instructionPhysicalAddress;
              byteAddress < instructionPhysicalAddress + instruction.Length;
              byteAddress++) {

--- a/src/Spice86.Core/Emulator/CPU/CfgCpu/Feeder/MemoryInstructionMatcher.cs
+++ b/src/Spice86.Core/Emulator/CPU/CfgCpu/Feeder/MemoryInstructionMatcher.cs
@@ -17,7 +17,7 @@ public class MemoryInstructionMatcher {
     }
 
     private bool IsMatchingWithCurrentMemory(CfgInstruction instruction) {
-        Span<byte> bytesInMemory = _memory.GetSpan((int)instruction.Address.ToPhysical(), instruction.Length);
+        Span<byte> bytesInMemory = _memory.GetSpan((int)instruction.Address.Linear, instruction.Length);
         return instruction.Discriminator.SpanEquivalent(bytesInMemory);
     }
 

--- a/src/Spice86.Core/Emulator/CPU/CfgCpu/ParsedInstruction/SelfModifying/DiscriminatedNode.cs
+++ b/src/Spice86.Core/Emulator/CPU/CfgCpu/ParsedInstruction/SelfModifying/DiscriminatedNode.cs
@@ -26,10 +26,9 @@ public class DiscriminatedNode : CfgNode {
     }
 
     public override void Execute(InstructionExecutionHelper helper) {
-        int address = (int)Address.ToPhysical();
         foreach (Discriminator discriminator in SuccessorsPerDiscriminator.Keys) {
             int length = discriminator.DiscriminatorValue.Count;
-            Span<byte> bytes = helper.Memory.GetSpan(address, length);
+            Span<byte> bytes = helper.Memory.GetSpan((int)Address.Linear, length);
             if (discriminator.SpanEquivalent(bytes)) {
                 helper.NextNode = SuccessorsPerDiscriminator[discriminator];
                 return;

--- a/src/Spice86.Core/Emulator/CPU/CfgCpu/Parser/FieldReader/InstructionFieldReader.cs
+++ b/src/Spice86.Core/Emulator/CPU/CfgCpu/Parser/FieldReader/InstructionFieldReader.cs
@@ -39,7 +39,7 @@ public abstract class InstructionFieldReader<T> {
         T value = PeekValue();
         ImmutableList<byte?> bytes = PeekData(FieldSize());
         return new InstructionField<T>(AddressSource.IndexInInstruction, FieldSize(),
-            CurrentAddress.ToPhysical(), value, bytes, finalValue);
+            CurrentAddress.Linear, value, bytes, finalValue);
     }
 
     /// <summary>
@@ -54,7 +54,7 @@ public abstract class InstructionFieldReader<T> {
     }
 
     private ImmutableList<byte?> PeekData(int size) {
-        byte[] data = Memory.GetData(CurrentAddress.ToPhysical(), (uint)size);
+        byte[] data = Memory.GetData(CurrentAddress.Linear, (uint)size);
         return data.
             Select(b => (byte?)b).
             ToImmutableList();

--- a/src/Spice86.Core/Emulator/Function/Dump/GhidraSymbolsDumper.cs
+++ b/src/Spice86.Core/Emulator/Function/Dump/GhidraSymbolsDumper.cs
@@ -69,11 +69,11 @@ public class GhidraSymbolsDumper {
     }
 
     private string ToGhidraSymbol(string name, SegmentedAddress address, string type) {
-        return $"{name}_{ToString(address)} {ConvertUtils.ToHex(address.ToPhysical())} {type}";
+        return $"{name}_{ToString(address)} {ConvertUtils.ToHex(address.Linear)} {type}";
     }
 
     private string ToString(SegmentedAddress address) {
-        return $"{ConvertUtils.ToHex16WithoutX(address.Segment)}_{ConvertUtils.ToHex16WithoutX(address.Offset)}_{ConvertUtils.ToHex32WithoutX(address.ToPhysical())}";
+        return $"{ConvertUtils.ToHex16WithoutX(address.Segment)}_{ConvertUtils.ToHex16WithoutX(address.Offset)}_{ConvertUtils.ToHex32WithoutX(address.Linear)}";
     }
 
     /// <summary>

--- a/src/Spice86.Core/Emulator/Function/ExecutionFlowRecorder.cs
+++ b/src/Spice86.Core/Emulator/Function/ExecutionFlowRecorder.cs
@@ -203,7 +203,7 @@ public class ExecutionFlowRecorder {
     }
 
     private void RegisterExecutableByteModification(SegmentedAddress instructionAddress, uint modifiedAddress, byte oldValue, byte newValue) {
-        uint instructionAddressPhysical = instructionAddress.ToPhysical();
+        uint instructionAddressPhysical = instructionAddress.Linear;
         if (instructionAddressPhysical == 0) {
             // Probably Exe load
             return;

--- a/src/Spice86.Core/Emulator/Function/FunctionHandler.cs
+++ b/src/Spice86.Core/Emulator/Function/FunctionHandler.cs
@@ -162,7 +162,7 @@ public class FunctionHandler {
         IMemory memory = _memory;
         return returnCallType switch {
             CallType.NEAR => new SegmentedAddress(_state.CS, memory.UInt16[stackPhysicalAddress]),
-            CallType.FAR or CallType.INTERRUPT => new SegmentedAddress(memory.SegmentedAddress[stackPhysicalAddress]),
+            CallType.FAR or CallType.INTERRUPT => memory.SegmentedAddress[stackPhysicalAddress],
             CallType.MACHINE => null,
             _ => null
         };
@@ -277,11 +277,11 @@ public class FunctionHandler {
             && !currentFunctionInformation.UnalignedReturns.ContainsKey(currentFunctionReturn)) {
             CallType callType = currentFunctionCall.CallType;
             SegmentedAddress stackAddressAfterCall = currentFunctionCall.StackAddressAfterCall;
-            SegmentedAddress? returnAddressOnCallTimeStack = PeekReturnAddressOnMachineStack(callType, stackAddressAfterCall.ToPhysical());
+            SegmentedAddress? returnAddressOnCallTimeStack = PeekReturnAddressOnMachineStack(callType, stackAddressAfterCall.Linear);
             SegmentedAddress currentStackAddress = CurrentStackAddress;
             string additionalInformation = Environment.NewLine;
             if (!currentStackAddress.Equals(stackAddressAfterCall)) {
-                int delta = (int)Math.Abs(currentStackAddress.ToPhysical() - (long)stackAddressAfterCall.ToPhysical());
+                int delta = (int)Math.Abs(currentStackAddress.Linear - (long)stackAddressAfterCall.Linear);
                 additionalInformation +=
                     $"Stack is not pointing at the same address as it was at call time. Delta is {delta} bytes{Environment.NewLine}";
             }

--- a/src/Spice86.Core/Emulator/InterruptHandlers/Common/MemoryWriter/MemoryAsmWriter.cs
+++ b/src/Spice86.Core/Emulator/InterruptHandlers/Common/MemoryWriter/MemoryAsmWriter.cs
@@ -30,7 +30,7 @@ public class MemoryAsmWriter : MemoryWriter {
     /// <param name="callbackNumber">Callback index</param>
     /// <param name="runnable">Action to run when this callback is executed by the CPU</param>
     public void RegisterAndWriteCallback(byte callbackNumber, Action runnable) {
-        Callback callback = new Callback(callbackNumber, runnable, GetCurrentAddressCopy());
+        Callback callback = new Callback(callbackNumber, runnable, CurrentAddress);
         _callbackHandler.AddCallback(callback);
         WriteCallback(callback.Index);
     }
@@ -84,7 +84,7 @@ public class MemoryAsmWriter : MemoryWriter {
         if (inMemoryAddressSwitcher.DefaultAddress is null) {
             throw new UnrecoverableException("Cannot write a FAR call to a null address.");
         }
-        inMemoryAddressSwitcher.PhysicalLocation = WriteFarCall(inMemoryAddressSwitcher.DefaultAddress.Value).ToPhysical();
+        inMemoryAddressSwitcher.PhysicalLocation = WriteFarCall(inMemoryAddressSwitcher.DefaultAddress.Value).Linear;
     }
 
     /// <summary>
@@ -95,7 +95,7 @@ public class MemoryAsmWriter : MemoryWriter {
     public SegmentedAddress WriteFarCall(SegmentedAddress destination) {
         WriteUInt8(0x9A);
         // Make a copy of the address since it is going to be modified by our writes.
-        SegmentedAddress ret = GetCurrentAddressCopy();
+        SegmentedAddress ret = CurrentAddress;
         WriteSegmentedAddress(destination);
         return ret;
     }

--- a/src/Spice86.Core/Emulator/InterruptHandlers/Common/MemoryWriter/MemoryWriter.cs
+++ b/src/Spice86.Core/Emulator/InterruptHandlers/Common/MemoryWriter/MemoryWriter.cs
@@ -15,14 +15,6 @@ public class MemoryWriter {
     public SegmentedAddress CurrentAddress { get; set; }
 
     /// <summary>
-    /// Creates and returns a copy of CurrentAddress so that the returned instance is not impacted by changes to CurrentAddress.
-    /// </summary>
-    /// <returns>a copy of CurrentAddress</returns>
-    public SegmentedAddress GetCurrentAddressCopy() {
-        return new SegmentedAddress(CurrentAddress);
-    }
-
-    /// <summary>
     /// Initializes a new instance of the <see cref="MemoryWriter"/> class with the specified memory as a data sink and beginningAddress for position for the first write.
     /// </summary>
     /// <param name="memory">memory bus to write to</param>

--- a/src/Spice86.Core/Emulator/InterruptHandlers/Input/Mouse/BiosMouseInt74Handler.cs
+++ b/src/Spice86.Core/Emulator/InterruptHandlers/Input/Mouse/BiosMouseInt74Handler.cs
@@ -43,11 +43,11 @@ public class BiosMouseInt74Handler : IInterruptHandler {
 
         // Write ASM
         // Default mouse driver: nothing, just a far ret
-        _driverAddressSwitcher.DefaultAddress = memoryAsmWriter.GetCurrentAddressCopy();
+        _driverAddressSwitcher.DefaultAddress = memoryAsmWriter.CurrentAddress;
         memoryAsmWriter.WriteFarRet();
 
         // Entry point to the interrupt handler
-        SegmentedAddress interruptHandlerAddress = memoryAsmWriter.GetCurrentAddressCopy();
+        SegmentedAddress interruptHandlerAddress = memoryAsmWriter.CurrentAddress;
         // Far call to default driver, can be changed via _inMemoryAddressSwitcher
         memoryAsmWriter.WriteFarCallToSwitcherDefaultAddress(_driverAddressSwitcher);
         // Write a callback that will EOI PIC after mouse driver execution

--- a/src/Spice86.Core/Emulator/InterruptHandlers/Input/Mouse/MouseDriver.cs
+++ b/src/Spice86.Core/Emulator/InterruptHandlers/Input/Mouse/MouseDriver.cs
@@ -340,10 +340,10 @@ public class MouseDriver : IMouseDriver {
 
         // Write ASM
         // Default user handler: nothing, just a far ret. 
-        _userHandlerAddressSwitcher.DefaultAddress = memoryAsmWriter.GetCurrentAddressCopy();
+        _userHandlerAddressSwitcher.DefaultAddress = memoryAsmWriter.CurrentAddress;
         memoryAsmWriter.WriteFarRet();
 
-        SegmentedAddress driverAddress = memoryAsmWriter.GetCurrentAddressCopy();
+        SegmentedAddress driverAddress = memoryAsmWriter.CurrentAddress;
         memoryAsmWriter.RegisterAndWriteCallback(BeforeUserHandlerExecutionCallbackNumber, BeforeUserHandlerExecution);
         // Far call to default handler, can be changed via _inMemoryAddressSwitcher
         memoryAsmWriter.WriteFarCallToSwitcherDefaultAddress(_userHandlerAddressSwitcher);

--- a/src/Spice86.Core/Emulator/InterruptHandlers/InterruptHandler.cs
+++ b/src/Spice86.Core/Emulator/InterruptHandlers/InterruptHandler.cs
@@ -60,7 +60,7 @@ public abstract class InterruptHandler : IndexBasedDispatcher<IRunnable>, IInter
         //  - Write that in ram with an IRET
 
         // Write ASM
-        SegmentedAddress interruptHandlerAddress = memoryAsmWriter.GetCurrentAddressCopy();
+        SegmentedAddress interruptHandlerAddress = memoryAsmWriter.CurrentAddress;
         memoryAsmWriter.RegisterAndWriteCallback(VectorNumber, Run);
         memoryAsmWriter.WriteIret();
 

--- a/src/Spice86.Core/Emulator/InterruptHandlers/VGA/VgaFunctionality.cs
+++ b/src/Spice86.Core/Emulator/InterruptHandlers/VGA/VgaFunctionality.cs
@@ -279,8 +279,8 @@ public class VgaFunctionality : IVgaFunctionality {
     /// <inheritdoc />
     public SegmentedAddress GetFontAddress(byte fontNumber) {
         SegmentedAddress address = fontNumber switch {
-            0x00 => GetInterruptVectorAddress(0x1F),
-            0x01 => GetInterruptVectorAddress(0x43),
+            0x00 => _interruptVectorTable[0x1F],
+            0x01 => _interruptVectorTable[0x43],
             0x02 => _vgaRom.VgaFont14Address,
             0x03 => _vgaRom.VgaFont8Address,
             0x04 => _vgaRom.VgaFont8Address2,
@@ -788,10 +788,6 @@ public class VgaFunctionality : IVgaFunctionality {
         return new CharacterPlusAttribute((char)0, 0, false);
     }
 
-    private SegmentedAddress GetInterruptVectorAddress(byte vector) {
-        return new SegmentedAddress(_interruptVectorTable[vector]);
-    }
-
     private int MemCmp(ReadOnlySpan<byte> bytes, ushort segment, ushort offset, int length) {
         int i = 0;
         while (length-- > 0 && i < bytes.Length) {
@@ -1162,10 +1158,10 @@ public class VgaFunctionality : IVgaFunctionality {
         int characterHeight = _biosDataArea.CharacterHeight;
         SegmentedAddress address;
         if (characterHeight == 8 && character >= 128) {
-            address = GetInterruptVectorAddress(0x1F);
+            address = _interruptVectorTable[0x1F];
             character = (char)(character - 128);
         } else {
-            address = GetInterruptVectorAddress(0x43);
+            address = _interruptVectorTable[0x43];
         }
         address += (ushort)(character * characterHeight);
         return address;

--- a/src/Spice86.Core/Emulator/ReverseEngineer/CSharpOverrideHelper.cs
+++ b/src/Spice86.Core/Emulator/ReverseEngineer/CSharpOverrideHelper.cs
@@ -541,7 +541,7 @@ public class CSharpOverrideHelper {
     /// <param name="vectorNumber">The vector number to call for the interrupt.</param>
     /// <exception cref="UnrecoverableException">If the interrupt vector number is not recognized.</exception>
     public void InterruptCall(ushort expectedReturnCs, ushort expectedReturnIp, byte vectorNumber) {
-        SegmentedAddress target = new(Cpu.InterruptVectorTable[vectorNumber]);
+        SegmentedAddress target = Cpu.InterruptVectorTable[vectorNumber];
         Func<int, Action>? function = SearchFunctionOverride(target);
         if (function is null) {
             throw FailAsUntested($"Could not find an override at address {target}");

--- a/src/Spice86.Shared/Utils/ConvertUtils.cs
+++ b/src/Spice86.Shared/Utils/ConvertUtils.cs
@@ -278,7 +278,7 @@ public static partial class ConvertUtils {
     /// <param name="address">The SegmentedAddress object to convert.</param>
     /// <returns>A C# formatted string representing the SegmentedAddress object with physical address.</returns>
     public static string ToCSharpStringWithPhysical(SegmentedAddress address) {
-        return $"{ToHex16WithoutX(address.Segment)}_{ToHex16WithoutX(address.Offset)}_{ToHex32WithoutX(address.ToPhysical())}";
+        return $"{ToHex16WithoutX(address.Segment)}_{ToHex16WithoutX(address.Offset)}_{ToHex32WithoutX(address.Linear)}";
     }
 
     /// <summary>

--- a/src/Spice86/MemoryWrappers/InstructionsDecoder.cs
+++ b/src/Spice86/MemoryWrappers/InstructionsDecoder.cs
@@ -6,7 +6,6 @@ using Spice86.Core.Emulator.CPU;
 using Spice86.Core.Emulator.Function;
 using Spice86.Core.Emulator.Memory;
 using Spice86.Models.Debugging;
-using Spice86.Shared.Emulator.Memory;
 using Spice86.ViewModels;
 
 using System;

--- a/src/Spice86/MemoryWrappers/InstructionsDecoder.cs
+++ b/src/Spice86/MemoryWrappers/InstructionsDecoder.cs
@@ -6,6 +6,7 @@ using Spice86.Core.Emulator.CPU;
 using Spice86.Core.Emulator.Function;
 using Spice86.Core.Emulator.Memory;
 using Spice86.Models.Debugging;
+using Spice86.Shared.Emulator.Memory;
 using Spice86.ViewModels;
 
 using System;

--- a/src/Spice86/Messages/AddressChangedMessage.cs
+++ b/src/Spice86/Messages/AddressChangedMessage.cs
@@ -1,3 +1,5 @@
 namespace Spice86.Messages;
 
-public record AddressChangedMessage(ulong Address);
+using Spice86.Shared.Emulator.Memory;
+
+public record AddressChangedMessage(SegmentedAddress Address);

--- a/src/Spice86/ViewModels/CfgCpuViewModel.cs
+++ b/src/Spice86/ViewModels/CfgCpuViewModel.cs
@@ -120,7 +120,7 @@ public partial class CfgCpuViewModel : ViewModelBase {
             case CfgInstruction cfgInstruction: {
                 SegmentedAddress nextAddress = new SegmentedAddress(cfgInstruction.Address.Segment,
                     (ushort)(cfgInstruction.Address.Offset + cfgInstruction.Length));
-                if (successor.Address.ToPhysical() != nextAddress.ToPhysical()) {
+                if (successor.Address != nextAddress) {
                     // Not direct successor, jump or call
                     label = "not contiguous";
                 }

--- a/src/Spice86/ViewModels/DebugWindowViewModel.cs
+++ b/src/Spice86/ViewModels/DebugWindowViewModel.cs
@@ -87,7 +87,7 @@ public partial class DebugWindowViewModel : ViewModelBase,
             emulatorBreakpointsManager,
             memory, state, 
             functionsInformation.ToDictionary(x =>
-                x.Key.ToPhysical(), x => x.Value),
+                x.Key.Linear, x => x.Value),
             BreakpointsViewModel, pauseHandler,
             uiDispatcher, messenger, textClipboard);
         DisassemblyViewModels.Add(disassemblyVm);

--- a/src/Spice86/ViewModels/StructureViewModel.cs
+++ b/src/Spice86/ViewModels/StructureViewModel.cs
@@ -131,7 +131,7 @@ public partial class StructureViewModel : ViewModelBase, IDisposable {
         if (value is null) {
             StructureMemory = _originalMemory;
             if (MemoryAddress is { } address) {
-                RequestScrollToAddress?.Invoke(this, new AddressChangedMessage(address.ToPhysical()));
+                RequestScrollToAddress?.Invoke(this, new AddressChangedMessage(address));
             }
         }
         Update();
@@ -139,7 +139,7 @@ public partial class StructureViewModel : ViewModelBase, IDisposable {
 
     partial void OnMemoryAddressChanged(SegmentedAddress? value) {
         if (value is { } address) {
-            RequestScrollToAddress?.Invoke(this, new AddressChangedMessage(address.ToPhysical()));
+            RequestScrollToAddress?.Invoke(this, new AddressChangedMessage(address));
         }
         Update();
     }
@@ -164,7 +164,7 @@ public partial class StructureViewModel : ViewModelBase, IDisposable {
 
         // Calculate the offset into the viewed memory.
         uint offset = IsAddressableMemory && MemoryAddress is { } address
-            ? address.ToPhysical()
+            ? address.Linear
             : 0;
 
         byte[] data = new byte[SelectedStructure.Size];

--- a/src/Spice86/Views/StructureView.axaml.cs
+++ b/src/Spice86/Views/StructureView.axaml.cs
@@ -20,7 +20,7 @@ public partial class StructureView : Window {
     }
 
     private void ViewModel_RequestScrollToAddress(object? sender, AddressChangedMessage e) {
-        var scrollOffset = new Vector(0.0, (double)e.Address / StructureHexEditor.HexView.ActualBytesPerLine);
+        var scrollOffset = new Vector(0.0, (double)e.Address.Linear / StructureHexEditor.HexView.ActualBytesPerLine);
         StructureHexEditor.Caret.HexView.ScrollOffset = scrollOffset;
     }
 }


### PR DESCRIPTION
### Description of Changes
- It's now truly immutable and never needs to recalculate the linear address.
- The addition and subtraction operators got bug fixes for over and underflows.
- A bunch of other comparison operators were added.
- Some constructs that assumed SegmentedAddress was mutable or a reference type were fixed.

### Rationale behind Changes
If the SegmentedAddress is more flexible and easier to use, then perhaps it'll be easier to keep address segments for longer before converting them to uints

### Suggested Testing Steps
I ran Krondor and Dune for a bit and noticed no issues.
