### PR TITLE
refactor: INT21 warns when a program has exited

### DIFF
--- a/src/Spice86.Core/Emulator/InterruptHandlers/Dos/DosInt21Handler.cs
+++ b/src/Spice86.Core/Emulator/InterruptHandlers/Dos/DosInt21Handler.cs
@@ -791,8 +791,8 @@ public class DosInt21Handler : InterruptHandler {
     /// </summary>
     public void QuitWithExitCode() {
         byte exitCode = State.AL;
-        if (LoggerService.IsEnabled(LogEventLevel.Verbose)) {
-            LoggerService.Verbose("QUIT WITH EXIT CODE {ExitCode}", ConvertUtils.ToHex8(exitCode));
+        if (LoggerService.IsEnabled(LogEventLevel.Warning)) {
+            LoggerService.Warning("INT21H: QUIT WITH EXIT CODE {ExitCode}", ConvertUtils.ToHex8(exitCode));
         }
         State.IsRunning = false;
     }


### PR DESCRIPTION
### Description of Changes

DOS warns on process exit.

### Rationale behind Changes

Helps detect games that are not supported. Well, some of them.

### Suggested Testing Steps

This is only a log line level change.