### PR TITLE
fix: Pass reference to functions dict

### DIFF
--- a/src/Spice86/Spice86DependencyInjection.cs
+++ b/src/Spice86/Spice86DependencyInjection.cs
@@ -257,8 +257,7 @@ public class Spice86DependencyInjection : IDisposable {
             DisassemblyViewModel disassemblyVm = new(
                 emulatorBreakpointsManager,
                 memory, state,
-                functionsInformation.ToDictionary(x =>
-                x.Key, x => x.Value),
+                functionsInformation,
             breakpointsViewModel, pauseHandler,
             uiThreadDispatcher, messenger, textClipboard);
             PaletteViewModel paletteViewModel = new(

--- a/src/Spice86/ViewModels/DisassemblyViewModel.cs
+++ b/src/Spice86/ViewModels/DisassemblyViewModel.cs
@@ -39,11 +39,6 @@ public partial class DisassemblyViewModel : ViewModelWithErrorDialog {
         : base(uiDispatcher, textClipboard) {
         _emulatorBreakpointsManager = emulatorBreakpointsManager;
         _functionsInformation = functionsInformation;
-        Functions = new(functionsInformation
-            .Select(x => new FunctionInfo() {
-                Name = x.Value.Name,
-                Address = x.Key,
-            }).OrderBy(x => x.Address));
         AreFunctionInformationProvided = functionsInformation.Count > 0;
         _breakpointsViewModel = breakpointsViewModel;
         _messenger = messenger;
@@ -86,6 +81,17 @@ public partial class DisassemblyViewModel : ViewModelWithErrorDialog {
     private void OnPaused() {
         _uiDispatcher.Post(() => {
             IsPaused = true;
+
+            Functions = new(_functionsInformation
+                .Select(x => new FunctionInfo() {
+                    Name = x.Value.Name,
+                    Address = x.Key,
+                }).OrderBy(x => x.Address));
+
+            SelectedFunction = Functions.FirstOrDefault(
+                x => x.Name == SelectedFunction?.Name &&
+                x.Address == SelectedFunction?.Address);
+
             if (!_didCsIpGoOutOfCurrentListing) {
                 UpdateDisassemblyInternal();
             } else if (GoToCsIpCommand.CanExecute(null)) {


### PR DESCRIPTION
### Description of Changes

The functions information dict reference is passed to the UI, instead of making a new dictionary.

More over, the types within the dictionnaries were the same anyway.

### Rationale behind Changes

This ensures that new functions discovered by the emulator are actually displayed in the functions combo box.

The AvalonaList behind it is updated for the benefit of the UI when the emulator is paused.

### Suggested Testing Steps


Already tested with Cryogenic:

![image](https://github.com/user-attachments/assets/b7a43fc0-eef1-4cd0-808e-b4aff8a68b3c)
