### PR TITLE
Fix: Lost Eden SB PCM and SB Music support

### DIFF
--- a/src/Spice86.Core/Emulator/Devices/Sound/Blaster/HardwareMixer.cs
+++ b/src/Spice86.Core/Emulator/Devices/Sound/Blaster/HardwareMixer.cs
@@ -52,7 +52,9 @@ public class HardwareMixer {
                 return GetDMAByte();
 
             default:
-                _logger.Warning("Unsupported mixer register {CurrentAddress:X2}h", CurrentAddress);
+                if (_logger.IsEnabled(Serilog.Events.LogEventLevel.Warning)) {
+                    _logger.Warning("Unsupported mixer register {CurrentAddress:X2}h", CurrentAddress);
+                }
                 return 0;
         }
     }
@@ -72,7 +74,9 @@ public class HardwareMixer {
                 _opl3fmSoundChannel.Volume = percentScaledValue;
                 break;
             default:
-                _logger.Warning("Unsupported mixer register {CurrentAddress:X2}h", CurrentAddress);
+                if (_logger.IsEnabled(Serilog.Events.LogEventLevel.Warning)) {
+                    _logger.Warning("Unsupported mixer register {CurrentAddress:X2}h", CurrentAddress);
+                }
                 break;
         }
     }

--- a/src/Spice86.Core/Emulator/Devices/Sound/Blaster/SbType.cs
+++ b/src/Spice86.Core/Emulator/Devices/Sound/Blaster/SbType.cs
@@ -7,9 +7,14 @@ public enum SbType {
     /// <summary>
     /// SoundBlaster 16
     /// </summary>
-    Sb16,
+    Sb16 = 6,
     /// <summary>
     /// SoundBlaster Pro
     /// </summary>
-    SbPro,
+    SbPro1 = 2,
+
+    /// <summary>
+    /// SoundBlaster Pro 2
+    /// </summary>
+    SbPro2 = 4,
 }

--- a/src/Spice86.Core/Emulator/Devices/Sound/Blaster/SoundBlaster.cs
+++ b/src/Spice86.Core/Emulator/Devices/Sound/Blaster/SoundBlaster.cs
@@ -175,7 +175,7 @@ public class SoundBlaster : DefaultIOPortHandler, IDmaDevice8, IDmaDevice16, IRe
     /// <summary>
     /// The type of SoundBlaster card currently emulated.
     /// </summary>
-    public SbType SbType { get; set; } = SbType.SbPro;
+    public SbType SbType { get; set; } = SbType.Sb16;
 
     /// <summary>
     /// Initializes a new instance of the SoundBlaster class.
@@ -218,7 +218,7 @@ public class SoundBlaster : DefaultIOPortHandler, IDmaDevice8, IDmaDevice16, IRe
     public override byte ReadByte(ushort port) {
         switch (port) {
             case MPU401_DATA_PORT:
-                return 0x0;
+                return 0xFF;
             case MPU401_STATUS_COMMAND_PORT:
                 return 0xC0; //No data, and the interface is not ready
             case DspPorts.DspReadStatus:

--- a/src/Spice86.Core/Emulator/Devices/Sound/Blaster/SoundBlasterHardwareConfig.cs
+++ b/src/Spice86.Core/Emulator/Devices/Sound/Blaster/SoundBlasterHardwareConfig.cs
@@ -3,7 +3,7 @@ namespace Spice86.Core.Emulator.Devices.Sound.Blaster;
 /// <summary>
 /// Depending on the SoundBlaster variant, these can change.
 /// </summary>
-/// <param name="Irq">Defaults is 7.</param>
+/// <param name="Irq">Defaults is 5.</param>
 /// <param name="LowDma">Defaults is 1.</param>
 /// <param name="HighDma">Default is 5.</param>
 /// <param name="SbType">The type of SoundBlaster card to emulate. Defaults to SoundBlaster 16.</param>

--- a/src/Spice86/Spice86DependencyInjection.cs
+++ b/src/Spice86/Spice86DependencyInjection.cs
@@ -116,7 +116,7 @@ public class Spice86DependencyInjection : IDisposable {
         PcSpeaker pcSpeaker = new PcSpeaker(softwareMixer, state, timer.GetCounter(2), ioPortDispatcher, pauseHandler, loggerService,
             configuration.FailOnUnhandledPort);
 
-        var soundBlasterHardwareConfig = new SoundBlasterHardwareConfig(7, 1, 5, SbType.Sb16);
+        var soundBlasterHardwareConfig = new SoundBlasterHardwareConfig(5, 1, 5, SbType.Sb16);
         SoundBlaster soundBlaster = new SoundBlaster(ioPortDispatcher, softwareMixer, state, dmaController, dualPic,
             configuration.FailOnUnhandledPort,
             loggerService, soundBlasterHardwareConfig, pauseHandler);


### PR DESCRIPTION
### Description of Changes

Fixes Lost Eden sound support.

Lost Eden (1995) is a Cryo game. its game engine is very close to Dune (1992).

It just replaces the Fremen with dinosaurs, essentially.


### Rationale behind Changes

Lost Eden FM Synth and PCM support is fixed:
All I had to is to return 0xFF when it tries to read the soundblaster's MPU-401 port, and set the soundBlaster IRQ to 5, which is the _factory_ default that all **real mode games** expect.


### Suggested Testing Steps

Command line parameters:

`-f -d false -e "C:\GOG Games\Lost Eden\EDENPRG.EXE" -a "ENG SDB2225"`

Also works with EMS:

`-f -d false -e "C:\GOG Games\Lost Eden\EDENPRG.EXE" -a "ENG SDB2225 EMS" --Ems`

Also works well with the CFGCPU:

`--CfgCpu true -f -d false -e "C:\GOG Games\Lost Eden\EDENPRG.EXE" -a "ENG SDB2225 EMS" --Ems`


![image](https://github.com/user-attachments/assets/2f188b81-a352-4da3-a025-0a98ccd3fdf8)
