### PR TITLE
Add a field in all nodes to represent whether the node is aligned with the current state of the machine. This makes CfgCpu slightly faster.

### DIFF
--- a/src/Spice86.Core/Emulator/CPU/CfgCpu/ControlFlowGraph/CfgNode.cs
+++ b/src/Spice86.Core/Emulator/CPU/CfgCpu/ControlFlowGraph/CfgNode.cs
@@ -15,8 +15,8 @@ public abstract class CfgNode : ICfgNode {
     public HashSet<ICfgNode> Successors { get; } = new();
     public SegmentedAddress Address { get; }
     public virtual bool CanCauseContextRestore => false;
-
-    public abstract bool IsAssembly { get; }
+   
+    public abstract bool IsLive { get; }
     
     public abstract void UpdateSuccessorCache();
 

--- a/src/Spice86.Core/Emulator/CPU/CfgCpu/ControlFlowGraph/ICfgNode.cs
+++ b/src/Spice86.Core/Emulator/CPU/CfgCpu/ControlFlowGraph/ICfgNode.cs
@@ -28,9 +28,11 @@ public interface ICfgNode {
     public SegmentedAddress Address { get; }
 
     /// <summary>
-    /// True when the node represents an assembly instruction that exists or has existed in memory
+    /// Returns whether the node Live.
+    /// Live means the node is in a state aligned with the machine state and can be executed.
+    /// For an instruction, it means it is the same as the memory representation of the instruction.
     /// </summary>
-    public bool IsAssembly { get; }
+    public bool IsLive { get; }
 
     /// <summary>
     /// True when the node execution can lead to going back to previous execution context if the next to execute is the correct address

--- a/src/Spice86.Core/Emulator/CPU/CfgCpu/Feeder/CfgNodeFeeder.cs
+++ b/src/Spice86.Core/Emulator/CPU/CfgCpu/Feeder/CfgNodeFeeder.cs
@@ -51,8 +51,8 @@ public class CfgNodeFeeder {
             return CurrentNodeFromInstructionFeeder;
         }
 
-        if (!currentFromGraph.IsAssembly) {
-            // Cannot check if match with memory. Just execute it.
+        if (currentFromGraph.IsLive) {
+            // Instruction is up to date. No need to do anything.
             return currentFromGraph;
         }
 

--- a/src/Spice86.Core/Emulator/CPU/CfgCpu/Feeder/CurrentInstructions.cs
+++ b/src/Spice86.Core/Emulator/CPU/CfgCpu/Feeder/CurrentInstructions.cs
@@ -84,6 +84,7 @@ public class CurrentInstructions : InstructionReplacer {
     private void AddInstructionInCurrentCache(CfgInstruction instruction) {
         SegmentedAddress instructionAddress = instruction.Address;
         _currentInstructionAtAddress.Add(instructionAddress, instruction);
+        instruction.SetLive(true);
     }
 
     private void ClearCurrentInstruction(CfgInstruction instruction) {
@@ -97,5 +98,6 @@ public class CurrentInstructions : InstructionReplacer {
         }
 
         _currentInstructionAtAddress.Remove(instruction.Address);
+        instruction.SetLive(false);
     }
 }

--- a/src/Spice86.Core/Emulator/CPU/CfgCpu/ParsedInstruction/CfgInstruction.cs
+++ b/src/Spice86.Core/Emulator/CPU/CfgCpu/ParsedInstruction/CfgInstruction.cs
@@ -12,6 +12,11 @@ using System.Linq;
 /// Base of all the instructions: Prefixes (optional) and an opcode that can be either one or 2 bytes.
 /// </summary>
 public abstract class CfgInstruction : CfgNode, ICfgInstruction {
+    /// <summary>
+    /// Instructions are born live.
+    /// </summary>
+    private bool _isLive = true;
+
     protected CfgInstruction(SegmentedAddress address, InstructionField<ushort> opcodeField) : this(address,
         opcodeField, new List<InstructionPrefix>()) {
     }
@@ -59,7 +64,7 @@ public abstract class CfgInstruction : CfgNode, ICfgInstruction {
         SuccessorsPerAddress = Successors.ToDictionary(node => node.Address);
     }
 
-    public override bool IsAssembly { get => true; }
+    public override bool IsLive => _isLive;
 
     public List<FieldWithValue> FieldsInOrder { get; } = new();
 
@@ -112,6 +117,8 @@ public abstract class CfgInstruction : CfgNode, ICfgInstruction {
             .SelectMany(i => i)
             .ToImmutableList();
     }
-
-// Equals and HashCode to use the discriminator and super methods
+    
+    public void SetLive(bool isLive) {
+        _isLive = isLive;
+    }
 }

--- a/src/Spice86.Core/Emulator/CPU/CfgCpu/ParsedInstruction/SelfModifying/DiscriminatedNode.cs
+++ b/src/Spice86.Core/Emulator/CPU/CfgCpu/ParsedInstruction/SelfModifying/DiscriminatedNode.cs
@@ -14,7 +14,7 @@ public class DiscriminatedNode : CfgNode {
     public DiscriminatedNode(SegmentedAddress address) : base(address) {
     }
 
-    public override bool IsAssembly => false;
+    public override bool IsLive => true;
 
     public Dictionary<Discriminator, CfgInstruction> SuccessorsPerDiscriminator { get; private set; } =
         new();


### PR DESCRIPTION
### Description of Changes
Each cycle, the CFG CPU needs to know whether the next node it got from graph execution is really what is in memory.
This was done via a dictionary lookup.

With this change, all nodes have a field indicating whether it is "live" or not. Live means it is in memory for instructions.
The field is managed when instruction is moved out of current pool (self modifying code).

### Rationale behind Changes
This makes code a bit faster and will allow the UI to represent live nodes differently in the future.

### Suggested Testing Steps
Tested with dune and Krondor, noticed a slight performance increase.