### PR TITLE
Do not create breakpoints on fields that are already read from memory to detect self modifying code.

### DIFF
--- a/src/Spice86.Core/Emulator/CPU/CfgCpu/ParsedInstruction/FieldWithValue.cs
+++ b/src/Spice86.Core/Emulator/CPU/CfgCpu/ParsedInstruction/FieldWithValue.cs
@@ -8,6 +8,11 @@ public abstract class FieldWithValue : Discriminator {
     }
 
     /// <summary>
+    /// Physical address of the field in memory
+    /// </summary>
+    public uint PhysicalAddress { get; init; }
+    
+    /// <summary>
     /// When true value can be used for execution.
     /// When false the value has to be retrieved from the memory location of the field because field value is modified by code.
     /// </summary>

--- a/src/Spice86.Core/Emulator/CPU/CfgCpu/ParsedInstruction/InstructionField.cs
+++ b/src/Spice86.Core/Emulator/CPU/CfgCpu/ParsedInstruction/InstructionField.cs
@@ -25,11 +25,6 @@ public class InstructionField<T> : FieldWithValue {
     }
 
     /// <summary>
-    /// Physical address of the field in memory
-    /// </summary>
-    public uint PhysicalAddress { get; }
-
-    /// <summary>
     /// Value of the field at creation time. Meaningless if UseValue is false.
     /// Differs to discriminator for fields which do not represent something that changes CPU logic.
     /// For example in MOV AX, 1234:


### PR DESCRIPTION
### Description of Changes
Instruction fields are usually read directly from instruction parsing, but if self modifying code modifies a field, subsequent reads are done from memory.
This change ensures we don't detect writes into a fields that is already read from memory as self modifying code.

### Rationale behind Changes
Reduces the number of times an instruction is going to be re-created.

### Suggested Testing Steps
Works with krondor and dune