### PR TITLE
hotfix: Valdiation does not block fields updates. Plus: Memory addressable limit validation (limit is A20Gate.EndOfHighMemoryArea), MemoryEdit/MemoryEditAddress validation, simplified all CanExecute methods

### DIFF
--- a/src/Spice86.Core/Emulator/Memory/Memory.cs
+++ b/src/Spice86.Core/Emulator/Memory/Memory.cs
@@ -54,6 +54,7 @@ public sealed class Memory : Indexable.Indexable, IMemory {
         if (length == 0) {
             length = (uint)_memoryDevices.Length;
         }
+        length = Math.Min(length, (uint)_memoryDevices.Length - offset);
         byte[] copy = new byte[length];
         for (uint address = 0; address < copy.Length; address++) {
             copy[address] = _memoryDevices[address + offset].Read(address + offset);
@@ -63,7 +64,8 @@ public sealed class Memory : Indexable.Indexable, IMemory {
     
     /// <inheritdoc />
     public void WriteRam(byte[] array, uint offset = 0) {
-        for (uint address = 0; address < array.Length; address++) {
+        var length = Math.Min(array.Length, (uint)_memoryDevices.Length - offset);
+        for (uint address = 0; address < length; address++) {
             _memoryDevices[address + offset].Write(address + offset, array[address]);
         }
     }

--- a/src/Spice86/ViewModels/BreakpointsViewModel.cs
+++ b/src/Spice86/ViewModels/BreakpointsViewModel.cs
@@ -306,11 +306,11 @@ public partial class BreakpointsViewModel : ViewModelBase {
 
     private bool ConfirmBreakpointCreationCanExecute() {
         if (IsInterruptBreakpointSelected) {
-            return _validationErrors.ContainsKey(nameof(InterruptNumber));
+            return !_validationErrors.ContainsKey(nameof(InterruptNumber));
         } else if (IsIoPortBreakpointSelected) {
-            return _validationErrors.ContainsKey(nameof(IoPortNumber));
+            return !_validationErrors.ContainsKey(nameof(IoPortNumber));
         } else if (IsCyclesBreakpointSelected) {
-            return _validationErrors.ContainsKey(nameof(CyclesValue));
+            return !_validationErrors.ContainsKey(nameof(CyclesValue));
         } else if (IsMemoryBreakpointSelected) {
             return
                 !_validationErrors.ContainsKey(nameof(MemoryBreakpointStartAddress)) &&

--- a/src/Spice86/ViewModels/BreakpointsViewModel.cs
+++ b/src/Spice86/ViewModels/BreakpointsViewModel.cs
@@ -306,17 +306,17 @@ public partial class BreakpointsViewModel : ViewModelBase {
 
     private bool ConfirmBreakpointCreationCanExecute() {
         if (IsInterruptBreakpointSelected) {
-            return !_validationErrors.ContainsKey(nameof(InterruptNumber));
+            return !ScanForValidationErrors(nameof(InterruptNumber));
         } else if (IsIoPortBreakpointSelected) {
-            return !_validationErrors.ContainsKey(nameof(IoPortNumber));
+            return !ScanForValidationErrors(nameof(IoPortNumber));
         } else if (IsCyclesBreakpointSelected) {
-            return !_validationErrors.ContainsKey(nameof(CyclesValue));
+            return !ScanForValidationErrors(nameof(CyclesValue));
         } else if (IsMemoryBreakpointSelected) {
             return
-                !_validationErrors.ContainsKey(nameof(MemoryBreakpointStartAddress)) &&
-                !_validationErrors.ContainsKey(nameof(MemoryBreakpointEndAddress));
+                !ScanForValidationErrors(nameof(MemoryBreakpointStartAddress)) &&
+                !ScanForValidationErrors(nameof(MemoryBreakpointEndAddress));
         } else if (IsExecutionBreakpointSelected) {
-            return !_validationErrors.ContainsKey(nameof(ExecutionAddressValue));
+            return !ScanForValidationErrors(nameof(ExecutionAddressValue));
         }
         return false;
     }

--- a/src/Spice86/ViewModels/BreakpointsViewModel.cs
+++ b/src/Spice86/ViewModels/BreakpointsViewModel.cs
@@ -141,10 +141,9 @@ public partial class BreakpointsViewModel : ViewModelBase {
     public long? CyclesValue {
         get => _cyclesValue;
         set {
-            if (TryValidateRequiredPropertyIsNotNull(value, out long? validatedValue) &&
-                SetProperty(ref _cyclesValue, validatedValue.Value)) {
-                ConfirmBreakpointCreationCommand.NotifyCanExecuteChanged();
-            }
+            ValidateRequiredPropertyIsNotNull(value);
+            SetProperty(ref _cyclesValue, value);
+            ConfirmBreakpointCreationCommand.NotifyCanExecuteChanged();
         }
     }
 
@@ -153,10 +152,9 @@ public partial class BreakpointsViewModel : ViewModelBase {
     public string? ExecutionAddressValue {
         get => _executionAddressValue;
         set {
-            if (ValidateAddressProperty(value, _state) &&
-                SetProperty(ref _executionAddressValue, value)) {
-                ConfirmBreakpointCreationCommand.NotifyCanExecuteChanged();
-            }
+            ValidateAddressProperty(value, _state);
+            SetProperty(ref _executionAddressValue, value);
+            ConfirmBreakpointCreationCommand.NotifyCanExecuteChanged();
         }
     }
 
@@ -165,10 +163,9 @@ public partial class BreakpointsViewModel : ViewModelBase {
     public string? MemoryBreakpointStartAddress {
         get => _memoryBreakpointStartAddress;
         set {
-            if (ValidateAddressProperty(value, _state) &&
-                SetProperty(ref _memoryBreakpointStartAddress, value)) {
-                ConfirmBreakpointCreationCommand.NotifyCanExecuteChanged();
-            }
+            ValidateAddressProperty(value, _state);
+            SetProperty(ref _memoryBreakpointStartAddress, value);
+            ConfirmBreakpointCreationCommand.NotifyCanExecuteChanged();
         }
     }
 
@@ -188,10 +185,9 @@ public partial class BreakpointsViewModel : ViewModelBase {
     public ushort? IoPortNumber {
         get => _ioPortNumber;
         set {
-            if (TryValidateRequiredPropertyIsNotNull(value, out ushort? validatedValue) &&
-                SetProperty(ref _ioPortNumber, validatedValue.Value)) {
-                ConfirmBreakpointCreationCommand.NotifyCanExecuteChanged();
-            }
+            ValidateRequiredPropertyIsNotNull(value);
+            SetProperty(ref _ioPortNumber, value);
+            ConfirmBreakpointCreationCommand.NotifyCanExecuteChanged();
         }
     }
 
@@ -200,10 +196,9 @@ public partial class BreakpointsViewModel : ViewModelBase {
     public int? InterruptNumber {
         get => _interruptNumber;
         set {
-            if (TryValidateRequiredPropertyIsNotNull(value, out int? validatedValue) &&
-                SetProperty(ref _interruptNumber, validatedValue.Value)) {
-                ConfirmBreakpointCreationCommand.NotifyCanExecuteChanged();
-            }
+            ValidateRequiredPropertyIsNotNull(value);
+            SetProperty(ref _interruptNumber, value);
+            ConfirmBreakpointCreationCommand.NotifyCanExecuteChanged();
         }
     }
 

--- a/src/Spice86/ViewModels/DisassemblyViewModel.cs
+++ b/src/Spice86/ViewModels/DisassemblyViewModel.cs
@@ -126,10 +126,9 @@ public partial class DisassemblyViewModel : ViewModelWithErrorDialog {
     public string? BreakpointAddress {
         get => _breakpointAddress;
         set {
-            if (ValidateAddressProperty(value, _state) &&
-                SetProperty(ref _breakpointAddress, value)) {
-                ConfirmCreateExecutionBreakpointCommand.NotifyCanExecuteChanged();
-            }
+            ValidateAddressProperty(value, _state);
+            SetProperty(ref _breakpointAddress, value);
+            ConfirmCreateExecutionBreakpointCommand.NotifyCanExecuteChanged();
         }
     }
 
@@ -179,10 +178,9 @@ public partial class DisassemblyViewModel : ViewModelWithErrorDialog {
     public string? StartAddress {
         get => _startAddress;
         set {
-            if (ValidateAddressProperty(value, _state) &&
-                SetProperty(ref _startAddress, value)) {
-                UpdateDisassemblyCommand.NotifyCanExecuteChanged();
-            }
+            ValidateAddressProperty(value, _state);
+            SetProperty(ref _startAddress, value);
+            UpdateDisassemblyCommand.NotifyCanExecuteChanged();
         }
     }
 
@@ -285,7 +283,7 @@ public partial class DisassemblyViewModel : ViewModelWithErrorDialog {
         SelectedInstruction = Instructions.FirstOrDefault();
     }
 
-    private bool CanExecuteUpdateDisassembly() {
+    private bool UpdateDisassemblyCommandCanExecute() {
         return IsPaused &&
             TryParseAddressString(StartAddress, _state, out uint? _);
     }
@@ -293,7 +291,7 @@ public partial class DisassemblyViewModel : ViewModelWithErrorDialog {
     [ObservableProperty]
     private bool _isLoading;
 
-    [RelayCommand(CanExecute = nameof(CanExecuteUpdateDisassembly))]
+    [RelayCommand(CanExecute = nameof(UpdateDisassemblyCommandCanExecute))]
     private async Task UpdateDisassembly() {
         if (!TryParseAddressString(StartAddress, _state, out uint? startAddress)) {
             return;

--- a/src/Spice86/ViewModels/DisassemblyViewModel.cs
+++ b/src/Spice86/ViewModels/DisassemblyViewModel.cs
@@ -159,7 +159,7 @@ public partial class DisassemblyViewModel : ViewModelWithErrorDialog {
 
     private bool ConfirmCreateExecutionBreakpointCanExecute() {
         return CreatingExecutionBreakpoint &&
-            !_validationErrors.ContainsKey(nameof(BreakpointAddress));
+            !ScanForValidationErrors(nameof(BreakpointAddress));
     }
 
     private void UpdateAssemblyLineIfShown(BreakpointViewModel breakpointViewModel) {
@@ -287,7 +287,7 @@ public partial class DisassemblyViewModel : ViewModelWithErrorDialog {
 
     private bool UpdateDisassemblyCommandCanExecute() {
         return IsPaused &&
-            !_validationErrors.ContainsKey(nameof(StartAddress));
+            !ScanForValidationErrors(nameof(StartAddress));
     }
 
     [ObservableProperty]

--- a/src/Spice86/ViewModels/DisassemblyViewModel.cs
+++ b/src/Spice86/ViewModels/DisassemblyViewModel.cs
@@ -127,6 +127,7 @@ public partial class DisassemblyViewModel : ViewModelWithErrorDialog {
         get => _breakpointAddress;
         set {
             ValidateAddressProperty(value, _state);
+            ValidateMemoryAddressIsWithinLimit(_state, value, A20Gate.EndOfHighMemoryArea);
             SetProperty(ref _breakpointAddress, value);
             ConfirmCreateExecutionBreakpointCommand.NotifyCanExecuteChanged();
         }
@@ -158,7 +159,7 @@ public partial class DisassemblyViewModel : ViewModelWithErrorDialog {
 
     private bool ConfirmCreateExecutionBreakpointCanExecute() {
         return CreatingExecutionBreakpoint &&
-            TryParseAddressString(BreakpointAddress, _state, out uint? _);
+            !_validationErrors.ContainsKey(nameof(BreakpointAddress));
     }
 
     private void UpdateAssemblyLineIfShown(BreakpointViewModel breakpointViewModel) {
@@ -179,6 +180,7 @@ public partial class DisassemblyViewModel : ViewModelWithErrorDialog {
         get => _startAddress;
         set {
             ValidateAddressProperty(value, _state);
+            ValidateMemoryAddressIsWithinLimit(_state, value, A20Gate.EndOfHighMemoryArea);
             SetProperty(ref _startAddress, value);
             UpdateDisassemblyCommand.NotifyCanExecuteChanged();
         }
@@ -285,7 +287,7 @@ public partial class DisassemblyViewModel : ViewModelWithErrorDialog {
 
     private bool UpdateDisassemblyCommandCanExecute() {
         return IsPaused &&
-            TryParseAddressString(StartAddress, _state, out uint? _);
+            !_validationErrors.ContainsKey(nameof(StartAddress));
     }
 
     [ObservableProperty]

--- a/src/Spice86/ViewModels/MainWindowViewModel.cs
+++ b/src/Spice86/ViewModels/MainWindowViewModel.cs
@@ -259,8 +259,8 @@ public sealed partial class MainWindowViewModel : ViewModelWithErrorDialog, IGui
     public double? TimeMultiplier {
         get => _timeMultiplier;
         set {
-            ValidateRequiredPropertyIsNotNull(value);
             _validationErrors.Clear();
+            ValidateRequiredPropertyIsNotNull(value);
             SetProperty(ref _timeMultiplier, value);
             if (value is not null) {
                 _pit?.SetTimeMultiplier(value.Value);

--- a/src/Spice86/ViewModels/MainWindowViewModel.cs
+++ b/src/Spice86/ViewModels/MainWindowViewModel.cs
@@ -143,9 +143,8 @@ public sealed partial class MainWindowViewModel : ViewModelWithErrorDialog, IGui
     public double? Scale {
         get => _scale;
         set {
-            if(TryValidateRequiredPropertyIsNotNull(value, out double? validatedValue)) {
-                SetProperty(ref _scale, Math.Max(validatedValue.Value, 1));
-            }
+            ValidateRequiredPropertyIsNotNull(value);
+            SetProperty(ref _scale, Math.Max(value ?? 0, 1));
         }
     }
 
@@ -260,10 +259,11 @@ public sealed partial class MainWindowViewModel : ViewModelWithErrorDialog, IGui
     public double? TimeMultiplier {
         get => _timeMultiplier;
         set {
-            if (TryValidateRequiredPropertyIsNotNull(value, out double? validatedValue)) {
-                _validationErrors.Clear();
-                SetProperty(ref _timeMultiplier, validatedValue.Value);
-                _pit?.SetTimeMultiplier(validatedValue.Value);
+            ValidateRequiredPropertyIsNotNull(value);
+            _validationErrors.Clear();
+            SetProperty(ref _timeMultiplier, value);
+            if (value is not null) {
+                _pit?.SetTimeMultiplier(value.Value);
             }
         }
     }

--- a/src/Spice86/ViewModels/MemoryViewModel.cs
+++ b/src/Spice86/ViewModels/MemoryViewModel.cs
@@ -285,7 +285,7 @@ public partial class MemoryViewModel : ViewModelWithErrorDialog {
     [NotifyCanExecuteChangedFor(nameof(GoToFoundOccurenceCommand))]
     private bool _isAddressOfFoundOccurrenceValid;
 
-    [RelayCommand(CanExecute = nameof(IsPaused), FlowExceptionsToTaskScheduler = false, IncludeCancelCommand = true)]
+    [RelayCommand(CanExecute = nameof(IsPaused), FlowExceptionsToTaskScheduler = true, IncludeCancelCommand = true)]
     private async Task SearchMemory(CancellationToken token) {
         if (string.IsNullOrWhiteSpace(MemorySearchValue) || token.IsCancellationRequested) {
             return;

--- a/src/Spice86/ViewModels/MemoryViewModel.cs
+++ b/src/Spice86/ViewModels/MemoryViewModel.cs
@@ -115,16 +115,14 @@ public partial class MemoryViewModel : ViewModelWithErrorDialog {
     public string? StartAddress {
         get => _startAddress;
         set {
-            if (ValidateAddressRange(_state,value, EndAddress,
-                nameof(StartAddress))) {
-                IsMemoryRangeValid = true;
-                if (SetProperty(ref _startAddress, value)) {
-                    TryUpdateHeaderAndMemoryDocument();
-                }
-            } else {
-                IsMemoryRangeValid = false;
-                DataMemoryDocument = null;
+            ValidateAddressRange(_state, value, EndAddress,
+                nameof(StartAddress));
+            IsMemoryRangeValid = true;
+            if (SetProperty(ref _startAddress, value)) {
+                TryUpdateHeaderAndMemoryDocument();
             }
+            IsMemoryRangeValid = false;
+            DataMemoryDocument = null;
         }
     }
 
@@ -186,10 +184,9 @@ public partial class MemoryViewModel : ViewModelWithErrorDialog {
     public string? MemoryBreakpointStartAddress {
         get => _memoryBreakpointStartAddress;
         set {
-            if (ValidateAddressProperty(value, _state) &&
-                SetProperty(ref _memoryBreakpointStartAddress, value)) {
-                ConfirmCreateMemoryBreakpointCommand.NotifyCanExecuteChanged();
-            }
+            ValidateAddressProperty(value, _state);
+            SetProperty(ref _memoryBreakpointStartAddress, value);
+            ConfirmCreateMemoryBreakpointCommand.NotifyCanExecuteChanged();
         }
     }
 
@@ -211,9 +208,9 @@ public partial class MemoryViewModel : ViewModelWithErrorDialog {
     private void ConfirmCreateMemoryBreakpoint() {
         if (TryParseAddressString(MemoryBreakpointStartAddress, _state, out uint? breakpointRangeStartAddress) &&
             TryParseAddressString(MemoryBreakpointEndAddress, _state, out uint? breakpointRangeEndAddress)) {
-                _breakpointsViewModel.CreateMemoryBreakpointRangeAtAddresses(
-                    breakpointRangeStartAddress.Value,
-                    breakpointRangeEndAddress.Value);
+            _breakpointsViewModel.CreateMemoryBreakpointRangeAtAddresses(
+                breakpointRangeStartAddress.Value,
+                breakpointRangeEndAddress.Value);
         } else if (breakpointRangeStartAddress != null) {
             _breakpointsViewModel.CreateMemoryBreakpointAtAddress(breakpointRangeStartAddress.Value);
         }
@@ -449,9 +446,8 @@ public partial class MemoryViewModel : ViewModelWithErrorDialog {
     public string? MemoryEditAddress {
         get => _memoryEditAddress;
         set {
-            if (ValidateAddressProperty(value, _state)) {
-                SetProperty(ref _memoryEditAddress, value);
-            }
+            ValidateAddressProperty(value, _state);
+            SetProperty(ref _memoryEditAddress, value);
         }
     }
 

--- a/src/Spice86/ViewModels/MemoryViewModel.cs
+++ b/src/Spice86/ViewModels/MemoryViewModel.cs
@@ -470,12 +470,16 @@ public partial class MemoryViewModel : ViewModelWithErrorDialog {
               CultureInfo.InvariantCulture, out long _)) {
             error = "Hex number could not be parsed";
         }
+        else {
+            return;
+        }
         if (!_validationErrors.TryGetValue(nameof(MemoryEditValue), out List<string>? values)) {
             _validationErrors.Add(nameof(MemoryEditValue), [error]);
         } else {
             values.Clear();
             values.Add(error);
         }
+        OnErrorsChanged(nameof(MemoryEditValue));
     }
 
     [RelayCommand(CanExecute = nameof(IsPaused))]

--- a/src/Spice86/ViewModels/MemoryViewModel.cs
+++ b/src/Spice86/ViewModels/MemoryViewModel.cs
@@ -98,8 +98,8 @@ public partial class MemoryViewModel : ViewModelWithErrorDialog {
     private string? _startAddress = "0x0";
 
     private bool UpdateBinaryDocumentCanExecute() {
-        return !_validationErrors.ContainsKey(nameof(StartAddress)) &&
-            !_validationErrors.ContainsKey(nameof(EndAddress));
+        return !ScanForValidationErrors(nameof(StartAddress)) &&
+            !ScanForValidationErrors(nameof(EndAddress));
     }
 
     [ObservableProperty]
@@ -196,8 +196,8 @@ public partial class MemoryViewModel : ViewModelWithErrorDialog {
 
     private bool ConfirmCreateMemoryBreakpointCanExecute() {
         return
-            !_validationErrors.ContainsKey(nameof(MemoryBreakpointStartAddress)) &&
-            !_validationErrors.ContainsKey(nameof(MemoryBreakpointEndAddress));
+            !ScanForValidationErrors(nameof(MemoryBreakpointStartAddress)) &&
+            !ScanForValidationErrors(nameof(MemoryBreakpointEndAddress));
     }
 
 

--- a/src/Spice86/ViewModels/MemoryViewModel.cs
+++ b/src/Spice86/ViewModels/MemoryViewModel.cs
@@ -512,7 +512,7 @@ public partial class MemoryViewModel : ViewModelWithErrorDialog {
     private void CancelMemoryEdit() => IsEditingMemory = false;
 
     private bool ApplyMemoryEditCanExecute() {
-        return ScanForValidationErrors(nameof(MemoryEditValue),
+        return !ScanForValidationErrors(nameof(MemoryEditValue),
             nameof(MemoryEditAddress)) &&
             IsPaused;
     }

--- a/src/Spice86/ViewModels/MemoryViewModel.cs
+++ b/src/Spice86/ViewModels/MemoryViewModel.cs
@@ -1,7 +1,5 @@
 ﻿namespace Spice86.ViewModels;
 
-using Avalonia.Threading;
-
 using AvaloniaHex.Document;
 using AvaloniaHex.Editing;
 
@@ -428,7 +426,7 @@ public partial class MemoryViewModel : ViewModelWithErrorDialog {
     }
 
     private void OnMemoryReadInvalidOperation(Exception exception) {
-        Dispatcher.UIThread.Post(() => ShowError(exception));
+        _uiDispatcher.Post(() => ShowError(exception));
     }
 
     [RelayCommand]

--- a/src/Spice86/ViewModels/MemoryViewModel.cs
+++ b/src/Spice86/ViewModels/MemoryViewModel.cs
@@ -467,8 +467,7 @@ public partial class MemoryViewModel : ViewModelWithErrorDialog {
         } else if(!value.StartsWith("0x")) {
             error = "Hex must start with 0x";
         } else if (value.Length > 2 &&
-            !long.TryParse(value[2..], NumberStyles.HexNumber,
-              CultureInfo.InvariantCulture, out long _)) {
+            !ConvertUtils.TryParseHexToByteArray(value[2..], out byte[]? _)) {
             error = "Hex number could not be parsed";
         }
         if (!_validationErrors.TryGetValue(nameof(MemoryEditValue), out List<string>? values)) {
@@ -526,14 +525,14 @@ public partial class MemoryViewModel : ViewModelWithErrorDialog {
         }
         if (!TryParseAddressString(MemoryEditAddress, _state, out uint? address) ||
             !GetIsMemoryRangeValid(address, A20Gate.EndOfHighMemoryArea) ||
-            !long.TryParse(memoryEditValue, NumberStyles.HexNumber,
-            CultureInfo.InvariantCulture, out long value)) {
+            !ConvertUtils.TryParseHexToByteArray(memoryEditValue, out byte[]? bytes)) {
             return;
         }
         try {
-            DataMemoryDocument?.WriteBytes(address.Value, BitConverter.GetBytes(value));
+
+            DataMemoryDocument?.WriteBytes(address.Value, bytes);
             TryUpdateHeaderAndMemoryDocument();
-        } catch (IndexOutOfRangeException e) {
+        } catch (Exception e) {
             ShowError(e);
             MemoryEditValue = null;
             MemoryEditAddress = null;

--- a/src/Spice86/ViewModels/MemoryViewModel.cs
+++ b/src/Spice86/ViewModels/MemoryViewModel.cs
@@ -115,17 +115,16 @@ public partial class MemoryViewModel : ViewModelWithErrorDialog {
             ValidateAddressRange(_state, value, EndAddress,
                 nameof(StartAddress));
             ValidateMemoryAddressIsWithinLimit(_state, value);
-            if (SetProperty(ref _startAddress, value)) {
-                UpdateBinaryDocumentCommand.NotifyCanExecuteChanged();
-                TryUpdateHeaderAndMemoryDocument();
-            }
+            SetProperty(ref _startAddress, value);
+            UpdateBinaryDocumentCommand.NotifyCanExecuteChanged();
+            TryUpdateHeaderAndMemoryDocument();
         }
     }
 
     private void TryUpdateHeaderAndMemoryDocument() {
-        Header = $"{StartAddress:X} - {EndAddress:X}";
         if (UpdateBinaryDocumentCommand.CanExecute(null)) {
             UpdateBinaryDocumentCommand.Execute(null);
+            Header = $"{StartAddress:X} - {EndAddress:X}";
         }
     }
 
@@ -137,10 +136,9 @@ public partial class MemoryViewModel : ViewModelWithErrorDialog {
             ValidateAddressRange(_state, StartAddress, value,
                 nameof(EndAddress));
             ValidateMemoryAddressIsWithinLimit(_state, value);
-            if (SetProperty(ref _endAddress, value)) {
-                UpdateBinaryDocumentCommand.NotifyCanExecuteChanged();
-                TryUpdateHeaderAndMemoryDocument();
-            }
+            SetProperty(ref _endAddress, value);
+            UpdateBinaryDocumentCommand.NotifyCanExecuteChanged();
+            TryUpdateHeaderAndMemoryDocument();
         }
     }
 

--- a/src/Spice86/ViewModels/MemoryViewModel.cs
+++ b/src/Spice86/ViewModels/MemoryViewModel.cs
@@ -9,8 +9,6 @@ using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 using CommunityToolkit.Mvvm.Messaging;
 
-using Newtonsoft.Json;
-
 using Spice86.Core.Emulator.CPU;
 using Spice86.Core.Emulator.Function.Dump;
 using Spice86.Core.Emulator.Memory;

--- a/src/Spice86/ViewModels/StructureViewModel.cs
+++ b/src/Spice86/ViewModels/StructureViewModel.cs
@@ -39,10 +39,9 @@ public partial class StructureViewModel : ViewModelBase, IDisposable {
     public string? MemoryAddress {
         get => _memoryAddress;
         set {
-            if(ValidateAddressProperty(value, _state)) {
-                SetProperty(ref _memoryAddress, value);
-                OnMemoryAddressChanged(value);
-            }
+            ValidateAddressProperty(value, _state);
+            SetProperty(ref _memoryAddress, value);
+            OnMemoryAddressChanged(value);
         }
     }
 

--- a/src/Spice86/ViewModels/ViewModelBase.cs
+++ b/src/Spice86/ViewModels/ViewModelBase.cs
@@ -93,15 +93,14 @@ public abstract partial class ViewModelBase : ObservableObject, INotifyDataError
             out List<string>? values)) {
                 values = new List<string>();
                 _validationErrors[nameof(textBoxBindedPropertyName)] = values;
+            } else {
+                values.Clear();
             }
-            values.Clear();
             if (!rangeStatus) {
                 values.Add(RangeError);
-            }
-            if (!statusStart) {
+            } else if (!statusStart) {
                 values.Add(StartError);
-            }
-            if (!statusEnd) {
+            } else if (!statusEnd) {
                 values.Add(EndError);
             }
             OnErrorsChanged(textBoxBindedPropertyName);
@@ -163,11 +162,11 @@ public abstract partial class ViewModelBase : ObservableObject, INotifyDataError
         if (!status) {
             if (!_validationErrors.TryGetValue(propertyName,
                 out List<string>? values)) {
-                values = new List<string>();
-                _validationErrors[propertyName] = values;
+                _validationErrors[propertyName] = [error];
+            } else {
+                values.Clear();
+                values.Add(error);
             }
-            values.Clear();
-            values.Add(error);
         } else {
             _validationErrors.Remove(propertyName);
         }

--- a/src/Spice86/ViewModels/ViewModelBase.cs
+++ b/src/Spice86/ViewModels/ViewModelBase.cs
@@ -99,22 +99,22 @@ public abstract partial class ViewModelBase : ObservableObject, INotifyDataError
                 rangeStatus = GetIsMemoryRangeValid(start, end);
             }
         }
-            if (!_validationErrors.TryGetValue(textBoxBindedPropertyName,
-            out List<string>? values)) {
-                values = new List<string>();
-                _validationErrors[textBoxBindedPropertyName] = values;
-            } else {
-                values.Clear();
-            }
-            if (!rangeStatus) {
-                values.Add(RangeError);
-            } else if (!statusStart) {
-                values.Add(StartError);
-            } else if (!statusEnd) {
-                values.Add(EndError);
-            }
-            OnErrorsChanged(textBoxBindedPropertyName);
+        if (!_validationErrors.TryGetValue(textBoxBindedPropertyName,
+        out List<string>? values)) {
+            values = new List<string>();
+            _validationErrors[textBoxBindedPropertyName] = values;
+        } else {
+            values.Clear();
         }
+        if (!rangeStatus) {
+            values.Add(RangeError);
+        } else if (!statusStart) {
+            values.Add(StartError);
+        } else if (!statusEnd) {
+            values.Add(EndError);
+        }
+        OnErrorsChanged(textBoxBindedPropertyName);
+    }
 
     private static bool TryParseSegmentOrRegister(string value, State state,
             [NotNullWhen(true)] out ushort? @ushort) {

--- a/src/Spice86/ViewModels/ViewModelBase.cs
+++ b/src/Spice86/ViewModels/ViewModelBase.cs
@@ -35,19 +35,20 @@ public abstract partial class ViewModelBase : ObservableObject, INotifyDataError
 
     protected void ValidateMemoryAddressIsWithinLimit(State state, string? value,
         uint limit = A20Gate.EndOfHighMemoryArea,
-        [CallerMemberName] string? bindedTextBoxPropertyName = null) {
+        [CallerMemberName] string? bindedPropertyName = null) {
         ArgumentNullException.ThrowIfNullOrWhiteSpace(
-            bindedTextBoxPropertyName);
+            bindedPropertyName);
         if (TryParseAddressString(value, state, out uint? address) &&
             !GetIsMemoryRangeValid(address, limit)) {
-            if (!_validationErrors.TryGetValue(bindedTextBoxPropertyName,
+            if (!_validationErrors.TryGetValue(bindedPropertyName,
                 out List<string>? values)) {
                 values = new List<string>();
-                _validationErrors[bindedTextBoxPropertyName] = values;
+                _validationErrors[bindedPropertyName] = values;
             }
             values.Clear();
             values.Add("Value is beyond addressable range");
         }
+        OnErrorsChanged(bindedPropertyName);
     }
 
     protected void ValidateRequiredPropertyIsNotNull<T>(T? value,

--- a/src/Spice86/ViewModels/ViewModelBase.cs
+++ b/src/Spice86/ViewModels/ViewModelBase.cs
@@ -57,8 +57,9 @@ public abstract partial class ViewModelBase : ObservableObject, INotifyDataError
             return;
         }
         if (value is not null ||
-            value is string stringValue && !string.IsNullOrWhiteSpace(
-                stringValue)) {
+            (value is string stringValue && !string.IsNullOrWhiteSpace(
+                stringValue))) {
+            return;
         }
         if (!_validationErrors.TryGetValue(bindedPropertyName, out List<string>? values)) {
             _validationErrors.Add(bindedPropertyName, ["This field is required."]);

--- a/src/Spice86/ViewModels/ViewModelBase.cs
+++ b/src/Spice86/ViewModels/ViewModelBase.cs
@@ -99,7 +99,6 @@ public abstract partial class ViewModelBase : ObservableObject, INotifyDataError
                 rangeStatus = GetIsMemoryRangeValid(start, end);
             }
         }
-        if (!rangeStatus || !statusStart || !statusEnd) {
             if (!_validationErrors.TryGetValue(textBoxBindedPropertyName,
             out List<string>? values)) {
                 values = new List<string>();
@@ -116,7 +115,6 @@ public abstract partial class ViewModelBase : ObservableObject, INotifyDataError
             }
             OnErrorsChanged(textBoxBindedPropertyName);
         }
-    }
 
     private static bool TryParseSegmentOrRegister(string value, State state,
             [NotNullWhen(true)] out ushort? @ushort) {

--- a/src/Spice86/ViewModels/ViewModelBase.cs
+++ b/src/Spice86/ViewModels/ViewModelBase.cs
@@ -75,6 +75,16 @@ public abstract partial class ViewModelBase : ObservableObject, INotifyDataError
         && endAddress >= startAddress;
     }
 
+    protected bool ScanForValidationErrors(params string[] properties) {
+        foreach (string property in properties) {
+            _validationErrors.TryGetValue(property, out List<string>? values);
+            if (values?.Count > 0) {
+                return true;
+            }
+        }
+        return false;
+    }
+
     protected void ValidateAddressRange(State state, string? startAddress,
         string? endAddress, string textBoxBindedPropertyName) {
         const string RangeError = "Invalid address range.";
@@ -93,7 +103,7 @@ public abstract partial class ViewModelBase : ObservableObject, INotifyDataError
             if (!_validationErrors.TryGetValue(textBoxBindedPropertyName,
             out List<string>? values)) {
                 values = new List<string>();
-                _validationErrors[nameof(textBoxBindedPropertyName)] = values;
+                _validationErrors[textBoxBindedPropertyName] = values;
             } else {
                 values.Clear();
             }

--- a/src/Spice86/Views/MemoryView.axaml.cs
+++ b/src/Spice86/Views/MemoryView.axaml.cs
@@ -1,6 +1,7 @@
 namespace Spice86.Views;
 
 using Avalonia.Controls;
+using Avalonia.Input;
 
 using AvaloniaHex;
 
@@ -12,6 +13,15 @@ public partial class MemoryView : UserControl {
         // Subscribe to the DataContextChanged event to ensure that the ViewModel's event handler
         // is connected to the HexEditor's Selection.RangeChanged event after the DataContext is set.
         DataContextChanged += OnDataContextChanged;
+
+        this.HexViewer.DoubleTapped += OnHexViewerDoubleTapped;
+    }
+
+    private void OnHexViewerDoubleTapped(object? sender, TappedEventArgs e) {
+        if(DataContext is MemoryViewModel viewModel &&
+            viewModel.EditMemoryCommand.CanExecute(null)) {
+            viewModel.EditMemoryCommand.Execute(null);
+        }
     }
 
     /// <summary>


### PR DESCRIPTION
### PR Summary

This pull request refactors property setters in all ViewModel classes dealing with input validation in order to avoid out of sync behavior between ViewModel bindings and textboxes values.

INotifyDataErrorInfo is supposed only to notify of errors, not block fields updates.

Plus, it contains the following validation enhancments, and related fixes:

- MemoryEditAddress and MemoryEditValue are validated now
- The memory edit command has a can execute
- IsMemoryRangeValid property is gone, replaced by a proper CanExecute
- All CanExecutes use _validationsErrors dictionary every time it makes sense to do so
- We validate the memory addresses to see if they are also addressable (ie. not beyond the end of the high memory area)
- FlowExceptionToTaskScheduler is set to True in the async relay command, so if an exception happens we can manage it instead of crashing. This crash should not happen.
- Memory class was fixed in ReadRam and WriteRam to avoid OutOfRangeException (tested in the memory view by going at and writing values at 0x10FFEA, which is close to 0x10FFEF, the end of the HMA).
- MemoryEdit feature wasn't very usable and is now fixed.