### PR TITLE
Rename discriminated node to selector node which is a better name.

### DIFF
--- a/src/Spice86.Core/Emulator/CPU/CfgCpu/Linker/NodeLinker.cs
+++ b/src/Spice86.Core/Emulator/CPU/CfgCpu/Linker/NodeLinker.cs
@@ -34,8 +34,8 @@ public class NodeLinker : InstructionReplacer {
             case CfgInstruction currentCfgInstruction:
                 LinkCfgInstructionWithType(InstructionSuccessorType.Normal, currentCfgInstruction, next);
                 break;
-            case DiscriminatedNode discriminatedNode:
-                LinkDiscriminatedNode(discriminatedNode, next);
+            case SelectorNode selectorNode:
+                LinkSelectorNode(selectorNode, next);
                 break;
         }
     }
@@ -101,7 +101,7 @@ public class NodeLinker : InstructionReplacer {
         return InstructionSuccessorType.CallToReturn;
     }
 
-    private void LinkDiscriminatedNode(DiscriminatedNode current, ICfgNode next) {
+    private void LinkSelectorNode(SelectorNode current, ICfgNode next) {
         if (next is CfgInstruction nextCfgInstruction) {
             Dictionary<Discriminator, CfgInstruction> successors = current.SuccessorsPerDiscriminator;
             if (!successors.TryGetValue(nextCfgInstruction.Discriminator, out CfgInstruction? shouldBeNextOrNull)) {
@@ -110,10 +110,10 @@ public class NodeLinker : InstructionReplacer {
                 return;
             }
             if (!ReferenceEquals(shouldBeNextOrNull, next)) {
-                throw new UnhandledCfgDiscrepancyException("Next instruction's discriminator is present in the discriminated node successors, but the corresponding successor is not next instruction which should never happen.");
+                throw new UnhandledCfgDiscrepancyException("Next instruction's discriminator is present in the selector node successors, but the corresponding successor is not next instruction which should never happen.");
             }
         } else {
-            throw new UnhandledCfgDiscrepancyException("Trying to attach a non ASM instruction to a discriminated node which is not allowed. This should never happen.");
+            throw new UnhandledCfgDiscrepancyException("Trying to attach a non ASM instruction to a selector node which is not allowed. This should never happen.");
         }
     }
     

--- a/src/Spice86.Core/Emulator/CPU/CfgCpu/ParsedInstruction/SelfModifying/SelectorNode.cs
+++ b/src/Spice86.Core/Emulator/CPU/CfgCpu/ParsedInstruction/SelfModifying/SelectorNode.cs
@@ -12,10 +12,7 @@ using System.Linq;
 /// Node that precedes self modifying code divergence point.
 /// To decide what is next node in the graph, the only way is to compare discriminators in SuccessorsPerDiscriminator with actual memory content. 
 /// </summary>
-public class DiscriminatedNode : CfgNode {
-    public DiscriminatedNode(SegmentedAddress address) : base(address) {
-    }
-
+public class SelectorNode(SegmentedAddress address) : CfgNode(address) {
     public override bool IsLive => true;
 
     public Dictionary<Discriminator, CfgInstruction> SuccessorsPerDiscriminator { get; private set; } =

--- a/src/Spice86/ViewModels/CfgCpuViewModel.cs
+++ b/src/Spice86/ViewModels/CfgCpuViewModel.cs
@@ -9,9 +9,7 @@ using CommunityToolkit.Mvvm.Input;
 
 using Spice86.Core.CLI;
 using Spice86.Core.Emulator.CPU.CfgCpu;
-using Spice86.Core.Emulator.CPU.CfgCpu.Ast.Builder;
 using Spice86.Core.Emulator.CPU.CfgCpu.ControlFlowGraph;
-using Spice86.Core.Emulator.CPU.CfgCpu.InstructionRenderer;
 using Spice86.Core.Emulator.CPU.CfgCpu.ParsedInstruction;
 using Spice86.Core.Emulator.CPU.CfgCpu.ParsedInstruction.SelfModifying;
 using Spice86.Core.Emulator.VM;
@@ -23,8 +21,7 @@ using System.Diagnostics;
 public partial class CfgCpuViewModel : ViewModelBase {
     private readonly IPerformanceMeasurer _performanceMeasurer;
     private readonly ExecutionContextManager _executionContextManager;
-    private readonly AstBuilder _astBuilder = new();
-    private readonly AstInstructionRenderer _astInstructionRenderer = new();
+    private readonly NodeToString _nodeToString = new();
 
     [ObservableProperty] private int _maxNodesToDisplay = 200;
 
@@ -131,8 +128,8 @@ public partial class CfgCpuViewModel : ViewModelBase {
 
                 break;
             }
-            case DiscriminatedNode discriminatedNode: {
-                Discriminator discriminator = discriminatedNode.SuccessorsPerDiscriminator
+            case SelectorNode selectorNode: {
+                Discriminator discriminator = selectorNode.SuccessorsPerDiscriminator
                     .FirstOrDefault(x => x.Value == successor).Key;
                 label = discriminator.ToString();
                 break;
@@ -145,10 +142,5 @@ public partial class CfgCpuViewModel : ViewModelBase {
     private static (int, int) GenerateEdgeKey(ICfgNode node, ICfgNode successor)
         => (node.Id, successor.Id);
 
-    private string GenerateNodeText(ICfgNode node) =>
-        $"{node.Address} / {node.Id} {Environment.NewLine} {CfgNodeToAssemblyString(node)}";
-
-    private string CfgNodeToAssemblyString(ICfgNode node) {
-        return _astInstructionRenderer.VisitInstructionNode(node.ToInstructionAst(_astBuilder));
-    }
+    private string GenerateNodeText(ICfgNode node) => $"{_nodeToString.ToHeaderString(node)}{Environment.NewLine}{_nodeToString.ToAssemblyString(node)}";
 }

--- a/tests/Spice86.Tests/CfgGraphDumper.cs
+++ b/tests/Spice86.Tests/CfgGraphDumper.cs
@@ -1,7 +1,6 @@
 ﻿namespace Spice86.Tests;
 
 using Spice86.Core.Emulator.CPU.CfgCpu.Ast.Builder;
-using Spice86.Core.Emulator.CPU.CfgCpu.Ast.Instruction;
 using Spice86.Core.Emulator.CPU.CfgCpu.ControlFlowGraph;
 using Spice86.Core.Emulator.CPU.CfgCpu.InstructionRenderer;
 using Spice86.Core.Emulator.CPU.CfgCpu.ParsedInstruction;
@@ -9,14 +8,14 @@ using Spice86.Core.Emulator.VM;
 using Spice86.Shared.Emulator.Memory;
 
 public class CfgGraphDumper {
+    private readonly NodeToString _nodeToString = new();
     public List<string> ToAssemblyListing(Machine machine) {
         List<ICfgNode> nodes = DumpInOrder(machine);
-        AstBuilder astBuilder = new();
-        AstInstructionRenderer renderer = new();
+        
         List<string> res = new();
         foreach (ICfgNode node in nodes) {
             string address = node.Address.ToString();
-            string instruction = renderer.VisitInstructionNode(node.ToInstructionAst(astBuilder));
+            string instruction = _nodeToString.ToAssemblyString(node);
             res.Add($"{address} {instruction}");
         }
         return res;


### PR DESCRIPTION
### Description of Changes
Discriminated was a bad name, selector reflect better what it does
Also factorized code that transform node to string