### PR TITLE
Int1A - SystemClock - Fix incorrectly assigned call numbers

### DIFF
--- a/src/Spice86.Core/Emulator/InterruptHandlers/SystemClock/SystemClockInt1AHandler.cs
+++ b/src/Spice86.Core/Emulator/InterruptHandlers/SystemClock/SystemClockInt1AHandler.cs
@@ -25,8 +25,8 @@ public class SystemClockInt1AHandler : InterruptHandler {
     public SystemClockInt1AHandler(IMemory memory, IFunctionHandlerProvider functionHandlerProvider, Stack stack, State state, ILoggerService loggerService, TimerInt8Handler timerHandler)
         : base(memory, functionHandlerProvider, stack, state, loggerService) {
         _timerHandler = timerHandler;
-        AddAction(0x00, SetSystemClockCounter);
-        AddAction(0x01, GetSystemClockCounter);
+		AddAction(0x00, GetSystemClockCounter);
+        AddAction(0x01, SetSystemClockCounter); 
         AddAction(0x81, TandySoundSystemUnhandled);
         AddAction(0x82, TandySoundSystemUnhandled);
         AddAction(0x83, TandySoundSystemUnhandled);


### PR DESCRIPTION
### Description of Changes

SystemClockInt1AHandler (INT 1A) has switched Get and Set calls.
This PR simply changes 0 <-> 1 to assign proper handlers to calls.

### Rationale behind Changes

https://stanislavs.org/helppc/int_1a.html

* `INT 1A` `AH=0`: Read system clock counter
* `INT 1A` `AH=1`:  Set system clock counter

### Suggested Testing Steps

I tested it on game Warlords.

Before the fix, it got stuck in the loading phase, printing "SET SYSTEM CLOCK COUNTER" in logs but in the debugger, I clearly see AH=0 for `INT 0x1A` syscall.

After the fix, I got into the main screen:

<img width="1136" alt="image" src="https://github.com/user-attachments/assets/b22a335f-2514-4760-bf33-6a1806bc9df5" />

