### PR TITLE
feature: Implement the XADD instruction

### DIFF
--- a/src/Spice86.Core/Emulator/CPU/CPU.cs
+++ b/src/Spice86.Core/Emulator/CPU/CPU.cs
@@ -1,4 +1,4 @@
-﻿namespace Spice86.Core.Emulator.CPU;
+namespace Spice86.Core.Emulator.CPU;
 
 using Serilog.Events;
 
@@ -322,6 +322,15 @@ public class Cpu : IInstructionExecutor, IFunctionHandlerProvider {
             case 0xBF:
                 // MOVSX r32, r/m16
                 _instructions32.Movsx();
+                break;
+            case 0xC0:
+                // XADD r/m8, r8
+                _instructions8.XaddRm();
+                break;
+            case 0xC1:
+                // XADD r/m16, r16
+                // XADD r/m32, r32
+                _instructions16Or32.XaddRm();
                 break;
             default:
                 HandleInvalidOpcode((ushort)(subcode | 0x0F00));

--- a/src/Spice86.Core/Emulator/CPU/CfgCpu/Ast/Instruction/InstructionOperation.cs
+++ b/src/Spice86.Core/Emulator/CPU/CfgCpu/Ast/Instruction/InstructionOperation.cs
@@ -1,4 +1,4 @@
-﻿namespace Spice86.Core.Emulator.CPU.CfgCpu.Ast.Instruction;
+namespace Spice86.Core.Emulator.CPU.CfgCpu.Ast.Instruction;
 
 public enum InstructionOperation {
     AAA,
@@ -148,6 +148,7 @@ public enum InstructionOperation {
     STOS,
     SUB,
     TEST,
+    XADD,
     XCHG,
     XLAT,
     XOR

--- a/src/Spice86.Core/Emulator/CPU/CfgCpu/ParsedInstruction/Instructions/Mixins/XaddRm.mixin
+++ b/src/Spice86.Core/Emulator/CPU/CfgCpu/ParsedInstruction/Instructions/Mixins/XaddRm.mixin
@@ -1,0 +1,33 @@
+@moxy
+@attribute required int Size
+@moxy
+
+namespace {{ moxy.Class.Namespace }};
+
+using Spice86.Core.Emulator.CPU.CfgCpu.Ast.Builder;
+using Spice86.Core.Emulator.CPU.CfgCpu.Ast.Instruction;
+using Spice86.Core.Emulator.CPU.CfgCpu.InstructionExecutor;
+using Spice86.Core.Emulator.CPU.CfgCpu.ParsedInstruction.ModRm;
+using Spice86.Core.Emulator.CPU.CfgCpu.ParsedInstruction.Prefix;
+using Spice86.Shared.Emulator.Memory;
+
+public partial class {{ moxy.Class.Name }} : InstructionWithModRm {
+
+    public {{ moxy.Class.Name }}(SegmentedAddress address, InstructionField<ushort> opcodeField, List<InstructionPrefix> prefixes, ModRmContext modRmContext) : base(address, opcodeField, prefixes, modRmContext) {
+    }
+
+    public override void Execute(InstructionExecutionHelper helper) {
+        helper.ModRm.RefreshWithNewModRmContext(ModRmContext);
+        var sum = helper.Alu{{Size}}.Add(helper.ModRm.R{{Size}}, helper.ModRm.RM{{Size}});
+        helper.ModRm.R{{Size}} = helper.ModRm.RM{{Size}};
+        helper.ModRm.RM{{Size}} = sum;
+        helper.MoveIpAndSetNextNode(this);
+    }
+
+    public override InstructionNode ToInstructionAst(AstBuilder builder) {
+        return new InstructionNode(InstructionOperation.XADD,
+            builder.ModRm.RmToNode(builder.UType({{Size}}), ModRmContext),
+            builder.ModRm.RToNode(builder.UType({{Size}}), ModRmContext)
+        );
+    }
+}

--- a/src/Spice86.Core/Emulator/CPU/CfgCpu/ParsedInstruction/Instructions/XaddRm.cs
+++ b/src/Spice86.Core/Emulator/CPU/CfgCpu/ParsedInstruction/Instructions/XaddRm.cs
@@ -1,0 +1,8 @@
+namespace Spice86.Core.Emulator.CPU.CfgCpu.ParsedInstruction.Instructions;
+
+[XaddRm(8)]
+public partial class XaddRm8;
+[XaddRm(16)]
+public partial class XaddRm16;
+[XaddRm(32)]
+public partial class XaddRm32;

--- a/src/Spice86.Core/Emulator/CPU/CfgCpu/Parser/InstructionParser.cs
+++ b/src/Spice86.Core/Emulator/CPU/CfgCpu/Parser/InstructionParser.cs
@@ -77,6 +77,7 @@ public class InstructionParser : BaseInstructionParser {
     private readonly XchgRegAccParser _xchgRegAccParser;
     private readonly XchgRmParser _xchgRmParser;
     private readonly XorAluOperationParser _xorAluOperationParser;
+    private readonly XaddRmParser _xaddRmParser;
 
     public InstructionParser(IIndexable memory, State state) : base(new(memory), state) {
         _adcAluOperationParser = new(this);
@@ -144,6 +145,7 @@ public class InstructionParser : BaseInstructionParser {
         _xchgRegAccParser = new(this);
         _xchgRmParser = new(this);
         _xorAluOperationParser = new(this);
+        _xaddRmParser = new(this);
     }
 
     private InstructionField<ushort> ReadOpcode() {
@@ -662,6 +664,9 @@ public class InstructionParser : BaseInstructionParser {
             case 0x0FBF:
                 return new MovRmSignExtendWord32(context.Address, context.OpcodeField, context.Prefixes,
                     _modRmParser.ParseNext(context));
+            case 0x0FC0:
+            case 0x0FC1:
+                return _xaddRmParser.Parse(context);
             case 0xDBE3:
                 return new FnInit(context.Address, context.OpcodeField, context.Prefixes);
         }

--- a/src/Spice86.Core/Emulator/CPU/CfgCpu/Parser/SpecificParsers/OperationModRmParser.cs
+++ b/src/Spice86.Core/Emulator/CPU/CfgCpu/Parser/SpecificParsers/OperationModRmParser.cs
@@ -41,3 +41,5 @@ partial class ImulRmParser;
 partial class MovRmZeroExtendByteParser;
 [OperationModRmParser("MovRmSignExtendByte", false)]
 partial class MovRmSignExtendByteParser;
+[OperationModRmParser("XaddRm", true)]
+partial class XaddRmParser;

--- a/src/Spice86.Core/Emulator/CPU/InstructionsImpl/Instructions.cs
+++ b/src/Spice86.Core/Emulator/CPU/InstructionsImpl/Instructions.cs
@@ -134,6 +134,7 @@ public abstract class Instructions {
     public abstract void Ins();
     public abstract void Outs();
     public abstract void XchgRm();
+    public abstract void XaddRm();
 
     // Mov
     public abstract void MovRmReg();

--- a/src/Spice86.Core/Emulator/CPU/InstructionsImpl/Instructions16.cs
+++ b/src/Spice86.Core/Emulator/CPU/InstructionsImpl/Instructions16.cs
@@ -408,6 +408,15 @@ public class Instructions16 : Instructions16Or32 {
         ModRM.SetRm16(value2);
     }
 
+    public override void XaddRm() {
+        // XADD rmw rw
+        ModRM.Read();
+        ushort dest = ModRM.GetRm16();
+        ushort src = ModRM.R16;
+        ModRM.R16 = dest;
+        ModRM.SetRm16(_alu16.Add(src, dest));
+    }
+
     public override void XchgAcc(int regIndex) {
         // XCHG AX regIndex
         (State.AX, UInt16Registers[regIndex]) = (UInt16Registers[regIndex], State.AX);

--- a/src/Spice86.Core/Emulator/CPU/InstructionsImpl/Instructions32.cs
+++ b/src/Spice86.Core/Emulator/CPU/InstructionsImpl/Instructions32.cs
@@ -402,6 +402,15 @@ public class Instructions32 : Instructions16Or32 {
         ModRM.SetRm32(value2);
     }
 
+    public override void XaddRm() {
+        // XADD rmdw rdw
+        ModRM.Read();
+        uint dest = ModRM.GetRm32();
+        uint src = ModRM.R32;
+        ModRM.R32 = dest;
+        ModRM.SetRm32(_alu32.Add(src, dest));
+    }
+
     public override void XchgAcc(int regIndex) {
         // XCHG EAX regIndex
         (State.EAX, UInt32Registers[regIndex]) = (UInt32Registers[regIndex], State.EAX);

--- a/src/Spice86.Core/Emulator/CPU/InstructionsImpl/Instructions8.cs
+++ b/src/Spice86.Core/Emulator/CPU/InstructionsImpl/Instructions8.cs
@@ -432,6 +432,15 @@ public class Instructions8 : Instructions {
         ModRM.SetRm8(value2);
     }
 
+    public override void XaddRm() {
+        // XADD rmb rb
+        ModRM.Read();
+        byte dest = ModRM.GetRm8();
+        byte src = ModRM.R8;
+        ModRM.R8 = dest;
+        ModRM.SetRm8(_alu8.Add(src, dest));
+    }
+
     public override void MovRmReg() {
         // MOV rmb rb
         ModRM.Read();


### PR DESCRIPTION
### Description of Changes

This PR adds support for the instructions `XADD r/m,r8` and `XADD r/m,r16/32` (opcodes `0F C0 /r` and `0F C1 /r`), which was introduced first for 486.

### Rationale behind Changes

I was trying to run a little game that was compiled with Borland Pascal 6.0, but the CPU class threw an exception somewhere in the code. There was a single instance of `xadd edx, edx` in the executable.

This patch has let me advance further, although not without problems, but that's outside the scope of this PR.

### Suggested Testing Steps

I am not sure how this code behaves with the `LOCK` prefix, but I don't know any real-life program that could be used to test that. However, here is the archive with that game:
[banana-quest.zip](https://github.com/user-attachments/files/20991411/banana-quest.zip)