### PR TITLE
Feature/opl3 filters (Dune and Krondor FM Synth music sound better)

### DIFF
--- a/src/Spice86.Core/Emulator/Devices/Sound/Ymf262Emu/FmSynthesizer.cs
+++ b/src/Spice86.Core/Emulator/Devices/Sound/Ymf262Emu/FmSynthesizer.cs
@@ -2,6 +2,7 @@
 
 using Spice86.Core.Emulator.Devices.Sound.Ymf262Emu.Channels;
 using Spice86.Core.Emulator.Devices.Sound.Ymf262Emu.Operators;
+using Spice86.Core.Backend.Audio.IirFilters;
 
 /// <summary>
 /// Emulates a YMF262 OPL3 device.
@@ -12,6 +13,7 @@ public sealed class FmSynthesizer {
     private readonly double _tremoloIncrement0;
     private readonly double _tremoloIncrement1;
     private readonly int _tremoloTableLength;
+    private readonly LowPass _lowPassFilter;
 
     internal readonly int[] Registers = new int[0x200];
     internal readonly HighHat? HighHatOperator;
@@ -58,6 +60,10 @@ public sealed class FmSynthesizer {
         _tremoloTableLength = (int)(sampleRate / TremoloFrequency);
         _tremoloIncrement0 = CalculateIncrement(TremoloDepth0, 0, 1 / (2 * TremoloFrequency));
         _tremoloIncrement1 = CalculateIncrement(TremoloDepth1, 0, 1 / (2 * TremoloFrequency));
+        
+        // Initialize the low-pass filter with cutoff at 8000 Hz
+        _lowPassFilter = new LowPass();
+        _lowPassFilter.Setup(sampleRate, 8000);
 
         InitializeOperators();
         InitializeChannels2Op();
@@ -83,16 +89,20 @@ public sealed class FmSynthesizer {
     /// <param name="buffer">Buffer to fill with 16-bit waveform data.</param>
     public void GetData(Span<short> buffer) {
         for (int i = 0; i < buffer.Length; i++) {
-            buffer[i] = (short)(GetNextSample() * 32767);
+            // Apply low-pass filter directly to the output
+            double sample = _lowPassFilter.Filter(GetNextSample());
+            buffer[i] = (short)(sample * 32767);
         }
     }
+    
     /// <summary>
     /// Fills <paramref name="buffer"/> with 32-bit mono samples.
     /// </summary>
     /// <param name="buffer">Buffer to fill with 32-bit waveform data.</param>
     public void GetData(Span<float> buffer) {
         for (int i = 0; i < buffer.Length; i++) {
-            buffer[i] = (float)GetNextSample();
+            // Apply low-pass filter directly to the output
+            buffer[i] = (float)_lowPassFilter.Filter(GetNextSample());
         }
     }
 
@@ -205,7 +215,7 @@ public sealed class FmSynthesizer {
     private double GetNextSample() {
         Span<double> channelOutput = stackalloc double[4];
 
-        Span<double> outputBuffer = stackalloc double[4] { 0, 0, 0, 0 };
+        Span<double> outputBuffer = [0, 0, 0, 0];
 
         // If IsOpl3Mode = 0, use OPL2 mode with 9 channels. If IsOpl3Mode = 1, use OPL3 18 channels;
         for (int array = 0; array < (IsOpl3Mode + 1); array++) {
@@ -448,21 +458,20 @@ public sealed class FmSynthesizer {
             _operators[0, 0x14] = SnareDrumOperator;
             _operators[0, 0x12] = TomTomOperator;
             _operators[0, 0x15] = TopCymbalOperator;
-        }
-        else {
+        } else {
             for (int i = 6; i <= 8; i++) {
                 _channels[0, i] = Channels2Op[0, i];
             }
-            if(_highHatOperatorInNonRhythmMode is not null) {
+            if (_highHatOperatorInNonRhythmMode is not null) {
                 _operators[0, 0x11] = _highHatOperatorInNonRhythmMode;
             }
-            if(_snareDrumOperatorInNonRhythmMode is not null) {
+            if (_snareDrumOperatorInNonRhythmMode is not null) {
                 _operators[0, 0x14] = _snareDrumOperatorInNonRhythmMode;
             }
-            if(_tomTomOperatorInNonRhythmMode is not null) {
+            if (_tomTomOperatorInNonRhythmMode is not null) {
                 _operators[0, 0x12] = _tomTomOperatorInNonRhythmMode;
             }
-            if(_topCymbalOperatorInNonRhythmMode is not null) {
+            if (_topCymbalOperatorInNonRhythmMode is not null) {
                 _operators[0, 0x15] = _topCymbalOperatorInNonRhythmMode;
             }
         }

--- a/src/Spice86.Core/Emulator/Devices/Sound/Ymf262Emu/OPL3FM.cs
+++ b/src/Spice86.Core/Emulator/Devices/Sound/Ymf262Emu/OPL3FM.cs
@@ -16,7 +16,7 @@ public class OPL3FM : DefaultIOPortHandler, IDisposable {
     private const byte Timer2Mask = 0xA0;
 
     private readonly SoundChannel _soundChannel;
-    private readonly FmSynthesizer? _synth;
+    private readonly FmSynthesizer _synth;
     private int _currentAddress;
     private readonly DeviceThread _deviceThread;
     private byte _statusByte;
@@ -141,7 +141,7 @@ public class OPL3FM : DefaultIOPortHandler, IDisposable {
     }
 
     private void FillBuffer(Span<float> buffer, Span<float> playBuffer) {
-        _synth?.GetData(buffer);
+        _synth.GetData(buffer);
         ChannelAdapter.MonoToStereo(buffer, playBuffer);
     }
 }


### PR DESCRIPTION
A small PR to use a low pass filter on the Sound Blaster FM Synth music output. Config taken from DOSBox Staging source code.

Uses a hardcoded SB PRo 2 configuration for now: the cut off freq is 8000 Hz.

Tested with Dune and Krondor.

For better performance, it also removes a loop from Mono to Stereo processing. The sample are directly stereo, and directly processed by the low pass filter.