### PR TITLE
fix: performance measurement was degrading performance

### DIFF
--- a/src/Spice86.Core/Emulator/VM/EmulationLoop.cs
+++ b/src/Spice86.Core/Emulator/VM/EmulationLoop.cs
@@ -28,6 +28,8 @@ public class EmulationLoop {
     private readonly Stopwatch _stopwatch;
     private readonly DmaController _dmaController;
 
+    public IPerformanceMeasureReader CpuPerformanceMeasurer => _performanceMeasurer;
+
     /// <summary>
     /// Whether the emulation is paused.
     /// </summary>

--- a/src/Spice86.Shared/Diagnostics/PerformanceMeasurer.cs
+++ b/src/Spice86.Shared/Diagnostics/PerformanceMeasurer.cs
@@ -3,7 +3,7 @@ namespace Spice86.Shared.Diagnostics;
 using Spice86.Shared.Interfaces;
 
 /// <inheritdoc />
-public class PerformanceMeasurer : IPerformanceMeasurer {
+public class PerformanceMeasurer : IPerformanceMeasureReader, IPerformanceMeasureWriter {
     private long _measure;
     private long _lastTimeInMilliseconds;
     private long _sampledMetricsCount;
@@ -45,7 +45,8 @@ public class PerformanceMeasurer : IPerformanceMeasurer {
         long valueDelta = newMeasure - _measure;
         _measure = newMeasure;
         ValuePerMillisecond = valueDelta / millisecondsDelta;
-        AverageValuePerSecond = ApproxRollingAverage(AverageValuePerSecond, ValuePerSecond, _sampledMetricsCount++);
+        AverageValuePerSecond = ApproxRollingAverage(AverageValuePerSecond, 
+            ValuePerSecond, _sampledMetricsCount++);
     }
 
     private bool IsFirstMeasurement() {

--- a/src/Spice86.Shared/Interfaces/IPerformanceMeasurer.cs
+++ b/src/Spice86.Shared/Interfaces/IPerformanceMeasurer.cs
@@ -3,7 +3,7 @@ namespace Spice86.Shared.Interfaces;
 /// <summary>
 /// Measures a performance metric.
 /// </summary>
-public interface IPerformanceMeasurer {
+public interface IPerformanceMeasureReader {
     /// <summary>
     /// Gets the performance measurement value per millisecond.
     /// </summary>
@@ -18,7 +18,9 @@ public interface IPerformanceMeasurer {
     /// Gets the performance measurement value per second (average).
     /// </summary>
     long AverageValuePerSecond { get; }
+}
 
+public interface IPerformanceMeasureWriter {
     /// <summary>
     /// Updates performance measurements with a new value.
     /// </summary>

--- a/src/Spice86/Spice86DependencyInjection.cs
+++ b/src/Spice86/Spice86DependencyInjection.cs
@@ -293,6 +293,11 @@ public class Spice86DependencyInjection : IDisposable {
             loggerService.Information("Emulator state serializer created...");
         }
 
+        EmulationLoop emulationLoop = new EmulationLoop(_loggerService,
+            functionHandler, instructionExecutor,
+            state, timer, emulatorBreakpointsManager, dmaController,
+            pauseHandler);
+
         MainWindowViewModel? mainWindowViewModel = null;
         UIDispatcher? uiDispatcher = null;
         HostStorageProvider? hostStorageProvider = null;
@@ -305,7 +310,7 @@ public class Spice86DependencyInjection : IDisposable {
             textClipboard = new TextClipboard(mainWindow.Clipboard);
 
             PerformanceViewModel performanceViewModel = new(
-                state, pauseHandler, uiDispatcher);
+                state, pauseHandler, uiDispatcher, emulationLoop.CpuPerformanceMeasurer);
 
             mainWindow.PerformanceViewModel = performanceViewModel;
 
@@ -358,12 +363,6 @@ public class Spice86DependencyInjection : IDisposable {
         if (loggerService.IsEnabled(LogEventLevel.Information)) {
             loggerService.Information("Sound devices created...");
         }
-
-        EmulationLoop emulationLoop = new EmulationLoop(_loggerService,
-            functionHandler, instructionExecutor,
-            state, timer, emulatorBreakpointsManager,
-            dmaController,
-            pauseHandler);
 
         if (loggerService.IsEnabled(LogEventLevel.Information)) {
             loggerService.Information("Emulation loop created...");
@@ -504,7 +503,7 @@ public class Spice86DependencyInjection : IDisposable {
             MidiViewModel midiViewModel = new(midiDevice);
 
             CfgCpuViewModel cfgCpuViewModel = new(configuration, cfgCpu.ExecutionContextManager,
-                pauseHandler, new PerformanceMeasurer());
+                pauseHandler);
 
             StructureViewModelFactory structureViewModelFactory = new(configuration,
                 state, loggerService, pauseHandler);

--- a/src/Spice86/ViewModels/CfgCpuViewModel.cs
+++ b/src/Spice86/ViewModels/CfgCpuViewModel.cs
@@ -13,14 +13,14 @@ using Spice86.Core.Emulator.CPU.CfgCpu.ControlFlowGraph;
 using Spice86.Core.Emulator.CPU.CfgCpu.ParsedInstruction;
 using Spice86.Core.Emulator.CPU.CfgCpu.ParsedInstruction.SelfModifying;
 using Spice86.Core.Emulator.VM;
+using Spice86.Shared.Diagnostics;
 using Spice86.Shared.Emulator.Memory;
-using Spice86.Shared.Interfaces;
 
 using System.Diagnostics;
 
 public partial class CfgCpuViewModel : ViewModelBase {
-    private readonly IPerformanceMeasurer _performanceMeasurer;
     private readonly ExecutionContextManager _executionContextManager;
+    private readonly PerformanceMeasurer _performanceMeasurer;
     private readonly NodeToString _nodeToString = new();
 
     [ObservableProperty] private int _maxNodesToDisplay = 200;
@@ -33,10 +33,9 @@ public partial class CfgCpuViewModel : ViewModelBase {
 
     [ObservableProperty] private bool _isCfgCpuEnabled;
 
-    public CfgCpuViewModel(Configuration configuration, ExecutionContextManager executionContextManager, IPauseHandler pauseHandler,
-        IPerformanceMeasurer performanceMeasurer) {
+    public CfgCpuViewModel(Configuration configuration, ExecutionContextManager executionContextManager, IPauseHandler pauseHandler) {
         _executionContextManager = executionContextManager;
-        _performanceMeasurer = performanceMeasurer;
+        _performanceMeasurer = new PerformanceMeasurer();
         IsCfgCpuEnabled = configuration.CfgCpu;
 
         pauseHandler.Paused += () => UpdateGraphCommand.Execute(null);


### PR DESCRIPTION
### Description of Changes

Fixes Lost Eden voices being unbearable to the ears.

### Rationale behind Changes

performance measurement was degrading performance

Details:

- Updated `EmulationLoop` to expose `CpuPerformanceMeasurer` and share it that way in dependency injection step with the PerformanceViewModel constructor.
- Split `IPerformanceMeasurer` into `IPerformanceMeasureReader` and `IPerformanceMeasureWriter`for better interface segragation.
- Updated `PerformanceViewModel` to use `IPerformanceMeasureReader` and accept a `cpuPerfReader` parameter.
- Removed `performanceMeasurer` parameter from `CfgCpuViewModel` constructor. It creates an instance internally, because this instance measures internal performance of the class.
- Improved code formatting in `PerformanceMeasurer` to respect 80 columns limit.

### Suggested Testing Steps

Already tested with Lost Eden and Dune and Krondor.