### PR TITLE
1200 - Fix for writing the same character multiple times

### DIFF
--- a/src/Spice86.Core/Emulator/InterruptHandlers/VGA/VgaFunctionality.cs
+++ b/src/Spice86.Core/Emulator/InterruptHandlers/VGA/VgaFunctionality.cs
@@ -125,7 +125,7 @@ public class VgaFunctionality : IVgaFunctionality {
     public void WriteCharacterAtCursor(CharacterPlusAttribute character, byte page, int count = 1) {
         CursorPosition cursorPosition = GetCursorPosition(page);
         while (count-- > 0) {
-            WriteCharacter(cursorPosition, character);
+            cursorPosition = WriteCharacter(cursorPosition, character);
         }
     }
 


### PR DESCRIPTION
### Description of Changes
When writing a batch of the same character multiple times, the character is now written seq4euantilly instead of all at the same position.

### Rationale behind Changes
Fixes #1200 and other programs that use the text functionality of writing a character _n_ times.

### Suggested Testing Steps
- Fire up Dune II's SETUP.EXE
- try any other text-mode program
