### PR TITLE
Add date/time related interrupt handlers

### DIFF
--- a/src/Spice86.Core/Emulator/InterruptHandlers/Dos/DosInt21Handler.cs
+++ b/src/Spice86.Core/Emulator/InterruptHandlers/Dos/DosInt21Handler.cs
@@ -35,6 +35,7 @@ public class DosInt21Handler : InterruptHandler {
 
     private byte _lastDisplayOutputCharacter = 0x0;
     private bool _isCtrlCFlag;
+    private readonly Clock _clock;
 
     /// <summary>
     /// Initializes a new instance.
@@ -54,7 +55,7 @@ public class DosInt21Handler : InterruptHandler {
         IFunctionHandlerProvider functionHandlerProvider, Stack stack, State state,
         KeyboardInt16Handler keyboardInt16Handler, CountryInfo countryInfo,
         DosStringDecoder dosStringDecoder, DosMemoryManager dosMemoryManager,
-        DosFileManager dosFileManager, DosDriveManager dosDriveManager, ILoggerService loggerService)
+        DosFileManager dosFileManager, DosDriveManager dosDriveManager, Clock clock, ILoggerService loggerService)
             : base(memory, functionHandlerProvider, stack, state, loggerService) {
         _countryInfo = countryInfo;
         _dosStringDecoder = dosStringDecoder;
@@ -63,6 +64,7 @@ public class DosInt21Handler : InterruptHandler {
         _dosFileManager = dosFileManager;
         _dosDriveManager = dosDriveManager;
         _interruptVectorTable = new InterruptVectorTable(memory);
+        _clock = clock;
         FillDispatchTable();
     }
 
@@ -85,8 +87,10 @@ public class DosInt21Handler : InterruptHandler {
         AddAction(0x1A, SetDiskTransferAddress);
         AddAction(0x1B, GetAllocationInfoForDefaultDrive);
         AddAction(0x1C, GetAllocationInfoForAnyDrive);
+        AddAction(0x2D, SetTime);
         AddAction(0x25, SetInterruptVector);
         AddAction(0x2A, GetDate);
+        AddAction(0x2B, SetDate);
         AddAction(0x2C, GetTime);
         AddAction(0x2F, GetDiskTransferAddress);
         AddAction(0x30, GetDosVersion);
@@ -121,6 +125,35 @@ public class DosInt21Handler : InterruptHandler {
         AddAction(0x51, GetPspAddress);
         AddAction(0x62, GetPspAddress);
         AddAction(0x63, GetLeadByteTable);
+    }
+
+    public void SetDate() {
+        if (LoggerService.IsEnabled(LogEventLevel.Verbose)) {
+            LoggerService.Verbose("SET DATE");
+        }
+        
+        ushort year = State.CX;
+        byte month = State.DH;
+        byte day = State.DL;
+        
+        if (!_clock.SetDate(year, month, day)) {
+            State.AL = 0xFF; // Invalid date
+        }
+    }
+
+    public void SetTime() {
+        if (LoggerService.IsEnabled(LogEventLevel.Verbose)) {
+            LoggerService.Verbose("SET TIME");
+        }
+        
+        byte hours = State.CH;
+        byte minutes = State.CL;
+        byte seconds = State.DH;
+        byte hundredths = State.DL;
+        
+        if (!_clock.SetTime(hours, minutes, seconds, hundredths)) {
+            State.AL = 0xFF; // Invalid time
+        }
     }
 
     /// <summary>
@@ -681,11 +714,11 @@ public class DosInt21Handler : InterruptHandler {
         if (LoggerService.IsEnabled(LogEventLevel.Verbose)) {
             LoggerService.Verbose("GET DATE");
         }
-        DateTime now = DateTime.Now;
-        State.AL = (byte)now.DayOfWeek;
-        State.CX = (ushort)now.Year;
-        State.DH = (byte)now.Month;
-        State.DL = (byte)now.Day;
+        (ushort year, byte month, byte day, byte dayOfWeek) = _clock.GetDate();
+        State.AL = dayOfWeek;
+        State.CX = year;
+        State.DH = month;
+        State.DL = day;
     }
 
     /// <summary>
@@ -830,11 +863,11 @@ public class DosInt21Handler : InterruptHandler {
         if (LoggerService.IsEnabled(LogEventLevel.Verbose)) {
             LoggerService.Verbose("GET TIME");
         }
-        DateTime now = DateTime.Now;
-        State.CH = (byte)now.Hour;
-        State.CL = (byte)now.Minute;
-        State.DH = (byte)now.Second;
-        State.DL = (byte)now.Millisecond;
+        (byte hours, byte minutes, byte seconds, byte hundredths) = _clock.GetTime();
+        State.CH = hours;
+        State.CL = minutes;
+        State.DH = seconds;
+        State.DL = hundredths;
     }
 
     /// <summary>

--- a/src/Spice86.Core/Emulator/InterruptHandlers/Dos/DosInt21Handler.cs
+++ b/src/Spice86.Core/Emulator/InterruptHandlers/Dos/DosInt21Handler.cs
@@ -131,11 +131,11 @@ public class DosInt21Handler : InterruptHandler {
         if (LoggerService.IsEnabled(LogEventLevel.Verbose)) {
             LoggerService.Verbose("SET DATE");
         }
-        
+
         ushort year = State.CX;
         byte month = State.DH;
         byte day = State.DL;
-        
+
         if (!_clock.SetDate(year, month, day)) {
             State.AL = 0xFF; // Invalid date
         }
@@ -145,12 +145,12 @@ public class DosInt21Handler : InterruptHandler {
         if (LoggerService.IsEnabled(LogEventLevel.Verbose)) {
             LoggerService.Verbose("SET TIME");
         }
-        
+
         byte hours = State.CH;
         byte minutes = State.CL;
         byte seconds = State.DH;
         byte hundredths = State.DL;
-        
+
         if (!_clock.SetTime(hours, minutes, seconds, hundredths)) {
             State.AL = 0xFF; // Invalid time
         }

--- a/src/Spice86.Core/Emulator/InterruptHandlers/SystemClock/SystemClockInt1AHandler.cs
+++ b/src/Spice86.Core/Emulator/InterruptHandlers/SystemClock/SystemClockInt1AHandler.cs
@@ -34,8 +34,8 @@ public class SystemClockInt1AHandler : InterruptHandler {
         _clock = clock;
         AddAction(0x00, GetSystemClockCounter);
         AddAction(0x01, SetSystemClockCounter);
-        AddAction(0x02, ReadTimeFromRTC); 
-        AddAction(0x03, SetRTCTime); 
+        AddAction(0x02, ReadTimeFromRTC);
+        AddAction(0x03, SetRTCTime);
         AddAction(0x04, ReadDateFromRTC);
         AddAction(0x05, SetRTCDate);
         AddAction(0x81, TandySoundSystemUnhandled);
@@ -51,35 +51,35 @@ public class SystemClockInt1AHandler : InterruptHandler {
         int hours = currentTime.Hour;
         int minutes = currentTime.Minute;
         int seconds = currentTime.Second;
-        
+
         State.CH = (byte)((hours / 10) << 4 | (hours % 10));
         State.CL = (byte)((minutes / 10) << 4 | (minutes % 10));
         State.DH = (byte)((seconds / 10) << 4 | (seconds % 10));
         State.DL = (byte)(TimeZoneInfo.Local.IsDaylightSavingTime(currentTime) ? 1 : 0);
-    
+
         // Clear carry flag to indicate success
         State.CarryFlag = false;
     }
-    
+
     public void SetRTCTime() {
         if (LoggerService.IsEnabled(LogEventLevel.Verbose)) {
             LoggerService.Verbose("SET RTC TIME");
         }
-        
+
         int hoursBcd = State.CH;
         int minutesBcd = State.CL;
         int secondsBcd = State.DH;
-    
+
         int hours = ((hoursBcd >> 4) * 10) + (hoursBcd & 0x0F);
         int minutes = ((minutesBcd >> 4) * 10) + (minutesBcd & 0x0F);
         int seconds = ((secondsBcd >> 4) * 10) + (secondsBcd & 0x0F);
-        
+
         State.CarryFlag = !_clock.SetTime((byte)hours, (byte)minutes, (byte)seconds, 0);
     }
-    
+
     public void ReadDateFromRTC() {
         (int y, int month, int day) = _clock.GetVirtualDateTime();
-        
+
         int century = y / 100;
         int year = y % 100;
 
@@ -87,26 +87,26 @@ public class SystemClockInt1AHandler : InterruptHandler {
         State.CL = (byte)((year / 10) << 4 | (year % 10));
         State.DH = (byte)((month / 10) << 4 | (month % 10));
         State.DL = (byte)((day / 10) << 4 | (day % 10));
-        
+
         // Clear carry flag to indicate success
         State.CarryFlag = false;
     }
-    
+
     public void SetRTCDate() {
         if (LoggerService.IsEnabled(LogEventLevel.Verbose)) {
             LoggerService.Verbose("SET RTC DATE");
         }
-        
+
         int centuryBcd = State.CH;
         int yearBcd = State.CL;
         int monthBcd = State.DH;
         int dayBcd = State.DL;
-        
+
         int century = ((centuryBcd >> 4) * 10) + (centuryBcd & 0x0F);
         int year = ((yearBcd >> 4) * 10) + (yearBcd & 0x0F);
         int month = ((monthBcd >> 4) * 10) + (monthBcd & 0x0F);
         int day = ((dayBcd >> 4) * 10) + (dayBcd & 0x0F);
-        
+
         int fullYear = (century * 100) + year;
 
         State.CarryFlag = !_clock.SetDate((byte)day, (byte)month, (byte)fullYear);

--- a/src/Spice86.Core/Emulator/InterruptHandlers/SystemClock/SystemClockInt1AHandler.cs
+++ b/src/Spice86.Core/Emulator/InterruptHandlers/SystemClock/SystemClockInt1AHandler.cs
@@ -1,10 +1,13 @@
 ﻿namespace Spice86.Core.Emulator.InterruptHandlers.SystemClock;
 
+using Serilog.Events;
+
 using Spice86.Core.Emulator.CPU;
 using Spice86.Core.Emulator.Function;
 using Spice86.Core.Emulator.InterruptHandlers;
 using Spice86.Core.Emulator.InterruptHandlers.Timer;
 using Spice86.Core.Emulator.Memory;
+using Spice86.Core.Emulator.OperatingSystem;
 using Spice86.Shared.Interfaces;
 
 /// <summary>
@@ -12,6 +15,7 @@ using Spice86.Shared.Interfaces;
 /// </summary>
 public class SystemClockInt1AHandler : InterruptHandler {
     private readonly TimerInt8Handler _timerHandler;
+    private readonly Clock _clock; //it's only a fake RTC, but good enough for the time being
 
     /// <summary>
     /// Initializes a new instance.
@@ -22,16 +26,90 @@ public class SystemClockInt1AHandler : InterruptHandler {
     /// <param name="state">The CPU state.</param>
     /// <param name="loggerService">The logger service implementation.</param>
     /// <param name="timerHandler">The timer interrupt handler.</param>
-    public SystemClockInt1AHandler(IMemory memory, IFunctionHandlerProvider functionHandlerProvider, Stack stack, State state, ILoggerService loggerService, TimerInt8Handler timerHandler)
+    /// <param name="clock"></param>
+    public SystemClockInt1AHandler(IMemory memory, IFunctionHandlerProvider functionHandlerProvider, Stack stack,
+        State state, ILoggerService loggerService, TimerInt8Handler timerHandler, Clock clock)
         : base(memory, functionHandlerProvider, stack, state, loggerService) {
         _timerHandler = timerHandler;
-		AddAction(0x00, GetSystemClockCounter);
-        AddAction(0x01, SetSystemClockCounter); 
+        _clock = clock;
+        AddAction(0x00, GetSystemClockCounter);
+        AddAction(0x01, SetSystemClockCounter);
+        AddAction(0x02, ReadTimeFromRTC); 
+        AddAction(0x03, SetRTCTime); 
+        AddAction(0x04, ReadDateFromRTC);
+        AddAction(0x05, SetRTCDate);
         AddAction(0x81, TandySoundSystemUnhandled);
         AddAction(0x82, TandySoundSystemUnhandled);
         AddAction(0x83, TandySoundSystemUnhandled);
         AddAction(0x84, TandySoundSystemUnhandled);
         AddAction(0x85, TandySoundSystemUnhandled);
+    }
+
+    public void ReadTimeFromRTC() {
+        DateTime currentTime = _clock.GetVirtualDateTime();
+
+        int hours = currentTime.Hour;
+        int minutes = currentTime.Minute;
+        int seconds = currentTime.Second;
+        
+        State.CH = (byte)((hours / 10) << 4 | (hours % 10));
+        State.CL = (byte)((minutes / 10) << 4 | (minutes % 10));
+        State.DH = (byte)((seconds / 10) << 4 | (seconds % 10));
+        State.DL = (byte)(TimeZoneInfo.Local.IsDaylightSavingTime(currentTime) ? 1 : 0);
+    
+        // Clear carry flag to indicate success
+        State.CarryFlag = false;
+    }
+    
+    public void SetRTCTime() {
+        if (LoggerService.IsEnabled(LogEventLevel.Verbose)) {
+            LoggerService.Verbose("SET RTC TIME");
+        }
+        
+        int hoursBcd = State.CH;
+        int minutesBcd = State.CL;
+        int secondsBcd = State.DH;
+    
+        int hours = ((hoursBcd >> 4) * 10) + (hoursBcd & 0x0F);
+        int minutes = ((minutesBcd >> 4) * 10) + (minutesBcd & 0x0F);
+        int seconds = ((secondsBcd >> 4) * 10) + (secondsBcd & 0x0F);
+        
+        State.CarryFlag = !_clock.SetTime((byte)hours, (byte)minutes, (byte)seconds, 0);
+    }
+    
+    public void ReadDateFromRTC() {
+        (int y, int month, int day) = _clock.GetVirtualDateTime();
+        
+        int century = y / 100;
+        int year = y % 100;
+
+        State.CH = (byte)((century / 10) << 4 | (century % 10));
+        State.CL = (byte)((year / 10) << 4 | (year % 10));
+        State.DH = (byte)((month / 10) << 4 | (month % 10));
+        State.DL = (byte)((day / 10) << 4 | (day % 10));
+        
+        // Clear carry flag to indicate success
+        State.CarryFlag = false;
+    }
+    
+    public void SetRTCDate() {
+        if (LoggerService.IsEnabled(LogEventLevel.Verbose)) {
+            LoggerService.Verbose("SET RTC DATE");
+        }
+        
+        int centuryBcd = State.CH;
+        int yearBcd = State.CL;
+        int monthBcd = State.DH;
+        int dayBcd = State.DL;
+        
+        int century = ((centuryBcd >> 4) * 10) + (centuryBcd & 0x0F);
+        int year = ((yearBcd >> 4) * 10) + (yearBcd & 0x0F);
+        int month = ((monthBcd >> 4) * 10) + (monthBcd & 0x0F);
+        int day = ((dayBcd >> 4) * 10) + (dayBcd & 0x0F);
+        
+        int fullYear = (century * 100) + year;
+
+        State.CarryFlag = !_clock.SetDate((byte)day, (byte)month, (byte)fullYear);
     }
 
     /// <inheritdoc />

--- a/src/Spice86.Core/Emulator/OperatingSystem/Clock.cs
+++ b/src/Spice86.Core/Emulator/OperatingSystem/Clock.cs
@@ -17,24 +17,23 @@ public class Clock(ILoggerService loggerService) {
     /// <param name="minutes">Minutes (0-59)</param>
     /// <param name="seconds">Seconds (0-59)</param>
     /// <param name="hundredths">Hundredths of a second (0-99)</param>
-    public bool SetTime(byte hours, byte minutes, byte seconds, byte hundredths)
-    {
+    public bool SetTime(byte hours, byte minutes, byte seconds, byte hundredths) {
         if (hours > 23 || minutes > 59 || seconds > 59 || hundredths > 99) {
             return false;
         }
-        
+
         TimeSpan virtualTime;
         try {
             virtualTime = new TimeSpan(0, hours, minutes, seconds, hundredths * 10);
-        }
-        catch (ArgumentOutOfRangeException)
-        {
+        } catch (ArgumentOutOfRangeException) {
             if (loggerService.IsEnabled(LogEventLevel.Warning)) {
-                loggerService.Warning("Invalid time (hours, minutes, seconds, hundredths): {}, {}, {}, {}", hours, minutes, seconds, hundredths);
+                loggerService.Warning("Invalid time (hours, minutes, seconds, hundredths): {}, {}, {}, {}", hours,
+                    minutes, seconds, hundredths);
             }
+
             return false;
         }
-        
+
         TimeSpan realTime = DateTime.Now.TimeOfDay;
         _timeOffset = virtualTime - realTime;
         _hasTimeOffset = true;
@@ -49,31 +48,28 @@ public class Clock(ILoggerService loggerService) {
     /// <summary>
     /// Sets the virtual date by computing the offset from the real date.
     /// </summary>
-    public bool SetDate(ushort year, byte month, byte day)
-    {
+    public bool SetDate(ushort year, byte month, byte day) {
         if (month > 12 || day > 31) {
             return false;
         }
-        
+
         DateTime virtualDate;
-        try
-        {
+        try {
             virtualDate = new DateTime(year, month, day);
-        }
-        catch (ArgumentOutOfRangeException)
-        {
+        } catch (ArgumentOutOfRangeException) {
             if (loggerService.IsEnabled(LogEventLevel.Warning)) {
                 loggerService.Warning("Invalid date (y-m-d): {}-{}-{}", year, month, day);
             }
+
             return false;
         }
-        
+
         DateTime realDate = DateTime.Now.Date;
         _dateOffset = virtualDate - realDate;
         _hasDateOffset = true;
-        
+
         if (loggerService.IsEnabled(LogEventLevel.Verbose)) {
-            loggerService.Verbose("Date changed to {O}", GetVirtualDateTime());   
+            loggerService.Verbose("Date changed to {O}", GetVirtualDateTime());
         }
 
         return true;
@@ -83,11 +79,10 @@ public class Clock(ILoggerService loggerService) {
     /// Gets the current virtual time, applying the offset if one has been set.
     /// </summary>
     /// <returns>A tuple containing (hours, minutes, seconds, hundredths)</returns>
-    public (byte hours, byte minutes, byte seconds, byte hundredths) GetTime()
-    {
+    public (byte hours, byte minutes, byte seconds, byte hundredths) GetTime() {
         DateTime currentTime = GetVirtualDateTime();
         TimeSpan timeOfDay = currentTime.TimeOfDay;
-        
+
         return (
             (byte)timeOfDay.Hours,
             (byte)timeOfDay.Minutes,
@@ -100,10 +95,9 @@ public class Clock(ILoggerService loggerService) {
     /// Gets the current virtual date, applying the offset if one has been set.
     /// </summary>
     /// <returns>A tuple containing (year, month, day, dayOfWeek)</returns>
-    public (ushort year, byte month, byte day, byte dayOfWeek) GetDate()
-    {
+    public (ushort year, byte month, byte day, byte dayOfWeek) GetDate() {
         DateTime currentDate = GetVirtualDateTime();
-        
+
         return (
             (ushort)currentDate.Year,
             (byte)currentDate.Month,
@@ -116,23 +110,20 @@ public class Clock(ILoggerService loggerService) {
     /// Gets the virtual DateTime by applying both date and time offsets to the current real time.
     /// </summary>
     /// <returns>The virtual DateTime</returns>
-    public DateTime GetVirtualDateTime()
-    {
+    public DateTime GetVirtualDateTime() {
         DateTime now = DateTime.Now;
         DateTime virtualDateTime = now;
-        
+
         // Apply date offset if set
-        if (_hasDateOffset)
-        {
+        if (_hasDateOffset) {
             virtualDateTime = virtualDateTime.Add(_dateOffset);
         }
-        
+
         // Apply time offset if set
-        if (_hasTimeOffset)
-        {
+        if (_hasTimeOffset) {
             virtualDateTime = virtualDateTime.Add(_timeOffset);
         }
-        
+
         return virtualDateTime;
     }
 

--- a/src/Spice86.Core/Emulator/OperatingSystem/Clock.cs
+++ b/src/Spice86.Core/Emulator/OperatingSystem/Clock.cs
@@ -29,7 +29,9 @@ public class Clock(ILoggerService loggerService) {
         }
         catch (ArgumentOutOfRangeException)
         {
-            loggerService.Warning("Invalid time (hours, minutes, seconds, hundredths): {}, {}, {}, {}", hours, minutes, seconds, hundredths);
+            if (loggerService.IsEnabled(LogEventLevel.Warning)) {
+                loggerService.Warning("Invalid time (hours, minutes, seconds, hundredths): {}, {}, {}, {}", hours, minutes, seconds, hundredths);
+            }
             return false;
         }
         
@@ -60,7 +62,9 @@ public class Clock(ILoggerService loggerService) {
         }
         catch (ArgumentOutOfRangeException)
         {
-            loggerService.Warning("Invalid date (y-m-d): {}-{}-{}", year, month, day);
+            if (loggerService.IsEnabled(LogEventLevel.Warning)) {
+                loggerService.Warning("Invalid date (y-m-d): {}-{}-{}", year, month, day);
+            }
             return false;
         }
         

--- a/src/Spice86.Core/Emulator/OperatingSystem/Clock.cs
+++ b/src/Spice86.Core/Emulator/OperatingSystem/Clock.cs
@@ -1,0 +1,139 @@
+﻿namespace Spice86.Core.Emulator.OperatingSystem;
+
+using Serilog.Events;
+
+using Spice86.Shared.Interfaces;
+
+public class Clock(ILoggerService loggerService) {
+    private TimeSpan _timeOffset = TimeSpan.Zero;
+    private TimeSpan _dateOffset = TimeSpan.Zero;
+    private bool _hasTimeOffset;
+    private bool _hasDateOffset;
+
+    /// <summary>
+    /// Sets the virtual time by computing the offset from the real time.
+    /// </summary>
+    /// <param name="hours">Hours (0-23)</param>
+    /// <param name="minutes">Minutes (0-59)</param>
+    /// <param name="seconds">Seconds (0-59)</param>
+    /// <param name="hundredths">Hundredths of a second (0-99)</param>
+    public bool SetTime(byte hours, byte minutes, byte seconds, byte hundredths)
+    {
+        if (hours > 23 || minutes > 59 || seconds > 59 || hundredths > 99) {
+            return false;
+        }
+        
+        TimeSpan virtualTime;
+        try {
+            virtualTime = new TimeSpan(0, hours, minutes, seconds, hundredths * 10);
+        }
+        catch (ArgumentOutOfRangeException)
+        {
+            loggerService.Warning("Invalid time (hours, minutes, seconds, hundredths): {}, {}, {}, {}", hours, minutes, seconds, hundredths);
+            return false;
+        }
+        
+        TimeSpan realTime = DateTime.Now.TimeOfDay;
+        _timeOffset = virtualTime - realTime;
+        _hasTimeOffset = true;
+
+        if (loggerService.IsEnabled(LogEventLevel.Verbose)) {
+            loggerService.Verbose("Time changed to {O}", GetVirtualDateTime());
+        }
+
+        return true;
+    }
+
+    /// <summary>
+    /// Sets the virtual date by computing the offset from the real date.
+    /// </summary>
+    public bool SetDate(ushort year, byte month, byte day)
+    {
+        if (month > 12 || day > 31) {
+            return false;
+        }
+        
+        DateTime virtualDate;
+        try
+        {
+            virtualDate = new DateTime(year, month, day);
+        }
+        catch (ArgumentOutOfRangeException)
+        {
+            loggerService.Warning("Invalid date (y-m-d): {}-{}-{}", year, month, day);
+            return false;
+        }
+        
+        DateTime realDate = DateTime.Now.Date;
+        _dateOffset = virtualDate - realDate;
+        _hasDateOffset = true;
+        
+        if (loggerService.IsEnabled(LogEventLevel.Verbose)) {
+            loggerService.Verbose("Date changed to {O}", GetVirtualDateTime());   
+        }
+
+        return true;
+    }
+
+    /// <summary>
+    /// Gets the current virtual time, applying the offset if one has been set.
+    /// </summary>
+    /// <returns>A tuple containing (hours, minutes, seconds, hundredths)</returns>
+    public (byte hours, byte minutes, byte seconds, byte hundredths) GetTime()
+    {
+        DateTime currentTime = GetVirtualDateTime();
+        TimeSpan timeOfDay = currentTime.TimeOfDay;
+        
+        return (
+            (byte)timeOfDay.Hours,
+            (byte)timeOfDay.Minutes,
+            (byte)timeOfDay.Seconds,
+            (byte)(timeOfDay.Milliseconds / 10)
+        );
+    }
+
+    /// <summary>
+    /// Gets the current virtual date, applying the offset if one has been set.
+    /// </summary>
+    /// <returns>A tuple containing (year, month, day, dayOfWeek)</returns>
+    public (ushort year, byte month, byte day, byte dayOfWeek) GetDate()
+    {
+        DateTime currentDate = GetVirtualDateTime();
+        
+        return (
+            (ushort)currentDate.Year,
+            (byte)currentDate.Month,
+            (byte)currentDate.Day,
+            (byte)currentDate.DayOfWeek
+        );
+    }
+
+    /// <summary>
+    /// Gets the virtual DateTime by applying both date and time offsets to the current real time.
+    /// </summary>
+    /// <returns>The virtual DateTime</returns>
+    public DateTime GetVirtualDateTime()
+    {
+        DateTime now = DateTime.Now;
+        DateTime virtualDateTime = now;
+        
+        // Apply date offset if set
+        if (_hasDateOffset)
+        {
+            virtualDateTime = virtualDateTime.Add(_dateOffset);
+        }
+        
+        // Apply time offset if set
+        if (_hasTimeOffset)
+        {
+            virtualDateTime = virtualDateTime.Add(_timeOffset);
+        }
+        
+        return virtualDateTime;
+    }
+
+    /// <summary>
+    /// Gets a value indicating whether any virtual time or date has been set.
+    /// </summary>
+    public bool HasOffset => _hasTimeOffset || _hasDateOffset;
+}

--- a/src/Spice86.Core/Emulator/OperatingSystem/Dos.cs
+++ b/src/Spice86.Core/Emulator/OperatingSystem/Dos.cs
@@ -124,17 +124,18 @@ public sealed class Dos {
     /// <param name="functionHandlerProvider">Provides current call flow handler to peek call stack.</param>
     /// <param name="stack">The CPU stack.</param>
     /// <param name="state">The CPU state.</param>
-    /// <param name="vgaFunctionality">The high-level VGA functions.</param>
-    /// <param name="envVars">The DOS environment variables.</param>
-    /// <param name="loggerService">The logger service implementation.</param>
     /// <param name="biosKeyboardBuffer">The BIOS keyboard buffer structure in emulated memory.</param>
     /// <param name="keyboardInt16Handler">The BIOS interrupt handler that writes/reads the BIOS Keyboard Buffer.</param>
     /// <param name="biosDataArea">The memory mapped BIOS values and settings.</param>
+    /// <param name="vgaFunctionality">The high-level VGA functions.</param>
+    /// <param name="envVars">The DOS environment variables.</param>
+    /// <param name="clock"></param>
+    /// <param name="loggerService">The logger service implementation.</param>
     public Dos(Configuration configuration, IMemory memory,
         IFunctionHandlerProvider functionHandlerProvider, Stack stack, State state,
         BiosKeyboardBuffer biosKeyboardBuffer, KeyboardInt16Handler keyboardInt16Handler,
         BiosDataArea biosDataArea, IVgaFunctionality vgaFunctionality,
-        IDictionary<string, string> envVars, ILoggerService loggerService) {
+        IDictionary<string, string> envVars, Clock clock, ILoggerService loggerService) {
         _loggerService = loggerService;
         _biosKeyboardBuffer = biosKeyboardBuffer;
         _memory = memory;
@@ -162,7 +163,7 @@ public sealed class Dos {
         DosInt20Handler = new DosInt20Handler(_memory, functionHandlerProvider, stack, state, _loggerService);
         DosInt21Handler = new DosInt21Handler(_memory, functionHandlerProvider, stack, state,
             keyboardInt16Handler, CountryInfo, dosStringDecoder,
-            MemoryManager, FileManager, DosDriveManager, _loggerService);
+            MemoryManager, FileManager, DosDriveManager, clock, _loggerService);
         DosInt2FHandler = new DosInt2fHandler(_memory, functionHandlerProvider, stack, state, _loggerService);
         DosInt25Handler = new DosDiskInt25Handler(_memory, DosDriveManager, functionHandlerProvider, stack, state, _loggerService);
         DosInt26Handler = new DosDiskInt26Handler(_memory, DosDriveManager, functionHandlerProvider, stack, state, _loggerService);

--- a/tests/Spice86.Tests/Dos/DosFileManagerTests.cs
+++ b/tests/Spice86.Tests/Dos/DosFileManagerTests.cs
@@ -167,10 +167,12 @@ public class DosFileManagerTests {
             memory, biosDataArea, functionHandlerProvider, stack, state, loggerService,
     biosKeyboardInt9Handler.BiosKeyboardBuffer, emulationLoopRecall);
 
+        var clock = new Clock(loggerService);
+
         Dos dos = new Dos(configuration, memory, functionHandlerProvider, stack, state,
             biosKeyboardBuffer, keyboardInt16Handler, biosDataArea,
             vgaFunctionality, new Dictionary<string, string> { { "BLASTER", soundBlaster.BlasterString } },
-            loggerService);
+            clock, loggerService);
 
         DosDriveManager dosDriveManager = new(loggerService, configuration.CDrive, configuration.Exe);
 

--- a/tests/Spice86.Tests/Emulator/OperatingSystem/ClockTest.cs
+++ b/tests/Spice86.Tests/Emulator/OperatingSystem/ClockTest.cs
@@ -9,20 +9,17 @@ using Spice86.Shared.Interfaces;
 
 using Xunit;
 
-public class ClockTests
-{
+public class ClockTests {
     private readonly ILoggerService _loggerService;
     private readonly Clock _clock;
 
-    public ClockTests()
-    {
+    public ClockTests() {
         _loggerService = Substitute.For<ILoggerService>();
         _clock = new Clock(_loggerService);
     }
 
     [Fact]
-    public void Constructor_InitializesWithNoOffset()
-    {
+    public void Constructor_InitializesWithNoOffset() {
         // Arrange & Act
         var clock = new Clock(_loggerService);
 
@@ -35,8 +32,7 @@ public class ClockTests
     [InlineData(0, 0, 0, 0)]
     [InlineData(12, 30, 45, 50)]
     [InlineData(23, 59, 59, 99)]
-    public void SetTime_ValidTime_ReturnsTrue(byte hours, byte minutes, byte seconds, byte hundredths)
-    {
+    public void SetTime_ValidTime_ReturnsTrue(byte hours, byte minutes, byte seconds, byte hundredths) {
         // Act
         bool result = _clock.SetTime(hours, minutes, seconds, hundredths);
 
@@ -50,8 +46,7 @@ public class ClockTests
     [InlineData(0, 60, 0, 0)]
     [InlineData(0, 0, 60, 0)]
     [InlineData(0, 0, 0, 100)]
-    public void SetTime_InvalidTime_ReturnsFalse(byte hours, byte minutes, byte seconds, byte hundredths)
-    {
+    public void SetTime_InvalidTime_ReturnsFalse(byte hours, byte minutes, byte seconds, byte hundredths) {
         // Act
         bool result = _clock.SetTime(hours, minutes, seconds, hundredths);
 
@@ -64,8 +59,7 @@ public class ClockTests
     [InlineData(2023, 1, 1)]
     [InlineData(2024, 12, 31)]
     [InlineData(1980, 6, 15)]
-    public void SetDate_ValidDate_ReturnsTrue(ushort year, byte month, byte day)
-    {
+    public void SetDate_ValidDate_ReturnsTrue(ushort year, byte month, byte day) {
         // Act
         bool result = _clock.SetDate(year, month, day);
 
@@ -80,8 +74,7 @@ public class ClockTests
     [InlineData(2023, 1, 0)]
     [InlineData(2023, 1, 32)]
     [InlineData(2023, 2, 29)] // Not a leap year
-    public void SetDate_InvalidDate_ReturnsFalse(ushort year, byte month, byte day)
-    {
+    public void SetDate_InvalidDate_ReturnsFalse(ushort year, byte month, byte day) {
         // Act
         bool result = _clock.SetDate(year, month, day);
 
@@ -91,8 +84,7 @@ public class ClockTests
     }
 
     [Fact]
-    public void GetTime_WithTimeOffset_ReturnsVirtualTime()
-    {
+    public void GetTime_WithTimeOffset_ReturnsVirtualTime() {
         // Arrange
         byte expectedHours = 15;
         byte expectedMinutes = 30;
@@ -111,8 +103,7 @@ public class ClockTests
     }
 
     [Fact]
-    public void GetDate_WithDateOffset_ReturnsVirtualDate()
-    {
+    public void GetDate_WithDateOffset_ReturnsVirtualDate() {
         // Arrange
         ushort expectedYear = 2023;
         byte expectedMonth = 6;
@@ -130,8 +121,7 @@ public class ClockTests
     }
 
     [Fact]
-    public void GetTime_WithoutOffset_ReturnsRealTime()
-    {
+    public void GetTime_WithoutOffset_ReturnsRealTime() {
         // Arrange
         DateTime now = DateTime.Now;
 
@@ -146,8 +136,7 @@ public class ClockTests
     }
 
     [Fact]
-    public void GetDate_WithoutOffset_ReturnsRealDate()
-    {
+    public void GetDate_WithoutOffset_ReturnsRealDate() {
         // Arrange
         DateTime now = DateTime.Now;
 
@@ -162,8 +151,7 @@ public class ClockTests
     }
 
     [Fact]
-    public void GetVirtualDateTime_WithBothOffsets_AppliesBoth()
-    {
+    public void GetVirtualDateTime_WithBothOffsets_AppliesBoth() {
         // Arrange
         ushort virtualYear = 2024;
         byte virtualMonth = 12;
@@ -188,8 +176,7 @@ public class ClockTests
     }
 
     [Fact]
-    public void GetVirtualDateTime_WithOnlyDateOffset_AppliesDateOnly()
-    {
+    public void GetVirtualDateTime_WithOnlyDateOffset_AppliesDateOnly() {
         // Arrange
         DateTime now = DateTime.Now;
         ushort virtualYear = 2024;
@@ -210,8 +197,7 @@ public class ClockTests
     }
 
     [Fact]
-    public void GetVirtualDateTime_WithOnlyTimeOffset_AppliesTimeOnly()
-    {
+    public void GetVirtualDateTime_WithOnlyTimeOffset_AppliesTimeOnly() {
         // Arrange
         DateTime now = DateTime.Now;
         byte virtualHours = 18;
@@ -233,8 +219,7 @@ public class ClockTests
     }
 
     [Fact]
-    public void GetVirtualDateTime_WithoutOffset_ReturnsRealTime()
-    {
+    public void GetVirtualDateTime_WithoutOffset_ReturnsRealTime() {
         // Arrange
         DateTime now = DateTime.Now;
 
@@ -246,8 +231,7 @@ public class ClockTests
     }
 
     [Fact]
-    public void HasOffset_ReturnsTrue_WhenTimeOffsetSet()
-    {
+    public void HasOffset_ReturnsTrue_WhenTimeOffsetSet() {
         // Act
         _clock.SetTime(12, 0, 0, 0);
 
@@ -256,8 +240,7 @@ public class ClockTests
     }
 
     [Fact]
-    public void HasOffset_ReturnsTrue_WhenDateOffsetSet()
-    {
+    public void HasOffset_ReturnsTrue_WhenDateOffsetSet() {
         // Act
         _clock.SetDate(2023, 6, 15);
 
@@ -266,8 +249,7 @@ public class ClockTests
     }
 
     [Fact]
-    public void HasOffset_ReturnsTrue_WhenBothOffsetsSet()
-    {
+    public void HasOffset_ReturnsTrue_WhenBothOffsetsSet() {
         // Act
         _clock.SetDate(2023, 6, 15);
         _clock.SetTime(12, 0, 0, 0);
@@ -277,8 +259,7 @@ public class ClockTests
     }
 
     [Fact]
-    public void SetTime_OverridesPreviousTimeOffset()
-    {
+    public void SetTime_OverridesPreviousTimeOffset() {
         // Arrange
         _clock.SetTime(12, 0, 0, 0);
 
@@ -294,8 +275,7 @@ public class ClockTests
     }
 
     [Fact]
-    public void SetDate_OverridesPreviousDateOffset()
-    {
+    public void SetDate_OverridesPreviousDateOffset() {
         // Arrange
         _clock.SetDate(2023, 1, 1);
 

--- a/tests/Spice86.Tests/Emulator/OperatingSystem/ClockTest.cs
+++ b/tests/Spice86.Tests/Emulator/OperatingSystem/ClockTest.cs
@@ -1,0 +1,311 @@
+﻿namespace Spice86.Tests.Emulator.OperatingSystem;
+
+using FluentAssertions;
+
+using NSubstitute;
+
+using Spice86.Core.Emulator.OperatingSystem;
+using Spice86.Shared.Interfaces;
+
+using Xunit;
+
+public class ClockTests
+{
+    private readonly ILoggerService _loggerService;
+    private readonly Clock _clock;
+
+    public ClockTests()
+    {
+        _loggerService = Substitute.For<ILoggerService>();
+        _clock = new Clock(_loggerService);
+    }
+
+    [Fact]
+    public void Constructor_InitializesWithNoOffset()
+    {
+        // Arrange & Act
+        var clock = new Clock(_loggerService);
+
+        // Assert
+        clock.HasOffset.Should().BeFalse();
+        clock.GetVirtualDateTime().Should().BeCloseTo(DateTime.Now, TimeSpan.FromSeconds(1));
+    }
+
+    [Theory]
+    [InlineData(0, 0, 0, 0)]
+    [InlineData(12, 30, 45, 50)]
+    [InlineData(23, 59, 59, 99)]
+    public void SetTime_ValidTime_ReturnsTrue(byte hours, byte minutes, byte seconds, byte hundredths)
+    {
+        // Act
+        bool result = _clock.SetTime(hours, minutes, seconds, hundredths);
+
+        // Assert
+        result.Should().BeTrue();
+        _clock.HasOffset.Should().BeTrue();
+    }
+
+    [Theory]
+    [InlineData(24, 0, 0, 0)]
+    [InlineData(0, 60, 0, 0)]
+    [InlineData(0, 0, 60, 0)]
+    [InlineData(0, 0, 0, 100)]
+    public void SetTime_InvalidTime_ReturnsFalse(byte hours, byte minutes, byte seconds, byte hundredths)
+    {
+        // Act
+        bool result = _clock.SetTime(hours, minutes, seconds, hundredths);
+
+        // Assert
+        result.Should().BeFalse();
+        _clock.HasOffset.Should().BeFalse();
+    }
+
+    [Theory]
+    [InlineData(2023, 1, 1)]
+    [InlineData(2024, 12, 31)]
+    [InlineData(1980, 6, 15)]
+    public void SetDate_ValidDate_ReturnsTrue(ushort year, byte month, byte day)
+    {
+        // Act
+        bool result = _clock.SetDate(year, month, day);
+
+        // Assert
+        result.Should().BeTrue();
+        _clock.HasOffset.Should().BeTrue();
+    }
+
+    [Theory]
+    [InlineData(2023, 0, 1)]
+    [InlineData(2023, 13, 1)]
+    [InlineData(2023, 1, 0)]
+    [InlineData(2023, 1, 32)]
+    [InlineData(2023, 2, 29)] // Not a leap year
+    public void SetDate_InvalidDate_ReturnsFalse(ushort year, byte month, byte day)
+    {
+        // Act
+        bool result = _clock.SetDate(year, month, day);
+
+        // Assert
+        result.Should().BeFalse();
+        _clock.HasOffset.Should().BeFalse();
+    }
+
+    [Fact]
+    public void GetTime_WithTimeOffset_ReturnsVirtualTime()
+    {
+        // Arrange
+        byte expectedHours = 15;
+        byte expectedMinutes = 30;
+        byte expectedSeconds = 45;
+        byte expectedHundredths = 50;
+
+        // Act
+        _clock.SetTime(expectedHours, expectedMinutes, expectedSeconds, expectedHundredths);
+        var (hours, minutes, seconds, hundredths) = _clock.GetTime();
+
+        // Assert
+        hours.Should().Be(expectedHours);
+        minutes.Should().Be(expectedMinutes);
+        seconds.Should().Be(expectedSeconds);
+        hundredths.Should().Be(expectedHundredths);
+    }
+
+    [Fact]
+    public void GetDate_WithDateOffset_ReturnsVirtualDate()
+    {
+        // Arrange
+        ushort expectedYear = 2023;
+        byte expectedMonth = 6;
+        byte expectedDay = 15;
+
+        // Act
+        _clock.SetDate(expectedYear, expectedMonth, expectedDay);
+        var (year, month, day, dayOfWeek) = _clock.GetDate();
+
+        // Assert
+        year.Should().Be(expectedYear);
+        month.Should().Be(expectedMonth);
+        day.Should().Be(expectedDay);
+        dayOfWeek.Should().Be((byte)new DateTime(expectedYear, expectedMonth, expectedDay).DayOfWeek);
+    }
+
+    [Fact]
+    public void GetTime_WithoutOffset_ReturnsRealTime()
+    {
+        // Arrange
+        DateTime now = DateTime.Now;
+
+        // Act
+        var (hours, minutes, seconds, hundredths) = _clock.GetTime();
+
+        // Assert
+        hours.Should().Be((byte)now.Hour);
+        minutes.Should().Be((byte)now.Minute);
+        seconds.Should().BeCloseTo((byte)now.Second, 1);
+        hundredths.Should().BeCloseTo((byte)(now.Millisecond / 10), 10);
+    }
+
+    [Fact]
+    public void GetDate_WithoutOffset_ReturnsRealDate()
+    {
+        // Arrange
+        DateTime now = DateTime.Now;
+
+        // Act
+        var (year, month, day, dayOfWeek) = _clock.GetDate();
+
+        // Assert
+        year.Should().Be((ushort)now.Year);
+        month.Should().Be((byte)now.Month);
+        day.Should().Be((byte)now.Day);
+        dayOfWeek.Should().Be((byte)now.DayOfWeek);
+    }
+
+    [Fact]
+    public void GetVirtualDateTime_WithBothOffsets_AppliesBoth()
+    {
+        // Arrange
+        ushort virtualYear = 2024;
+        byte virtualMonth = 12;
+        byte virtualDay = 25;
+        byte virtualHours = 18;
+        byte virtualMinutes = 45;
+        byte virtualSeconds = 30;
+        byte virtualHundredths = 0;
+
+        // Act
+        _clock.SetDate(virtualYear, virtualMonth, virtualDay);
+        _clock.SetTime(virtualHours, virtualMinutes, virtualSeconds, virtualHundredths);
+        DateTime virtualDateTime = _clock.GetVirtualDateTime();
+
+        // Assert
+        virtualDateTime.Year.Should().Be(virtualYear);
+        virtualDateTime.Month.Should().Be(virtualMonth);
+        virtualDateTime.Day.Should().Be(virtualDay);
+        virtualDateTime.Hour.Should().Be(virtualHours);
+        virtualDateTime.Minute.Should().Be(virtualMinutes);
+        virtualDateTime.Second.Should().Be(virtualSeconds);
+    }
+
+    [Fact]
+    public void GetVirtualDateTime_WithOnlyDateOffset_AppliesDateOnly()
+    {
+        // Arrange
+        DateTime now = DateTime.Now;
+        ushort virtualYear = 2024;
+        byte virtualMonth = 12;
+        byte virtualDay = 25;
+
+        // Act
+        _clock.SetDate(virtualYear, virtualMonth, virtualDay);
+        DateTime virtualDateTime = _clock.GetVirtualDateTime();
+
+        // Assert
+        virtualDateTime.Year.Should().Be(virtualYear);
+        virtualDateTime.Month.Should().Be(virtualMonth);
+        virtualDateTime.Day.Should().Be(virtualDay);
+        virtualDateTime.Hour.Should().Be(now.Hour);
+        virtualDateTime.Minute.Should().Be(now.Minute);
+        virtualDateTime.Second.Should().BeCloseTo(now.Second, 1);
+    }
+
+    [Fact]
+    public void GetVirtualDateTime_WithOnlyTimeOffset_AppliesTimeOnly()
+    {
+        // Arrange
+        DateTime now = DateTime.Now;
+        byte virtualHours = 18;
+        byte virtualMinutes = 45;
+        byte virtualSeconds = 30;
+        byte virtualHundredths = 0;
+
+        // Act
+        _clock.SetTime(virtualHours, virtualMinutes, virtualSeconds, virtualHundredths);
+        DateTime virtualDateTime = _clock.GetVirtualDateTime();
+
+        // Assert
+        virtualDateTime.Year.Should().Be(now.Year);
+        virtualDateTime.Month.Should().Be(now.Month);
+        virtualDateTime.Day.Should().Be(now.Day);
+        virtualDateTime.Hour.Should().Be(virtualHours);
+        virtualDateTime.Minute.Should().Be(virtualMinutes);
+        virtualDateTime.Second.Should().Be(virtualSeconds);
+    }
+
+    [Fact]
+    public void GetVirtualDateTime_WithoutOffset_ReturnsRealTime()
+    {
+        // Arrange
+        DateTime now = DateTime.Now;
+
+        // Act
+        DateTime virtualDateTime = _clock.GetVirtualDateTime();
+
+        // Assert
+        virtualDateTime.Should().BeCloseTo(now, TimeSpan.FromSeconds(1));
+    }
+
+    [Fact]
+    public void HasOffset_ReturnsTrue_WhenTimeOffsetSet()
+    {
+        // Act
+        _clock.SetTime(12, 0, 0, 0);
+
+        // Assert
+        _clock.HasOffset.Should().BeTrue();
+    }
+
+    [Fact]
+    public void HasOffset_ReturnsTrue_WhenDateOffsetSet()
+    {
+        // Act
+        _clock.SetDate(2023, 6, 15);
+
+        // Assert
+        _clock.HasOffset.Should().BeTrue();
+    }
+
+    [Fact]
+    public void HasOffset_ReturnsTrue_WhenBothOffsetsSet()
+    {
+        // Act
+        _clock.SetDate(2023, 6, 15);
+        _clock.SetTime(12, 0, 0, 0);
+
+        // Assert
+        _clock.HasOffset.Should().BeTrue();
+    }
+
+    [Fact]
+    public void SetTime_OverridesPreviousTimeOffset()
+    {
+        // Arrange
+        _clock.SetTime(12, 0, 0, 0);
+
+        // Act
+        _clock.SetTime(18, 30, 45, 50);
+        var (hours, minutes, seconds, hundredths) = _clock.GetTime();
+
+        // Assert
+        hours.Should().Be(18);
+        minutes.Should().Be(30);
+        seconds.Should().Be(45);
+        hundredths.Should().Be(50);
+    }
+
+    [Fact]
+    public void SetDate_OverridesPreviousDateOffset()
+    {
+        // Arrange
+        _clock.SetDate(2023, 1, 1);
+
+        // Act
+        _clock.SetDate(2024, 12, 31);
+        var (year, month, day, _) = _clock.GetDate();
+
+        // Assert
+        year.Should().Be(2024);
+        month.Should().Be(12);
+        day.Should().Be(31);
+    }
+}


### PR DESCRIPTION
### Description of Changes
Implementation of interrupt handlers for setting and getting date/time.
The RTC is a fake one (for now), but it should be fine for our use case unless a "real" RTC has to be implemented.

### Rationale behind Changes
The game "Tom Long" crashed without those handlers

### Suggested Testing Steps
I started Tom Long and watched it get and set the date/time.
