### PR TITLE
fix out-of-bounds risk in GetDosString and simplify string handling

### DIFF
--- a/src/Spice86.Core/Emulator/OperatingSystem/DosStringDecoder.cs
+++ b/src/Spice86.Core/Emulator/OperatingSystem/DosStringDecoder.cs
@@ -56,19 +56,20 @@ public class DosStringDecoder {
     /// <returns>The string from memory.</returns>
     public string GetDosString(ushort segment, ushort offset, char end) {
         uint address = MemoryUtils.ToPhysicalAddress(segment, offset);
-        int length = MaxDosStringLength;
+        byte endByte = (byte)end;
         Span<byte> data = stackalloc byte[MaxDosStringLength];
         int dataIndex = 0;
-        while (length-- != 0) {
-            byte memByte = _memory.UInt8[address++];
-            if (memByte == end || dataIndex >= MaxDosStringLength) {
+
+        while (dataIndex < MaxDosStringLength) {
+            byte memByte = _memory.UInt8[address + (uint)dataIndex];
+            if (memByte == endByte) {
                 break;
             }
+
             data[dataIndex++] = memByte;
         }
-        data[dataIndex] = 0; // Null terminate the string
-        string convertedString = ConvertDosChars( data[..dataIndex]);
-        return convertedString;
+
+        return ConvertDosChars(data[..dataIndex]);
     }
 
     /// <summary>


### PR DESCRIPTION
An exception was thrown randomly while I tried to run "Another World". The end character was not found within 0..MaxDosStringLength. Strangely, I could not reproduce the issue afterwards but its better to fix it.

The string handling is also slightly improved.

I also thought about resizing the array if needed but would leave that open for discussion.

### Description of Changes
Prevent possible OutOfBounds exception

### Rationale behind Changes
Random exception while trying to run "Another World"

### Suggested Testing Steps
I just started "Another World" but somehow, the error disappeared.