### PR TITLE
Fix/1208 video memory issue

### DIFF
--- a/src/Spice86.Core/Emulator/Devices/Video/Registers/Graphics/MiscellaneousGraphicsRegister.cs
+++ b/src/Spice86.Core/Emulator/Devices/Video/Registers/Graphics/MiscellaneousGraphicsRegister.cs
@@ -47,4 +47,15 @@ public class MiscellaneousGraphicsRegister : Register8 {
         3 => 0xB8000,
         _ => throw new ArgumentOutOfRangeException()
     };
+
+    /// <summary>
+    ///     The size of the graphics memory window.
+    /// </summary>
+    public uint MemorySize => MemoryMap switch {
+        0 => 128 * 1024,
+        1 => 64 * 1024,
+        2 => 32 * 1024,
+        3 => 32 * 1024,
+        _ => throw new ArgumentOutOfRangeException()
+    };
 }

--- a/src/Spice86.Core/Emulator/Devices/Video/Renderer.cs
+++ b/src/Spice86.Core/Emulator/Devices/Video/Renderer.cs
@@ -3,6 +3,8 @@ namespace Spice86.Core.Emulator.Devices.Video;
 using Spice86.Core.Emulator.Devices.Video.Registers.CrtController;
 using Spice86.Core.Emulator.Devices.Video.Registers.Graphics;
 using Spice86.Core.Emulator.Memory;
+using Spice86.Logging;
+
 using ClockSelect = Spice86.Core.Emulator.Devices.Video.Registers.General.MiscellaneousOutput.ClockSelectValue;
 
 using System.Diagnostics;
@@ -18,10 +20,11 @@ public class Renderer : IVgaRenderer {
     /// </summary>
     /// <param name="memory">The video memory implementation.</param>
     /// <param name="state">The video state implementation.</param>
-    public Renderer(IMemory memory, IVideoState state) {
+    /// <param name="loggerService">The logger service implementation.</param>
+    public Renderer(IMemory memory, IVideoState state, LoggerService loggerService) {
         _state = state;
         const uint videoBaseAddress = MemoryMap.GraphicVideoMemorySegment << 4;
-        _memory = new VideoMemory(_state);
+        _memory = new VideoMemory(_state, loggerService);
         memory.RegisterMapping(videoBaseAddress, _memory.Size, _memory);
     }
 

--- a/src/Spice86/Spice86DependencyInjection.cs
+++ b/src/Spice86/Spice86DependencyInjection.cs
@@ -250,7 +250,7 @@ public class Spice86DependencyInjection : IDisposable {
         VideoState videoState = new();
         VgaIoPortHandler vgaIoPortHandler = new(state, ioPortDispatcher,
             loggerService, videoState, configuration.FailOnUnhandledPort);
-        Renderer vgaRenderer = new(memory, videoState);
+        Renderer vgaRenderer = new(memory, videoState, loggerService);
         VgaRom vgaRom = new();
         VgaFunctionality vgaFunctionality = new VgaFunctionality(memory,
             interruptVectorTable, ioPortDispatcher,

--- a/tests/Spice86.Tests/MachineTest.cs
+++ b/tests/Spice86.Tests/MachineTest.cs
@@ -275,7 +275,7 @@ public class MachineTest
         spice86DependencyInjection.ProgramExecutor.Run();
         Machine machine = spice86DependencyInjection.Machine;
         IMemory memory = machine.Memory;
-        CompareMemoryWithExpected(memory, expected, 0, expected.Length);
+        CompareMemoryWithExpected(memory, expected);
         CompareListingWithExpected(binName, enableCfgCpu, machine);
         return machine;
     }
@@ -396,9 +396,9 @@ public class MachineTest
     }
 
     [AssertionMethod]
-    private void CompareMemoryWithExpected(IMemory memory, byte[] expected, int start, int end)
+    private static void CompareMemoryWithExpected(IMemory memory, byte[] expected)
     {
-        byte[] actual = memory.ReadRam();
-        Assert.Equal(expected[start..end], actual[start..end]);
+        byte[] actual = memory.ReadRam((uint)expected.Length);
+        Assert.Equal(expected, actual);
     }
 }


### PR DESCRIPTION
### Description of Changes
We check if VGA memory access is within the currently mapped memory.
If it is not, we log writes and return 0x00 for reads.

### Rationale behind Changes
Dune2 writes debug information to 0xB0000+ which on real hardware would be visible on a secondary monochrome monitor.

### Suggested Testing Steps
Finish 1st mission of dune2.
Regression test your favorite game.

In the future we could implement this secondary screen.
