### PR TITLE
fix incorrect error code if FindFirstMatchingFile fails

### DIFF
--- a/src/Spice86.Core/Emulator/OperatingSystem/DosFileManager.cs
+++ b/src/Spice86.Core/Emulator/OperatingSystem/DosFileManager.cs
@@ -272,7 +272,7 @@ public class DosFileManager {
                 enumerationOptions);
 
             if (matchingPaths.Length == 0) {
-                return DosFileOperationResult.Error(ErrorCode.PathNotFound);
+                return DosFileOperationResult.Error(ErrorCode.NoMoreFiles);
             }
 
             if (!TryUpdateDosTransferAreaWithFileMatch(dta, fileSpec, matchingPaths[0], searchFolder,


### PR DESCRIPTION
### Description of Changes
I debugged/traced how DosBox treats issues if a file can not be found in FindFirstMatchingFile. It turns out that the correct error code would is "NoMoreFiles". I also have a suspicion why the game does it. I assume there is a possibility to overwrite the games assets, which are in the data.-1- file, with files in the same directory. As we are returning the wrong error code, it would loop indefinitely.

In IDA, I can also see that it compares against 0x12 / dec 18:
<img width="217" height="82" alt="grafik" src="https://github.com/user-attachments/assets/a7761a24-2252-4894-b2cc-2c05f3bef762" />

Here is a proof that it works now.

<img width="1026" height="800" alt="grafik" src="https://github.com/user-attachments/assets/f1d607f8-b159-4a57-ba20-f380b90979eb" />

### Rationale behind Changes
Improve compatibility by returning the correct error code.

### Suggested Testing Steps
Launch EnviroKids