### PR TITLE
Fix/enviro kids german game

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ If there is already data there the emulator will load it first and complete it, 
 
 ```
   --Debug                            (Default: false) Starts the program paused.
-  --Ems                              (Default: false) Enables EMS memory. EMS adds 8 MB of memory accessible to DOS programs through the EMM Page Frame.
+  --Ems                              (Default: true) Enables EMS memory. EMS adds 8 MB of memory accessible to DOS programs through the EMM Page Frame.
   --A20Gate                          (Default: false) Disables the 20th address line to support programs relying on the rollover of memory addresses above the HMA (slightly above 1 MB).
   -m, --Mt32RomsPath                 Zip file or directory containing the MT-32 ROM files
   -c, --CDrive                       Path to C drive, default is exe parent

--- a/src/Spice86.Core/CLI/Configuration.cs
+++ b/src/Spice86.Core/CLI/Configuration.cs
@@ -137,7 +137,7 @@ public sealed class Configuration {
     /// <summary>
     /// Determines whether EMS (Expanded Memory Specification) should be enabled or not.
     /// </summary>
-    [Option(nameof(Ems), Default = false, Required = false, HelpText = "Enable EMS")]
+    [Option(nameof(Ems), Default = true, Required = false, HelpText = "Enable EMS")]
     public bool Ems { get; init; }
 
     /// <summary>

--- a/src/Spice86.Core/Emulator/InterruptHandlers/Bios/SystemBiosInt13Handler.cs
+++ b/src/Spice86.Core/Emulator/InterruptHandlers/Bios/SystemBiosInt13Handler.cs
@@ -51,6 +51,7 @@ public class SystemBiosInt13Handler : InterruptHandler {
     private void FillDispatchTable() {
         AddAction(0x0, () => ResetDiskSystem(true));
         AddAction(0x4, () => VerifySectors(true));
+        AddAction(0x15, () => GetDisketteOrHddType(true));
     }
 
     /// <summary>
@@ -85,5 +86,26 @@ public class SystemBiosInt13Handler : InterruptHandler {
         }
         State.AH = 0x0;
         SetCarryFlag(false, calledFromVm);
+    }
+
+    /// <summary>
+    /// Get Diskette Type or Check Hard Drive Installed
+    /// </summary>
+    /// <param name="calledFromVm">Whether this was called by internal emulator code or not.</param>
+    public void GetDisketteOrHddType(bool calledFromVm) {
+        if (LoggerService.IsEnabled(LogEventLevel.Warning)) {
+            LoggerService.Warning("{Method} was called! Only returning fake" +
+                "hard drive value if asking for first hard drive." +
+                "Invalid drive otherwise.", nameof(GetDisketteOrHddType));
+        }
+        if(State.DL is 0x80) { // first hard disk drive
+            State.AL = 0x3; // hard drive type
+            State.CX = 3;  // High word of 32-bit sector count
+            State.DX = 0x4800; //105 megs (0x00034800 = 215,040 of 512 bytes sector = 105 megs)
+            SetCarryFlag(false, calledFromVm);
+        } else {
+            State.AH = 0xFF; // BIOS Disk error code: sense operation failed.
+            SetCarryFlag(true, calledFromVm);
+        }
     }
 }

--- a/src/Spice86.Core/Emulator/OperatingSystem/DosFileManager.cs
+++ b/src/Spice86.Core/Emulator/OperatingSystem/DosFileManager.cs
@@ -272,7 +272,7 @@ public class DosFileManager {
                 enumerationOptions);
 
             if (matchingPaths.Length == 0) {
-                return DosFileOperationResult.Error(ErrorCode.PathNotFound);
+                return DosFileOperationResult.Error(ErrorCode.NoMoreFiles);
             }
 
             if (!TryUpdateDosTransferAreaWithFileMatch(dta, fileSpec, matchingPaths[0], searchFolder,


### PR DESCRIPTION
### Description of Changes

Adds GetDisketteOrHddType to the BIOS DISK (INT13H) handler - with a logged warning (it only knows about the first hard disk)

Adds one EMS function (GetMappablePhysicalAddressArray)

Fixes the error code return by DOS FindFirst function (again 0x18 instead of the unexpected 0x19)

Together, those changes make the German adventure game Enviro-Kids work.

Also, this PR enables EMS by default. **Dune** doesn't use it unless 'EMS386' command line arg is used.

<img width="1552" height="1200" alt="image" src="https://github.com/user-attachments/assets/c33585f7-c00f-4896-8832-2d3f7cca9977" />
