### PR TITLE
Several compatibility fixes

### DIFF
--- a/src/Spice86.Core/Emulator/InterruptHandlers/Input/Keyboard/KeyboardInt16Handler.cs
+++ b/src/Spice86.Core/Emulator/InterruptHandlers/Input/Keyboard/KeyboardInt16Handler.cs
@@ -54,10 +54,8 @@ public class KeyboardInt16Handler : InterruptHandler {
                 nameof(KeyboardInt16Handler), VectorNumber, operation);
         }
 
-        //If games that use those unsupported interrupts misbehave or crash, check if this state is the proper way to
-        //fix it as I couldn't find documentation about it
-        State.CarryFlag = true;
-        State.AX = 0;
+        //If games that use those unsupported interrupts misbehave or crash, check if certain flags/registers have to be set
+        //properly, e.g., AX = 0 and/or setting the carry flag accordingly.
     }
 
     /// <inheritdoc/>

--- a/src/Spice86.Core/Emulator/InterruptHandlers/Input/Mouse/MouseInt33Handler.cs
+++ b/src/Spice86.Core/Emulator/InterruptHandlers/Input/Mouse/MouseInt33Handler.cs
@@ -564,7 +564,17 @@ public class MouseInt33Handler : InterruptHandler {
         AddAction(0x1A, SetMouseSensitivity);
         AddAction(0x1B, GetMouseSensitivity);
         AddAction(0x1C, SetInterruptRate);
+        AddAction(0x21, Reset);
         AddAction(0x24, GetSoftwareVersionAndMouseType);
+    }
+    
+    private void Reset() {
+        if (LoggerService.IsEnabled(LogEventLevel.Verbose)) {
+            LoggerService.Verbose("{ClassName} INT {Int:X2} 21 {MethodName}: Resetting mouse", nameof(MouseInt33Handler), VectorNumber, nameof(Reset));
+        }
+        _mouseDriver.Reset();
+        State.AX = 0xFFFF;
+        State.BX = (ushort)_mouseDriver.ButtonCount;
     }
 
     private void GetMotionDistance() {

--- a/src/Spice86.Core/Emulator/OperatingSystem/DosFileManager.cs
+++ b/src/Spice86.Core/Emulator/OperatingSystem/DosFileManager.cs
@@ -150,6 +150,15 @@ public class DosFileManager {
     /// <returns>A <see cref="DosFileOperationResult"/> with details about the result of the operation.</returns>
     /// <exception cref="UnrecoverableException"></exception>
     public DosFileOperationResult CreateFileUsingHandle(string fileName, ushort fileAttribute) {
+        CharacterDevice? device = _dosVirtualDevices.OfType<CharacterDevice>()
+            .FirstOrDefault(device => device.IsName(fileName));
+        if (device is not null) {
+            if (_loggerService.IsEnabled(LogEventLevel.Verbose)) {
+                _loggerService.Verbose("Opening device {FileName}", fileName);
+            }
+            return OpenDevice(device);
+        }
+        
         string prefixedPath = _dosPathResolver.PrefixWithHostDirectory(fileName);
 
         FileStream? testFileStream = null;


### PR DESCRIPTION
### Description of Changes
This PR will enhance the compatibility for multiple games, like "Das Telekommando" for example.

### Rationale behind Changes
Enhanced compatibility, fallback for undocumented/unsupported keyboard operations according to https://stanislavs.org/helppc/int_16.html

Mouse reset is required for "Batman Returns". 

The correct treatment of an unsupported keyboard feature is debatable, but in my opinion, it should be alright. I could not find a proper documentation in that case. 