### PR TITLE
Optimize CfgCpu node linking by not doing it all the time

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -383,3 +383,6 @@ VSharp.*
 #AI guidelines
 .windsurfrules
 Knowledge/
+
+#Lost Dump files
+spice86dump*.json

--- a/src/Spice86.Core/Emulator/CPU/CfgCpu/ControlFlowGraph/CfgNode.cs
+++ b/src/Spice86.Core/Emulator/CPU/CfgCpu/ControlFlowGraph/CfgNode.cs
@@ -1,17 +1,16 @@
 namespace Spice86.Core.Emulator.CPU.CfgCpu.ControlFlowGraph;
 
-using Spice86.Core.Emulator.CPU.CfgCpu.Ast;
 using Spice86.Core.Emulator.CPU.CfgCpu.Ast.Builder;
 using Spice86.Core.Emulator.CPU.CfgCpu.Ast.Instruction;
 using Spice86.Core.Emulator.CPU.CfgCpu.InstructionExecutor;
-using Spice86.Core.Emulator.CPU.CfgCpu.InstructionRenderer;
 using Spice86.Shared.Emulator.Memory;
 
 public abstract class CfgNode : ICfgNode {
     private static int _nextId;
-    public CfgNode(SegmentedAddress address) {
+    public CfgNode(SegmentedAddress address, int? maxSuccessorsCount) {
         Address = address;
         Id = _nextId++;
+        MaxSuccessorsCount = maxSuccessorsCount;
     }
 
     public int Id { get; }
@@ -27,4 +26,10 @@ public abstract class CfgNode : ICfgNode {
     public abstract void Execute(InstructionExecutionHelper helper);
 
     public abstract InstructionNode ToInstructionAst(AstBuilder builder);
+
+    public int? MaxSuccessorsCount { get; set; }
+
+    public bool CanHaveMoreSuccessors { get; set; } = true;
+    
+    public ICfgNode? UniqueSuccessor { get; set; }
 }

--- a/src/Spice86.Core/Emulator/CPU/CfgCpu/ControlFlowGraph/ICfgNode.cs
+++ b/src/Spice86.Core/Emulator/CPU/CfgCpu/ControlFlowGraph/ICfgNode.cs
@@ -59,4 +59,20 @@ public interface ICfgNode {
     /// <param name="builder"></param>
     /// <returns></returns>
     public InstructionNode ToInstructionAst(AstBuilder builder);
+
+    /// <summary>
+    /// Max successors this node can be expected to have.
+    /// If null, it means the node can have an unlimited number of successors.
+    /// </summary>
+    public int? MaxSuccessorsCount { get; set; }
+    
+    /// <summary>
+    /// Whether the node can have more successors in its current state 
+    /// </summary>
+    public bool CanHaveMoreSuccessors { get; set; }
+    
+    /// <summary>
+    /// Direct access to successor for nodes with only one successor
+    /// </summary>
+    public ICfgNode? UniqueSuccessor { get; set; }
 }

--- a/src/Spice86.Core/Emulator/CPU/CfgCpu/Feeder/CfgNodeFeeder.cs
+++ b/src/Spice86.Core/Emulator/CPU/CfgCpu/Feeder/CfgNodeFeeder.cs
@@ -8,6 +8,8 @@ using Spice86.Core.Emulator.CPU.CfgCpu.ParsedInstruction.SelfModifying;
 using Spice86.Core.Emulator.Memory;
 using Spice86.Core.Emulator.VM.Breakpoint;
 
+using System.Diagnostics.CodeAnalysis;
+
 /// <summary>
 /// Handles coherency between the memory and the graph of instructions executed by the CPU.
 /// Next node to execute is normally the next node from the graph but several checks are done to make sure it is really it:
@@ -37,9 +39,10 @@ public class CfgNodeFeeder {
     public ICfgNode GetLinkedCfgNodeToExecute(ExecutionContext executionContext) {
         // Determine actual node to execute. Graph may not represent what is actually in memory if graph is not complete or if self modifying code
         ICfgNode toExecute = DetermineToExecute(executionContext.NodeToExecuteNextAccordingToGraph);
-        if (executionContext.LastExecuted != null) {
-            // Register what we found in the graph
-            _nodeLinker.Link(executionContext.LastExecuted, toExecute);
+        ICfgNode? lastExecuted = executionContext.LastExecuted;
+        if (lastExecuted is { CanHaveMoreSuccessors: true }) {
+            // Node can still have successors, try to register the link in the graph
+            _nodeLinker.Link(lastExecuted, toExecute);
         }
 
         return toExecute;

--- a/src/Spice86.Core/Emulator/CPU/CfgCpu/InstructionExecutor/InstructionExecutionHelper.cs
+++ b/src/Spice86.Core/Emulator/CPU/CfgCpu/InstructionExecutor/InstructionExecutionHelper.cs
@@ -202,6 +202,9 @@ public class InstructionExecutionHelper {
     }
 
     public ICfgNode? GetSuccessorAtCsIp(CfgInstruction instruction) {
+        if (instruction.UniqueSuccessor is not null) {
+            return instruction.UniqueSuccessor;
+        }
         instruction.SuccessorsPerAddress.TryGetValue(State.IpSegmentedAddress, out ICfgNode? res);
         return res;
     }
@@ -259,6 +262,8 @@ public class InstructionExecutionHelper {
             Stack.Push16(cpuException.ErrorCode.Value);
         }
         try {
+            // Link to the interrupt handler will likely need to be added
+            instruction.IncreaseMaxSuccessorsCount(InterruptVectorTable[cpuException.InterruptVector]);
             HandleInterruptCall(instruction, cpuException.InterruptVector);
         } catch (UnhandledOperationException e) {
             throw new AggregateException(cpuException, e);

--- a/src/Spice86.Core/Emulator/CPU/CfgCpu/ParsedInstruction/CfgInstruction.cs
+++ b/src/Spice86.Core/Emulator/CPU/CfgCpu/ParsedInstruction/CfgInstruction.cs
@@ -17,13 +17,13 @@ public abstract class CfgInstruction : CfgNode, ICfgInstruction {
     /// </summary>
     private bool _isLive = true;
 
-    protected CfgInstruction(SegmentedAddress address, InstructionField<ushort> opcodeField) : this(address,
-        opcodeField, new List<InstructionPrefix>()) {
+    protected CfgInstruction(SegmentedAddress address, InstructionField<ushort> opcodeField, int? maxSuccessorsCount) : this(address,
+        opcodeField, new List<InstructionPrefix>(), maxSuccessorsCount) {
     }
 
     protected CfgInstruction(SegmentedAddress address, InstructionField<ushort> opcodeField,
-        List<InstructionPrefix> prefixes)
-        : base(address) {
+        List<InstructionPrefix> prefixes, int? maxSuccessorsCount)
+        : base(address, maxSuccessorsCount) {
         InstructionPrefixes = prefixes;
         PrefixFields = prefixes.Select(prefix => prefix.PrefixField).ToList();
         foreach (InstructionPrefix prefix in prefixes) {
@@ -129,5 +129,15 @@ public abstract class CfgInstruction : CfgNode, ICfgInstruction {
     
     public void SetLive(bool isLive) {
         _isLive = isLive;
+    }
+
+    public void IncreaseMaxSuccessorsCount(SegmentedAddress target) {
+        if (MaxSuccessorsCount is not null && !SuccessorsPerAddress.ContainsKey(target)) {
+            // Ensure the subsequent link attempt will be done
+            CanHaveMoreSuccessors = true;
+            MaxSuccessorsCount++;
+            // Reset it. Will not be used anymore if MaxSuccessorsCount is now more than 1 or null.
+            UniqueSuccessor = null;
+        }
     }
 }

--- a/src/Spice86.Core/Emulator/CPU/CfgCpu/ParsedInstruction/Instructions/Aaa.cs
+++ b/src/Spice86.Core/Emulator/CPU/CfgCpu/ParsedInstruction/Instructions/Aaa.cs
@@ -7,7 +7,7 @@ using Spice86.Shared.Emulator.Memory;
 
 public class Aaa : CfgInstruction {
     public Aaa(SegmentedAddress address, InstructionField<ushort> opcodeField) :
-        base(address, opcodeField) {
+        base(address, opcodeField, 1) {
     }
 
     public override void Execute(InstructionExecutionHelper helper) {

--- a/src/Spice86.Core/Emulator/CPU/CfgCpu/ParsedInstruction/Instructions/Aad.cs
+++ b/src/Spice86.Core/Emulator/CPU/CfgCpu/ParsedInstruction/Instructions/Aad.cs
@@ -9,7 +9,7 @@ using Spice86.Shared.Emulator.Memory;
 
 public class Aad : InstructionWithValueField<byte> {
     public Aad(SegmentedAddress address, InstructionField<ushort> opcodeField, InstructionField<byte> valueField) :
-        base(address, opcodeField, new List<InstructionPrefix>(), valueField) {
+        base(address, opcodeField, new List<InstructionPrefix>(), valueField, 1) {
     }
 
     public override void Execute(InstructionExecutionHelper helper) {

--- a/src/Spice86.Core/Emulator/CPU/CfgCpu/ParsedInstruction/Instructions/Aam.cs
+++ b/src/Spice86.Core/Emulator/CPU/CfgCpu/ParsedInstruction/Instructions/Aam.cs
@@ -10,7 +10,7 @@ using Spice86.Shared.Emulator.Memory;
 
 public class Aam : InstructionWithValueField<byte> {
     public Aam(SegmentedAddress address, InstructionField<ushort> opcodeField, InstructionField<byte> valueField) :
-        base(address, opcodeField, new List<InstructionPrefix>(), valueField) {
+        base(address, opcodeField, new List<InstructionPrefix>(), valueField, 1) {
     }
 
     public override void Execute(InstructionExecutionHelper helper) {

--- a/src/Spice86.Core/Emulator/CPU/CfgCpu/ParsedInstruction/Instructions/Aas.cs
+++ b/src/Spice86.Core/Emulator/CPU/CfgCpu/ParsedInstruction/Instructions/Aas.cs
@@ -7,7 +7,7 @@ using Spice86.Shared.Emulator.Memory;
 
 public class Aas : CfgInstruction {
     public Aas(SegmentedAddress address, InstructionField<ushort> opcodeField) :
-        base(address, opcodeField) {
+        base(address, opcodeField, 1) {
     }
 
     public override void Execute(InstructionExecutionHelper helper) {

--- a/src/Spice86.Core/Emulator/CPU/CfgCpu/ParsedInstruction/Instructions/CallFarImm16.cs
+++ b/src/Spice86.Core/Emulator/CPU/CfgCpu/ParsedInstruction/Instructions/CallFarImm16.cs
@@ -11,7 +11,7 @@ public class CallFarImm16 : InstructionWithSegmentedAddressField {
         SegmentedAddress address,
         InstructionField<ushort> opcodeField,
         InstructionField<SegmentedAddress> segmentedAddressField) :
-        base(address, opcodeField, segmentedAddressField) {
+        base(address, opcodeField, segmentedAddressField, null) {
     }
 
     public override void Execute(InstructionExecutionHelper helper) {

--- a/src/Spice86.Core/Emulator/CPU/CfgCpu/ParsedInstruction/Instructions/CallNearImm.cs
+++ b/src/Spice86.Core/Emulator/CPU/CfgCpu/ParsedInstruction/Instructions/CallNearImm.cs
@@ -11,7 +11,7 @@ public class CallNearImm : InstructionWithOffsetField<short> {
     private readonly ushort _targetIp;
     public CallNearImm(SegmentedAddress address, InstructionField<ushort> opcodeField,
         List<InstructionPrefix> prefixes, InstructionField<short> offsetField) : base(address, opcodeField, prefixes,
-        offsetField) {
+        offsetField, null) {
         _targetIp = (ushort)(NextInMemoryAddress.Offset + offsetField.Value);
     }
 

--- a/src/Spice86.Core/Emulator/CPU/CfgCpu/ParsedInstruction/Instructions/Cbw16.cs
+++ b/src/Spice86.Core/Emulator/CPU/CfgCpu/ParsedInstruction/Instructions/Cbw16.cs
@@ -8,7 +8,7 @@ using Spice86.Shared.Emulator.Memory;
 
 public class Cbw16 : CfgInstruction {
     public Cbw16(SegmentedAddress address, InstructionField<ushort> opcodeField, List<InstructionPrefix> prefixes) :
-        base(address, opcodeField, prefixes) {
+        base(address, opcodeField, prefixes, 1) {
     }
 
     public override void Execute(InstructionExecutionHelper helper) {

--- a/src/Spice86.Core/Emulator/CPU/CfgCpu/ParsedInstruction/Instructions/Cbw32.cs
+++ b/src/Spice86.Core/Emulator/CPU/CfgCpu/ParsedInstruction/Instructions/Cbw32.cs
@@ -8,7 +8,7 @@ using Spice86.Shared.Emulator.Memory;
 
 public class Cbw32 : CfgInstruction {
     public Cbw32(SegmentedAddress address, InstructionField<ushort> opcodeField, List<InstructionPrefix> prefixes) :
-        base(address, opcodeField, prefixes) {
+        base(address, opcodeField, prefixes, 1) {
     }
 
     public override void Execute(InstructionExecutionHelper helper) {

--- a/src/Spice86.Core/Emulator/CPU/CfgCpu/ParsedInstruction/Instructions/CommonGrammar/EnterInstruction.cs
+++ b/src/Spice86.Core/Emulator/CPU/CfgCpu/ParsedInstruction/Instructions/CommonGrammar/EnterInstruction.cs
@@ -7,7 +7,8 @@ public abstract class EnterInstruction : CfgInstruction {
     public EnterInstruction(SegmentedAddress address,
         InstructionField<ushort> opcodeField, List<InstructionPrefix> prefixes,
         InstructionField<ushort> storageField,
-        InstructionField<byte> levelField) : base(address, opcodeField, prefixes) {
+        InstructionField<byte> levelField,
+        int? maxSuccessorsCount) : base(address, opcodeField, prefixes, maxSuccessorsCount) {
         StorageField = storageField;
         LevelField = levelField;
         AddField(StorageField);

--- a/src/Spice86.Core/Emulator/CPU/CfgCpu/ParsedInstruction/Instructions/CommonGrammar/InstructionWithModRmAndValueField.cs
+++ b/src/Spice86.Core/Emulator/CPU/CfgCpu/ParsedInstruction/Instructions/CommonGrammar/InstructionWithModRmAndValueField.cs
@@ -9,7 +9,7 @@ using System.Numerics;
 
 public abstract class InstructionWithModRmAndValueField<T> : InstructionWithModRm, IInstructionWithValueField<T> where T : INumberBase<T>  {
     protected InstructionWithModRmAndValueField(SegmentedAddress address, InstructionField<ushort> opcodeField, List<InstructionPrefix> prefixes,
-        ModRmContext modRmContext, InstructionField<T> valueField) : base(address, opcodeField, prefixes, modRmContext) {
+        ModRmContext modRmContext, InstructionField<T> valueField, int? maxSuccessorsCount) : base(address, opcodeField, prefixes, modRmContext, maxSuccessorsCount) {
         ValueField = valueField;
         AddField(ValueField);
     }

--- a/src/Spice86.Core/Emulator/CPU/CfgCpu/ParsedInstruction/Instructions/CommonGrammar/InstructionWithOffsetField.cs
+++ b/src/Spice86.Core/Emulator/CPU/CfgCpu/ParsedInstruction/Instructions/CommonGrammar/InstructionWithOffsetField.cs
@@ -7,8 +7,8 @@ using Spice86.Shared.Emulator.Memory;
 using System.Numerics;
 
 public abstract class InstructionWithOffsetField<T> : CfgInstruction, IInstructionWithOffsetField<T> where T : INumberBase<T> {
-    public InstructionWithOffsetField(SegmentedAddress address, InstructionField<ushort> opcodeField, List<InstructionPrefix> prefixes, InstructionField<T> offsetField) :
-        base(address, opcodeField, prefixes) {
+    public InstructionWithOffsetField(SegmentedAddress address, InstructionField<ushort> opcodeField, List<InstructionPrefix> prefixes, InstructionField<T> offsetField, int? maxSuccessorsCount) :
+        base(address, opcodeField, prefixes, maxSuccessorsCount) {
         OffsetField = offsetField;
         AddField(OffsetField);
     }

--- a/src/Spice86.Core/Emulator/CPU/CfgCpu/ParsedInstruction/Instructions/CommonGrammar/InstructionWithRegisterIndex.cs
+++ b/src/Spice86.Core/Emulator/CPU/CfgCpu/ParsedInstruction/Instructions/CommonGrammar/InstructionWithRegisterIndex.cs
@@ -8,8 +8,8 @@ public abstract class InstructionWithRegisterIndex : CfgInstruction, IInstructio
     protected InstructionWithRegisterIndex(SegmentedAddress address,
         InstructionField<ushort> opcodeField,
         List<InstructionPrefix> prefixes,
-        int registerIndex) :
-        base(address, opcodeField, prefixes) {
+        int registerIndex, int? maxSuccessorsCount) :
+        base(address, opcodeField, prefixes, maxSuccessorsCount) {
         RegisterIndex = registerIndex;
     }
     public int RegisterIndex { get; }

--- a/src/Spice86.Core/Emulator/CPU/CfgCpu/ParsedInstruction/Instructions/CommonGrammar/InstructionWithSegmentRegisterIndex.cs
+++ b/src/Spice86.Core/Emulator/CPU/CfgCpu/ParsedInstruction/Instructions/CommonGrammar/InstructionWithSegmentRegisterIndex.cs
@@ -5,7 +5,12 @@ using Spice86.Core.Emulator.CPU.CfgCpu.ParsedInstruction.Prefix;
 using Spice86.Shared.Emulator.Memory;
 
 public abstract class InstructionWithSegmentRegisterIndex: CfgInstruction, IInstructionWithSegmentRegisterIndex {
-    protected InstructionWithSegmentRegisterIndex(SegmentedAddress address, InstructionField<ushort> opcodeField, List<InstructionPrefix> prefixes, int segmentRegisterIndex) : base(address, opcodeField, prefixes) {
+    protected InstructionWithSegmentRegisterIndex(
+        SegmentedAddress address,
+        InstructionField<ushort> opcodeField,
+        List<InstructionPrefix> prefixes,
+        int segmentRegisterIndex,
+        int? maxSuccessorsCount) : base(address, opcodeField, prefixes, maxSuccessorsCount) {
         SegmentRegisterIndex = segmentRegisterIndex;
     }
     

--- a/src/Spice86.Core/Emulator/CPU/CfgCpu/ParsedInstruction/Instructions/CommonGrammar/InstructionWithSegmentRegisterIndexAndOffsetField.cs
+++ b/src/Spice86.Core/Emulator/CPU/CfgCpu/ParsedInstruction/Instructions/CommonGrammar/InstructionWithSegmentRegisterIndexAndOffsetField.cs
@@ -5,7 +5,13 @@ using Spice86.Core.Emulator.CPU.CfgCpu.ParsedInstruction.Prefix;
 using Spice86.Shared.Emulator.Memory;
 
 public abstract class InstructionWithSegmentRegisterIndexAndOffsetField<T>: CfgInstruction, IInstructionWithSegmentRegisterIndex, IInstructionWithOffsetField<T> {
-    protected InstructionWithSegmentRegisterIndexAndOffsetField(SegmentedAddress address, InstructionField<ushort> opcodeField, List<InstructionPrefix> prefixes, int segmentRegisterIndex, InstructionField<T> offsetField) : base(address, opcodeField, prefixes) {
+    protected InstructionWithSegmentRegisterIndexAndOffsetField(
+        SegmentedAddress address,
+        InstructionField<ushort> opcodeField,
+        List<InstructionPrefix> prefixes,
+        int segmentRegisterIndex,
+        InstructionField<T> offsetField,
+        int? maxSuccessorsCount) : base(address, opcodeField, prefixes, maxSuccessorsCount) {
         SegmentRegisterIndex = segmentRegisterIndex;
         OffsetField = offsetField;
         AddField(offsetField);

--- a/src/Spice86.Core/Emulator/CPU/CfgCpu/ParsedInstruction/Instructions/CommonGrammar/InstructionWithSegmentedAddressField.cs
+++ b/src/Spice86.Core/Emulator/CPU/CfgCpu/ParsedInstruction/Instructions/CommonGrammar/InstructionWithSegmentedAddressField.cs
@@ -6,8 +6,9 @@ public abstract class InstructionWithSegmentedAddressField : CfgInstruction {
     public InstructionWithSegmentedAddressField(
         SegmentedAddress address,
         InstructionField<ushort> opcodeField,
-        InstructionField<SegmentedAddress> segmentedAddressField) :
-        base(address, opcodeField) {
+        InstructionField<SegmentedAddress> segmentedAddressField,
+        int? maxSuccessorsCount) :
+        base(address, opcodeField, maxSuccessorsCount) {
         SegmentedAddressField = segmentedAddressField;
         AddField(segmentedAddressField);
     }

--- a/src/Spice86.Core/Emulator/CPU/CfgCpu/ParsedInstruction/Instructions/CommonGrammar/InstructionWithValueField.cs
+++ b/src/Spice86.Core/Emulator/CPU/CfgCpu/ParsedInstruction/Instructions/CommonGrammar/InstructionWithValueField.cs
@@ -10,14 +10,19 @@ public abstract class InstructionWithValueField<T> : CfgInstruction, IInstructio
     protected InstructionWithValueField(SegmentedAddress address,
         InstructionField<ushort> opcodeField,
         List<InstructionPrefix> prefixes,
-        InstructionField<T> valueField) :
-        base(address, opcodeField, prefixes) {
+        InstructionField<T> valueField,
+        int? maxSuccessorsCount) :
+        base(address, opcodeField, prefixes, maxSuccessorsCount) {
         ValueField = valueField;
         AddField(ValueField);
     }
     
-    protected InstructionWithValueField(SegmentedAddress address, InstructionField<ushort> opcodeField, InstructionField<T> valueField) : this(address,
-        opcodeField, new List<InstructionPrefix>(), valueField) {
+    protected InstructionWithValueField(
+        SegmentedAddress address,
+        InstructionField<ushort> opcodeField,
+        InstructionField<T> valueField,
+        int? maxSuccessorsCount) : this(address,
+        opcodeField, new List<InstructionPrefix>(), valueField, maxSuccessorsCount) {
     }
 
     public InstructionField<T> ValueField { get; }

--- a/src/Spice86.Core/Emulator/CPU/CfgCpu/ParsedInstruction/Instructions/CommonGrammar/InstructionWithValueFieldAndRegisterIndex.cs
+++ b/src/Spice86.Core/Emulator/CPU/CfgCpu/ParsedInstruction/Instructions/CommonGrammar/InstructionWithValueFieldAndRegisterIndex.cs
@@ -11,8 +11,9 @@ public abstract class InstructionWithValueFieldAndRegisterIndex<T> : Instruction
         InstructionField<ushort> opcodeField,
         List<InstructionPrefix> prefixes,
         InstructionField<T> valueField,
-        int registerIndex) :
-        base(address, opcodeField, prefixes, valueField) {
+        int registerIndex,
+        int? maxSuccessorsCount) :
+        base(address, opcodeField, prefixes, valueField, maxSuccessorsCount) {
         RegisterIndex = registerIndex;
     }
 

--- a/src/Spice86.Core/Emulator/CPU/CfgCpu/ParsedInstruction/Instructions/Cwd16.cs
+++ b/src/Spice86.Core/Emulator/CPU/CfgCpu/ParsedInstruction/Instructions/Cwd16.cs
@@ -8,7 +8,7 @@ using Spice86.Shared.Emulator.Memory;
 
 public class Cwd16 : CfgInstruction {
     public Cwd16(SegmentedAddress address, InstructionField<ushort> opcodeField, List<InstructionPrefix> prefixes) :
-        base(address, opcodeField, prefixes) {
+        base(address, opcodeField, prefixes, 1) {
     }
 
     public override void Execute(InstructionExecutionHelper helper) {

--- a/src/Spice86.Core/Emulator/CPU/CfgCpu/ParsedInstruction/Instructions/Cwd32.cs
+++ b/src/Spice86.Core/Emulator/CPU/CfgCpu/ParsedInstruction/Instructions/Cwd32.cs
@@ -8,7 +8,7 @@ using Spice86.Shared.Emulator.Memory;
 
 public class Cwd32 : CfgInstruction {
     public Cwd32(SegmentedAddress address, InstructionField<ushort> opcodeField, List<InstructionPrefix> prefixes) :
-        base(address, opcodeField, prefixes) {
+        base(address, opcodeField, prefixes, 1) {
     }
 
     public override void Execute(InstructionExecutionHelper helper) {

--- a/src/Spice86.Core/Emulator/CPU/CfgCpu/ParsedInstruction/Instructions/Daa.cs
+++ b/src/Spice86.Core/Emulator/CPU/CfgCpu/ParsedInstruction/Instructions/Daa.cs
@@ -7,7 +7,7 @@ using Spice86.Shared.Emulator.Memory;
 
 public class Daa : CfgInstruction {
     public Daa(SegmentedAddress address, InstructionField<ushort> opcodeField) :
-        base(address, opcodeField) {
+        base(address, opcodeField, 1) {
     }
 
     public override void Execute(InstructionExecutionHelper helper) {

--- a/src/Spice86.Core/Emulator/CPU/CfgCpu/ParsedInstruction/Instructions/Das.cs
+++ b/src/Spice86.Core/Emulator/CPU/CfgCpu/ParsedInstruction/Instructions/Das.cs
@@ -7,7 +7,7 @@ using Spice86.Shared.Emulator.Memory;
 
 public class Das : CfgInstruction {
     public Das(SegmentedAddress address, InstructionField<ushort> opcodeField) :
-        base(address, opcodeField) {
+        base(address, opcodeField, 1) {
     }
 
     public override void Execute(InstructionExecutionHelper helper) {

--- a/src/Spice86.Core/Emulator/CPU/CfgCpu/ParsedInstruction/Instructions/FnInit.cs
+++ b/src/Spice86.Core/Emulator/CPU/CfgCpu/ParsedInstruction/Instructions/FnInit.cs
@@ -8,7 +8,7 @@ using Spice86.Shared.Emulator.Memory;
 
 public class FnInit : CfgInstruction {
 
-    public FnInit(SegmentedAddress address, InstructionField<ushort> opcodeField, List<InstructionPrefix> prefixes) : base(address, opcodeField, prefixes) {
+    public FnInit(SegmentedAddress address, InstructionField<ushort> opcodeField, List<InstructionPrefix> prefixes) : base(address, opcodeField, prefixes, 1) {
     }
     public override void Execute(InstructionExecutionHelper helper) {
         // Do nothing, no FPU emulation, but this is used to detect FPU support.

--- a/src/Spice86.Core/Emulator/CPU/CfgCpu/ParsedInstruction/Instructions/Fnstcw.cs
+++ b/src/Spice86.Core/Emulator/CPU/CfgCpu/ParsedInstruction/Instructions/Fnstcw.cs
@@ -9,7 +9,7 @@ using Spice86.Shared.Emulator.Memory;
 
 public class Fnstcw : InstructionWithModRm {
 
-    public Fnstcw(SegmentedAddress address, InstructionField<ushort> opcodeField, List<InstructionPrefix> prefixes, ModRmContext modRmContext) : base(address, opcodeField, prefixes, modRmContext) {
+    public Fnstcw(SegmentedAddress address, InstructionField<ushort> opcodeField, List<InstructionPrefix> prefixes, ModRmContext modRmContext) : base(address, opcodeField, prefixes, modRmContext, 1) {
     }
     public override void Execute(InstructionExecutionHelper helper) {
         helper.ModRm.RefreshWithNewModRmContext(ModRmContext);

--- a/src/Spice86.Core/Emulator/CPU/CfgCpu/ParsedInstruction/Instructions/Fnstsw.cs
+++ b/src/Spice86.Core/Emulator/CPU/CfgCpu/ParsedInstruction/Instructions/Fnstsw.cs
@@ -9,7 +9,7 @@ using Spice86.Shared.Emulator.Memory;
 
 public class Fnstsw : InstructionWithModRm {
 
-    public Fnstsw(SegmentedAddress address, InstructionField<ushort> opcodeField, List<InstructionPrefix> prefixes, ModRmContext modRmContext) : base(address, opcodeField, prefixes, modRmContext) {
+    public Fnstsw(SegmentedAddress address, InstructionField<ushort> opcodeField, List<InstructionPrefix> prefixes, ModRmContext modRmContext) : base(address, opcodeField, prefixes, modRmContext, 1) {
     }
     public override void Execute(InstructionExecutionHelper helper) {
         helper.ModRm.RefreshWithNewModRmContext(ModRmContext);

--- a/src/Spice86.Core/Emulator/CPU/CfgCpu/ParsedInstruction/Instructions/Grp4Callback.cs
+++ b/src/Spice86.Core/Emulator/CPU/CfgCpu/ParsedInstruction/Instructions/Grp4Callback.cs
@@ -10,7 +10,7 @@ using Spice86.Shared.Emulator.Memory;
 public class Grp4Callback : InstructionWithModRm {
     public Grp4Callback(SegmentedAddress address, InstructionField<ushort> opcodeField, List<InstructionPrefix> prefixes,
         ModRmContext modRmContext, InstructionField<byte> callbackNumber) : base(address, opcodeField, prefixes,
-        modRmContext) {
+        modRmContext, null) {
         CallbackNumber = callbackNumber;
         AddField(callbackNumber);
     }

--- a/src/Spice86.Core/Emulator/CPU/CfgCpu/ParsedInstruction/Instructions/Grp5RmCallFar.cs
+++ b/src/Spice86.Core/Emulator/CPU/CfgCpu/ParsedInstruction/Instructions/Grp5RmCallFar.cs
@@ -11,7 +11,7 @@ using Spice86.Shared.Emulator.Memory;
 public class Grp5RmCallFar : InstructionWithModRm {
     public Grp5RmCallFar(SegmentedAddress address, InstructionField<ushort> opcodeField,
         List<InstructionPrefix> prefixes, ModRmContext modRmContext) : base(address, opcodeField, prefixes,
-        modRmContext) {
+        modRmContext, null) {
     }
 
     public override void Execute(InstructionExecutionHelper helper) {

--- a/src/Spice86.Core/Emulator/CPU/CfgCpu/ParsedInstruction/Instructions/Grp5RmCallNear.cs
+++ b/src/Spice86.Core/Emulator/CPU/CfgCpu/ParsedInstruction/Instructions/Grp5RmCallNear.cs
@@ -11,7 +11,7 @@ using Spice86.Shared.Emulator.Memory;
 public class Grp5RmCallNear : InstructionWithModRm {
     public Grp5RmCallNear(SegmentedAddress address, InstructionField<ushort> opcodeField,
         List<InstructionPrefix> prefixes, ModRmContext modRmContext) : base(address, opcodeField, prefixes,
-        modRmContext) {
+        modRmContext, null) {
     }
     
     public override void Execute(InstructionExecutionHelper helper) {

--- a/src/Spice86.Core/Emulator/CPU/CfgCpu/ParsedInstruction/Instructions/Grp5RmJumpFar.cs
+++ b/src/Spice86.Core/Emulator/CPU/CfgCpu/ParsedInstruction/Instructions/Grp5RmJumpFar.cs
@@ -11,7 +11,7 @@ using Spice86.Shared.Emulator.Memory;
 public class Grp5RmJumpFar : InstructionWithModRm {
     public Grp5RmJumpFar(SegmentedAddress address, InstructionField<ushort> opcodeField,
         List<InstructionPrefix> prefixes, ModRmContext modRmContext) : base(address, opcodeField, prefixes,
-        modRmContext) {
+        modRmContext, null) {
     }
     
     public override void Execute(InstructionExecutionHelper helper) {

--- a/src/Spice86.Core/Emulator/CPU/CfgCpu/ParsedInstruction/Instructions/Grp5RmJumpNear.cs
+++ b/src/Spice86.Core/Emulator/CPU/CfgCpu/ParsedInstruction/Instructions/Grp5RmJumpNear.cs
@@ -11,7 +11,7 @@ using Spice86.Shared.Emulator.Memory;
 public class Grp5RmJumpNear : InstructionWithModRm {
     public Grp5RmJumpNear(SegmentedAddress address, InstructionField<ushort> opcodeField,
         List<InstructionPrefix> prefixes, ModRmContext modRmContext) : base(address, opcodeField, prefixes,
-        modRmContext) {
+        modRmContext, null) {
     }
 
     public override void Execute(InstructionExecutionHelper helper) {

--- a/src/Spice86.Core/Emulator/CPU/CfgCpu/ParsedInstruction/Instructions/Hlt.cs
+++ b/src/Spice86.Core/Emulator/CPU/CfgCpu/ParsedInstruction/Instructions/Hlt.cs
@@ -7,7 +7,7 @@ using Spice86.Shared.Emulator.Memory;
 
 public class Hlt : CfgInstruction {
     public Hlt(SegmentedAddress address, InstructionField<ushort> opcodeField) :
-        base(address, opcodeField) {
+        base(address, opcodeField, 0) {
     }
 
     public override void Execute(InstructionExecutionHelper helper) {

--- a/src/Spice86.Core/Emulator/CPU/CfgCpu/ParsedInstruction/Instructions/Interrupt.cs
+++ b/src/Spice86.Core/Emulator/CPU/CfgCpu/ParsedInstruction/Instructions/Interrupt.cs
@@ -8,7 +8,7 @@ using Spice86.Shared.Emulator.Memory;
 
 public class Interrupt : InstructionWithValueField<byte> {
     public Interrupt(SegmentedAddress address, InstructionField<ushort> opcodeField,
-        InstructionField<byte> valueField) : base(address, opcodeField, valueField) {
+        InstructionField<byte> valueField) : base(address, opcodeField, valueField, null) {
     }
 
     public override void Execute(InstructionExecutionHelper helper) {

--- a/src/Spice86.Core/Emulator/CPU/CfgCpu/ParsedInstruction/Instructions/Interrupt3.cs
+++ b/src/Spice86.Core/Emulator/CPU/CfgCpu/ParsedInstruction/Instructions/Interrupt3.cs
@@ -6,7 +6,7 @@ using Spice86.Core.Emulator.CPU.CfgCpu.InstructionExecutor;
 using Spice86.Shared.Emulator.Memory;
 
 public class Interrupt3 : CfgInstruction {
-    public Interrupt3(SegmentedAddress address, InstructionField<ushort> opcodeField) : base(address, opcodeField) {
+    public Interrupt3(SegmentedAddress address, InstructionField<ushort> opcodeField) : base(address, opcodeField, null) {
     }
 
     public override void Execute(InstructionExecutionHelper helper) {

--- a/src/Spice86.Core/Emulator/CPU/CfgCpu/ParsedInstruction/Instructions/InterruptOverflow.cs
+++ b/src/Spice86.Core/Emulator/CPU/CfgCpu/ParsedInstruction/Instructions/InterruptOverflow.cs
@@ -6,7 +6,7 @@ using Spice86.Core.Emulator.CPU.CfgCpu.InstructionExecutor;
 using Spice86.Shared.Emulator.Memory;
 
 public class InterruptOverflow : CfgInstruction {
-    public InterruptOverflow(SegmentedAddress address, InstructionField<ushort> opcodeField) : base(address, opcodeField) {
+    public InterruptOverflow(SegmentedAddress address, InstructionField<ushort> opcodeField) : base(address, opcodeField, null) {
     }
 
     public override void Execute(InstructionExecutionHelper helper) {

--- a/src/Spice86.Core/Emulator/CPU/CfgCpu/ParsedInstruction/Instructions/JmpFarImm.cs
+++ b/src/Spice86.Core/Emulator/CPU/CfgCpu/ParsedInstruction/Instructions/JmpFarImm.cs
@@ -13,7 +13,7 @@ public class JmpFarImm : InstructionWithSegmentedAddressField {
         SegmentedAddress address,
         InstructionField<ushort> opcodeField,
         InstructionField<SegmentedAddress> segmentedAddressField) :
-        base(address, opcodeField, segmentedAddressField) {
+        base(address, opcodeField, segmentedAddressField, 1) {
         _targetAddress = SegmentedAddressField.Value;
     }
 

--- a/src/Spice86.Core/Emulator/CPU/CfgCpu/ParsedInstruction/Instructions/Lahf.cs
+++ b/src/Spice86.Core/Emulator/CPU/CfgCpu/ParsedInstruction/Instructions/Lahf.cs
@@ -7,7 +7,7 @@ using Spice86.Shared.Emulator.Memory;
 
 public class Lahf : CfgInstruction {
     public Lahf(SegmentedAddress address, InstructionField<ushort> opcodeField) :
-        base(address, opcodeField) {
+        base(address, opcodeField, 1) {
     }
 
     public override void Execute(InstructionExecutionHelper helper) {

--- a/src/Spice86.Core/Emulator/CPU/CfgCpu/ParsedInstruction/Instructions/Mixins/Cmps.mixin
+++ b/src/Spice86.Core/Emulator/CPU/CfgCpu/ParsedInstruction/Instructions/Mixins/Cmps.mixin
@@ -15,7 +15,7 @@ using Spice86.Shared.Emulator.Memory;
 
 public partial class {{ moxy.Class.Name }} : InstructionWithSegmentRegisterIndex, StringInstruction {
     public {{ moxy.Class.Name }}(SegmentedAddress address,
-        InstructionField<ushort> opcodeField, List<InstructionPrefix> prefixes, int segmentRegisterIndex) : base(address, opcodeField, prefixes, segmentRegisterIndex) {
+        InstructionField<ushort> opcodeField, List<InstructionPrefix> prefixes, int segmentRegisterIndex) : base(address, opcodeField, prefixes, segmentRegisterIndex, 1) {
     }
 
     public bool ChangesFlags => true;

--- a/src/Spice86.Core/Emulator/CPU/CfgCpu/ParsedInstruction/Instructions/Mixins/Enter.mixin
+++ b/src/Spice86.Core/Emulator/CPU/CfgCpu/ParsedInstruction/Instructions/Mixins/Enter.mixin
@@ -18,7 +18,7 @@ public partial class {{ moxy.Class.Name }} : EnterInstruction {
     public {{ moxy.Class.Name }}(SegmentedAddress address,
         InstructionField<ushort> opcodeField, List<InstructionPrefix> prefixes,
         InstructionField<ushort> storageField,
-        InstructionField<byte> levelField) : base(address, opcodeField, prefixes, storageField, levelField) {
+        InstructionField<byte> levelField) : base(address, opcodeField, prefixes, storageField, levelField, 1) {
     }
     
     public override void Execute(InstructionExecutionHelper helper) {

--- a/src/Spice86.Core/Emulator/CPU/CfgCpu/ParsedInstruction/Instructions/Mixins/FlagControl.mixin
+++ b/src/Spice86.Core/Emulator/CPU/CfgCpu/ParsedInstruction/Instructions/Mixins/FlagControl.mixin
@@ -12,7 +12,7 @@ using Spice86.Shared.Emulator.Memory;
 
 public partial class {{ moxy.Class.Name }} : CfgInstruction {
     public {{ moxy.Class.Name }}(SegmentedAddress address, InstructionField<ushort> opcodeField) :
-        base(address, opcodeField) {
+        base(address, opcodeField, 1) {
     }
 
     public override void Execute(InstructionExecutionHelper helper) {

--- a/src/Spice86.Core/Emulator/CPU/CfgCpu/ParsedInstruction/Instructions/Mixins/Grp1.mixin
+++ b/src/Spice86.Core/Emulator/CPU/CfgCpu/ParsedInstruction/Instructions/Mixins/Grp1.mixin
@@ -19,7 +19,7 @@ using Spice86.Shared.Emulator.Memory;
 public partial class {{ moxy.Class.Name }} : InstructionWithModRmAndValueField<{{Type}}> {
     public {{ moxy.Class.Name }}(SegmentedAddress address, InstructionField<ushort> opcodeField, List<InstructionPrefix> prefixes,
         ModRmContext modRmContext, InstructionField<{{Type}}> valueField) : base(address, opcodeField, prefixes,
-        modRmContext, valueField) {
+        modRmContext, valueField, 1) {
     }
     
     public override void Execute(InstructionExecutionHelper helper) {

--- a/src/Spice86.Core/Emulator/CPU/CfgCpu/ParsedInstruction/Instructions/Mixins/Grp2RmOp.mixin
+++ b/src/Spice86.Core/Emulator/CPU/CfgCpu/ParsedInstruction/Instructions/Mixins/Grp2RmOp.mixin
@@ -16,7 +16,7 @@ using Spice86.Shared.Emulator.Memory;
 
 public partial class {{ moxy.Class.Name }} : InstructionWithModRm {
     public {{ moxy.Class.Name }}(SegmentedAddress address, InstructionField<ushort> opcodeField, List<InstructionPrefix> prefixes,
-         ModRmContext modRmContext) : base(address, opcodeField, prefixes, modRmContext) {
+         ModRmContext modRmContext) : base(address, opcodeField, prefixes, modRmContext, 1) {
      }
     
     public override void Execute(InstructionExecutionHelper helper) {

--- a/src/Spice86.Core/Emulator/CPU/CfgCpu/ParsedInstruction/Instructions/Mixins/Grp2RmOpImm.mixin
+++ b/src/Spice86.Core/Emulator/CPU/CfgCpu/ParsedInstruction/Instructions/Mixins/Grp2RmOpImm.mixin
@@ -15,7 +15,7 @@ using Spice86.Shared.Emulator.Memory;
 
 public partial class {{ moxy.Class.Name }} : InstructionWithModRmAndValueField<byte> {
     public {{ moxy.Class.Name }}(SegmentedAddress address, InstructionField<ushort> opcodeField, List<InstructionPrefix> prefixes,
-         ModRmContext modRmContext, InstructionField<byte> valueField) : base(address, opcodeField, prefixes, modRmContext, valueField) {
+         ModRmContext modRmContext, InstructionField<byte> valueField) : base(address, opcodeField, prefixes, modRmContext, valueField, 1) {
      }
     
     public override void Execute(InstructionExecutionHelper helper) {

--- a/src/Spice86.Core/Emulator/CPU/CfgCpu/ParsedInstruction/Instructions/Mixins/Grp3DivRmAcc.mixin
+++ b/src/Spice86.Core/Emulator/CPU/CfgCpu/ParsedInstruction/Instructions/Mixins/Grp3DivRmAcc.mixin
@@ -21,7 +21,7 @@ using Spice86.Shared.Emulator.Memory;
 
 public partial class {{ moxy.Class.Name }} : InstructionWithModRm {
     public {{ moxy.Class.Name }}(SegmentedAddress address, InstructionField<ushort> opcodeField, List<InstructionPrefix> prefixes,
-         ModRmContext modRmContext) : base(address, opcodeField, prefixes, modRmContext) {
+         ModRmContext modRmContext) : base(address, opcodeField, prefixes, modRmContext, 1) {
      }
     
     public override void Execute(InstructionExecutionHelper helper) {

--- a/src/Spice86.Core/Emulator/CPU/CfgCpu/ParsedInstruction/Instructions/Mixins/Grp3MulRmAcc.mixin
+++ b/src/Spice86.Core/Emulator/CPU/CfgCpu/ParsedInstruction/Instructions/Mixins/Grp3MulRmAcc.mixin
@@ -19,7 +19,7 @@ using Spice86.Shared.Emulator.Memory;
 
 public partial class {{ moxy.Class.Name }} : InstructionWithModRm {
     public {{ moxy.Class.Name }}(SegmentedAddress address, InstructionField<ushort> opcodeField, List<InstructionPrefix> prefixes,
-         ModRmContext modRmContext) : base(address, opcodeField, prefixes, modRmContext) {
+         ModRmContext modRmContext) : base(address, opcodeField, prefixes, modRmContext, 1) {
      }
     
     public override void Execute(InstructionExecutionHelper helper) {

--- a/src/Spice86.Core/Emulator/CPU/CfgCpu/ParsedInstruction/Instructions/Mixins/Grp3NegRm.mixin
+++ b/src/Spice86.Core/Emulator/CPU/CfgCpu/ParsedInstruction/Instructions/Mixins/Grp3NegRm.mixin
@@ -14,7 +14,7 @@ using Spice86.Shared.Emulator.Memory;
 
 public partial class {{ moxy.Class.Name }} : InstructionWithModRm {
     public {{ moxy.Class.Name }}(SegmentedAddress address, InstructionField<ushort> opcodeField, List<InstructionPrefix> prefixes,
-         ModRmContext modRmContext) : base(address, opcodeField, prefixes, modRmContext) {
+         ModRmContext modRmContext) : base(address, opcodeField, prefixes, modRmContext, 1) {
      }
     
     public override void Execute(InstructionExecutionHelper helper) {

--- a/src/Spice86.Core/Emulator/CPU/CfgCpu/ParsedInstruction/Instructions/Mixins/Grp3NotRm.mixin
+++ b/src/Spice86.Core/Emulator/CPU/CfgCpu/ParsedInstruction/Instructions/Mixins/Grp3NotRm.mixin
@@ -14,7 +14,7 @@ using Spice86.Shared.Emulator.Memory;
 
 public partial class {{ moxy.Class.Name }} : InstructionWithModRm {
     public {{ moxy.Class.Name }}(SegmentedAddress address, InstructionField<ushort> opcodeField, List<InstructionPrefix> prefixes,
-         ModRmContext modRmContext) : base(address, opcodeField, prefixes, modRmContext) {
+         ModRmContext modRmContext) : base(address, opcodeField, prefixes, modRmContext, 1) {
      }
     
     public override void Execute(InstructionExecutionHelper helper) {

--- a/src/Spice86.Core/Emulator/CPU/CfgCpu/ParsedInstruction/Instructions/Mixins/Grp3TestRmImm.mixin
+++ b/src/Spice86.Core/Emulator/CPU/CfgCpu/ParsedInstruction/Instructions/Mixins/Grp3TestRmImm.mixin
@@ -16,7 +16,7 @@ using Spice86.Shared.Emulator.Memory;
 public partial class {{ moxy.Class.Name }} : InstructionWithModRmAndValueField<{{Type}}> {
     public {{ moxy.Class.Name }}(SegmentedAddress address, InstructionField<ushort> opcodeField, List<InstructionPrefix> prefixes,
          ModRmContext modRmContext, InstructionField<{{Type}}> valueField) : base(address, opcodeField, prefixes,
-         modRmContext, valueField) {
+         modRmContext, valueField, 1) {
      }
     
     public override void Execute(InstructionExecutionHelper helper) {

--- a/src/Spice86.Core/Emulator/CPU/CfgCpu/ParsedInstruction/Instructions/Mixins/Grp45RmIncDec.mixin
+++ b/src/Spice86.Core/Emulator/CPU/CfgCpu/ParsedInstruction/Instructions/Mixins/Grp45RmIncDec.mixin
@@ -14,7 +14,7 @@ using Spice86.Shared.Emulator.Memory;
 
 public partial class {{ moxy.Class.Name }} : InstructionWithModRm {
     public {{ moxy.Class.Name }}(SegmentedAddress address, InstructionField<ushort> opcodeField, List<InstructionPrefix> prefixes,
-        ModRmContext modRmContext) : base(address, opcodeField, prefixes, modRmContext) {
+        ModRmContext modRmContext) : base(address, opcodeField, prefixes, modRmContext, 1) {
     }
     
     public override void Execute(InstructionExecutionHelper helper) {

--- a/src/Spice86.Core/Emulator/CPU/CfgCpu/ParsedInstruction/Instructions/Mixins/Grp5RmPush.mixin
+++ b/src/Spice86.Core/Emulator/CPU/CfgCpu/ParsedInstruction/Instructions/Mixins/Grp5RmPush.mixin
@@ -14,7 +14,7 @@ using Spice86.Shared.Emulator.Memory;
 public partial class {{ moxy.Class.Name }} : InstructionWithModRm {
     public {{ moxy.Class.Name }}(SegmentedAddress address, InstructionField<ushort> opcodeField,
         List<InstructionPrefix> prefixes, ModRmContext modRmContext) : base(address, opcodeField, prefixes,
-        modRmContext) {
+        modRmContext, 1) {
     }
     
     public override void Execute(InstructionExecutionHelper helper) {

--- a/src/Spice86.Core/Emulator/CPU/CfgCpu/ParsedInstruction/Instructions/Mixins/ImulImmRm.mixin
+++ b/src/Spice86.Core/Emulator/CPU/CfgCpu/ParsedInstruction/Instructions/Mixins/ImulImmRm.mixin
@@ -19,7 +19,7 @@ using Spice86.Shared.Emulator.Memory;
 public partial class {{ moxy.Class.Name }} : InstructionWithModRmAndValueField<{{ImmSignedType}}> {
     public {{ moxy.Class.Name }}(SegmentedAddress address, InstructionField<ushort> opcodeField, List<InstructionPrefix> prefixes,
         ModRmContext modRmContext, InstructionField<{{ImmSignedType}}> valueField) : base(address, opcodeField, prefixes,
-        modRmContext, valueField) {
+        modRmContext, valueField, 1) {
     }
     
     public override void Execute(InstructionExecutionHelper helper) {

--- a/src/Spice86.Core/Emulator/CPU/CfgCpu/ParsedInstruction/Instructions/Mixins/ImulRm.mixin
+++ b/src/Spice86.Core/Emulator/CPU/CfgCpu/ParsedInstruction/Instructions/Mixins/ImulRm.mixin
@@ -17,7 +17,7 @@ using Spice86.Shared.Emulator.Memory;
 
 public partial class {{ moxy.Class.Name }} : InstructionWithModRm {
     public {{ moxy.Class.Name }}(SegmentedAddress address, InstructionField<ushort> opcodeField, List<InstructionPrefix> prefixes,
-        ModRmContext modRmContext) : base(address, opcodeField, prefixes, modRmContext) {
+        ModRmContext modRmContext) : base(address, opcodeField, prefixes, modRmContext, 1) {
     }
     
     public override void Execute(InstructionExecutionHelper helper) {

--- a/src/Spice86.Core/Emulator/CPU/CfgCpu/ParsedInstruction/Instructions/Mixins/InAccDx.mixin
+++ b/src/Spice86.Core/Emulator/CPU/CfgCpu/ParsedInstruction/Instructions/Mixins/InAccDx.mixin
@@ -15,7 +15,7 @@ using Spice86.Shared.Emulator.Memory;
 
 public partial class {{ moxy.Class.Name }} : CfgInstruction {
     public {{ moxy.Class.Name }}(SegmentedAddress address,
-        InstructionField<ushort> opcodeField, List<InstructionPrefix> prefixes) : base(address, opcodeField, prefixes) {
+        InstructionField<ushort> opcodeField, List<InstructionPrefix> prefixes) : base(address, opcodeField, prefixes, 1) {
     }
     
     public override void Execute(InstructionExecutionHelper helper) {

--- a/src/Spice86.Core/Emulator/CPU/CfgCpu/ParsedInstruction/Instructions/Mixins/InAccImm.mixin
+++ b/src/Spice86.Core/Emulator/CPU/CfgCpu/ParsedInstruction/Instructions/Mixins/InAccImm.mixin
@@ -15,7 +15,7 @@ using Spice86.Shared.Emulator.Memory;
 public partial class {{ moxy.Class.Name }} : InstructionWithValueField<byte> {
     public {{ moxy.Class.Name }}(SegmentedAddress address,
         InstructionField<ushort> opcodeField, List<InstructionPrefix> prefixes,
-        InstructionField<byte> valueField) : base(address, opcodeField, prefixes, valueField) {
+        InstructionField<byte> valueField) : base(address, opcodeField, prefixes, valueField, 1) {
     }
     
     public override void Execute(InstructionExecutionHelper helper) {

--- a/src/Spice86.Core/Emulator/CPU/CfgCpu/ParsedInstruction/Instructions/Mixins/IncDecReg.mixin
+++ b/src/Spice86.Core/Emulator/CPU/CfgCpu/ParsedInstruction/Instructions/Mixins/IncDecReg.mixin
@@ -15,7 +15,7 @@ using Spice86.Shared.Emulator.Memory;
 
 public partial class {{ moxy.Class.Name }} : InstructionWithRegisterIndex {
     public {{ moxy.Class.Name }}(SegmentedAddress address, InstructionField<ushort> opcodeField, List<InstructionPrefix> prefixes,
-        int registerIndex) : base(address, opcodeField, prefixes, registerIndex) {
+        int registerIndex) : base(address, opcodeField, prefixes, registerIndex, 1) {
     }
     
     public override void Execute(InstructionExecutionHelper helper) {

--- a/src/Spice86.Core/Emulator/CPU/CfgCpu/ParsedInstruction/Instructions/Mixins/InsDx.mixin
+++ b/src/Spice86.Core/Emulator/CPU/CfgCpu/ParsedInstruction/Instructions/Mixins/InsDx.mixin
@@ -15,7 +15,7 @@ using Spice86.Shared.Emulator.Memory;
 
 public partial class {{ moxy.Class.Name }} : CfgInstruction, StringInstruction {
     public {{ moxy.Class.Name }}(SegmentedAddress address,
-        InstructionField<ushort> opcodeField, List<InstructionPrefix> prefixes) : base(address, opcodeField, prefixes) {
+        InstructionField<ushort> opcodeField, List<InstructionPrefix> prefixes) : base(address, opcodeField, prefixes, 1) {
     }
 
     public bool ChangesFlags => false;

--- a/src/Spice86.Core/Emulator/CPU/CfgCpu/ParsedInstruction/Instructions/Mixins/JccNearImm.mixin
+++ b/src/Spice86.Core/Emulator/CPU/CfgCpu/ParsedInstruction/Instructions/Mixins/JccNearImm.mixin
@@ -16,6 +16,8 @@ using Spice86.Shared.Emulator.Memory;
 public partial class {{ moxy.Class.Name }} : JmpNearImm{{Size}} {
     public {{ moxy.Class.Name }}(SegmentedAddress address, InstructionField<ushort> opcodeField, List<InstructionPrefix> prefixes, InstructionField<{{SignedType}}> offsetField) :
         base(address, opcodeField, prefixes, offsetField) {
+        // JmpNearImm8 Has 1 but we are a conditional instruction, so 2
+        MaxSuccessorsCount = 2;
     }
 
     public override void Execute(InstructionExecutionHelper helper) {

--- a/src/Spice86.Core/Emulator/CPU/CfgCpu/ParsedInstruction/Instructions/Mixins/JmpNearImm.mixin
+++ b/src/Spice86.Core/Emulator/CPU/CfgCpu/ParsedInstruction/Instructions/Mixins/JmpNearImm.mixin
@@ -17,7 +17,7 @@ public partial class {{ moxy.Class.Name }} : InstructionWithOffsetField<{{Signed
     private readonly ushort _targetIp;
 
     public {{ moxy.Class.Name }}(SegmentedAddress address, InstructionField<ushort> opcodeField, List<InstructionPrefix> prefixes, InstructionField<{{SignedType}}> offsetField) :
-        base(address, opcodeField, prefixes, offsetField) {
+        base(address, opcodeField, prefixes, offsetField, 1) {
         _targetIp = (ushort)(NextInMemoryAddress.Offset + offsetField.Value);
     }
 

--- a/src/Spice86.Core/Emulator/CPU/CfgCpu/ParsedInstruction/Instructions/Mixins/Lea.mixin
+++ b/src/Spice86.Core/Emulator/CPU/CfgCpu/ParsedInstruction/Instructions/Mixins/Lea.mixin
@@ -13,7 +13,7 @@ using Spice86.Shared.Emulator.Memory;
 
 public partial class {{ moxy.Class.Name }} : InstructionWithModRm {
 
-    public {{ moxy.Class.Name }}(SegmentedAddress address, InstructionField<ushort> opcodeField, List<InstructionPrefix> prefixes, ModRmContext modRmContext) : base(address, opcodeField, prefixes, modRmContext) {
+    public {{ moxy.Class.Name }}(SegmentedAddress address, InstructionField<ushort> opcodeField, List<InstructionPrefix> prefixes, ModRmContext modRmContext) : base(address, opcodeField, prefixes, modRmContext, 1) {
     }
 
     public override void Execute(InstructionExecutionHelper helper) {

--- a/src/Spice86.Core/Emulator/CPU/CfgCpu/ParsedInstruction/Instructions/Mixins/Leave.mixin
+++ b/src/Spice86.Core/Emulator/CPU/CfgCpu/ParsedInstruction/Instructions/Mixins/Leave.mixin
@@ -15,7 +15,7 @@ using Spice86.Shared.Emulator.Memory;
 
 public partial class {{ moxy.Class.Name }} : CfgInstruction {
     public {{ moxy.Class.Name }}(SegmentedAddress address,
-        InstructionField<ushort> opcodeField, List<InstructionPrefix> prefixes) : base(address, opcodeField, prefixes) {
+        InstructionField<ushort> opcodeField, List<InstructionPrefix> prefixes) : base(address, opcodeField, prefixes, 1) {
     }
     
     public override void Execute(InstructionExecutionHelper helper) {

--- a/src/Spice86.Core/Emulator/CPU/CfgCpu/ParsedInstruction/Instructions/Mixins/Lods.mixin
+++ b/src/Spice86.Core/Emulator/CPU/CfgCpu/ParsedInstruction/Instructions/Mixins/Lods.mixin
@@ -16,7 +16,7 @@ using Spice86.Shared.Emulator.Memory;
 
 public partial class {{ moxy.Class.Name }} : InstructionWithSegmentRegisterIndex, StringInstruction {
     public {{ moxy.Class.Name }}(SegmentedAddress address,
-        InstructionField<ushort> opcodeField, List<InstructionPrefix> prefixes, int segmentRegisterIndex) : base(address, opcodeField, prefixes, segmentRegisterIndex) {
+        InstructionField<ushort> opcodeField, List<InstructionPrefix> prefixes, int segmentRegisterIndex) : base(address, opcodeField, prefixes, segmentRegisterIndex, 1) {
     }
 
     public bool ChangesFlags => false;

--- a/src/Spice86.Core/Emulator/CPU/CfgCpu/ParsedInstruction/Instructions/Mixins/Loop.mixin
+++ b/src/Spice86.Core/Emulator/CPU/CfgCpu/ParsedInstruction/Instructions/Mixins/Loop.mixin
@@ -16,6 +16,8 @@ using Spice86.Shared.Emulator.Memory;
 public partial class {{ moxy.Class.Name }} : JmpNearImm8 {
     public {{ moxy.Class.Name }}(SegmentedAddress address, InstructionField<ushort> opcodeField, List<InstructionPrefix> prefixes, InstructionField<sbyte> offsetField) :
         base(address, opcodeField, prefixes, offsetField) {
+        // JmpNearImm8 Has 1 but we are a conditional instruction, so 2
+        MaxSuccessorsCount = 2;
     }
 
     public override void Execute(InstructionExecutionHelper helper) {

--- a/src/Spice86.Core/Emulator/CPU/CfgCpu/ParsedInstruction/Instructions/Mixins/Lxs.mixin
+++ b/src/Spice86.Core/Emulator/CPU/CfgCpu/ParsedInstruction/Instructions/Mixins/Lxs.mixin
@@ -14,7 +14,7 @@ using Spice86.Shared.Emulator.Memory;
 
 public partial class {{ moxy.Class.Name }} : InstructionWithModRm {
     public {{ moxy.Class.Name }}(SegmentedAddress address, InstructionField<ushort> opcodeField, List<InstructionPrefix> prefixes,
-         ModRmContext modRmContext) : base(address, opcodeField, prefixes, modRmContext) {
+         ModRmContext modRmContext) : base(address, opcodeField, prefixes, modRmContext, 1) {
      }
     
     public override void Execute(InstructionExecutionHelper helper) {

--- a/src/Spice86.Core/Emulator/CPU/CfgCpu/ParsedInstruction/Instructions/Mixins/MovAccMoffs.mixin
+++ b/src/Spice86.Core/Emulator/CPU/CfgCpu/ParsedInstruction/Instructions/Mixins/MovAccMoffs.mixin
@@ -15,7 +15,7 @@ using Spice86.Shared.Emulator.Memory;
 public partial class {{ moxy.Class.Name }} : InstructionWithSegmentRegisterIndexAndOffsetField<ushort> {
     public {{ moxy.Class.Name }}(SegmentedAddress address, InstructionField<ushort> opcodeField, List<InstructionPrefix> prefixes,
         int segmentRegisterIndex, InstructionField<ushort> offsetField) : base(address, opcodeField, prefixes,
-        segmentRegisterIndex, offsetField) {
+        segmentRegisterIndex, offsetField, 1) {
     }
     
     public override void Execute(InstructionExecutionHelper helper) {

--- a/src/Spice86.Core/Emulator/CPU/CfgCpu/ParsedInstruction/Instructions/Mixins/MovMoffsAcc.mixin
+++ b/src/Spice86.Core/Emulator/CPU/CfgCpu/ParsedInstruction/Instructions/Mixins/MovMoffsAcc.mixin
@@ -15,7 +15,7 @@ using Spice86.Shared.Emulator.Memory;
 public partial class {{ moxy.Class.Name }} : InstructionWithSegmentRegisterIndexAndOffsetField<ushort> {
     public {{ moxy.Class.Name }}(SegmentedAddress address, InstructionField<ushort> opcodeField, List<InstructionPrefix> prefixes,
         int segmentRegisterIndex, InstructionField<ushort> offsetField) : base(address, opcodeField, prefixes,
-        segmentRegisterIndex, offsetField) {
+        segmentRegisterIndex, offsetField, 1) {
     }
     
     public override void Execute(InstructionExecutionHelper helper) {

--- a/src/Spice86.Core/Emulator/CPU/CfgCpu/ParsedInstruction/Instructions/Mixins/MovRegImm.mixin
+++ b/src/Spice86.Core/Emulator/CPU/CfgCpu/ParsedInstruction/Instructions/Mixins/MovRegImm.mixin
@@ -18,7 +18,7 @@ public partial class {{ moxy.Class.Name }} : InstructionWithValueFieldAndRegiste
         InstructionField<ushort> opcodeField,
         List<InstructionPrefix> prefixes,
         InstructionField<{{Type}}> valueField,
-        int registerIndex) : base(address, opcodeField, prefixes, valueField, registerIndex) {
+        int registerIndex) : base(address, opcodeField, prefixes, valueField, registerIndex, 1) {
     }
     
     public override void Execute(InstructionExecutionHelper helper) {

--- a/src/Spice86.Core/Emulator/CPU/CfgCpu/ParsedInstruction/Instructions/Mixins/MovRegRm.mixin
+++ b/src/Spice86.Core/Emulator/CPU/CfgCpu/ParsedInstruction/Instructions/Mixins/MovRegRm.mixin
@@ -13,7 +13,7 @@ using Spice86.Shared.Emulator.Memory;
 
 public partial class {{ moxy.Class.Name }} : InstructionWithModRm {
     public {{ moxy.Class.Name }}(SegmentedAddress address, InstructionField<ushort> opcodeField, List<InstructionPrefix> prefixes,
-        ModRmContext modRmContext) : base(address, opcodeField, prefixes, modRmContext) {
+        ModRmContext modRmContext) : base(address, opcodeField, prefixes, modRmContext, 1) {
     }
     
     public override void Execute(InstructionExecutionHelper helper) {

--- a/src/Spice86.Core/Emulator/CPU/CfgCpu/ParsedInstruction/Instructions/Mixins/MovRmImm.mixin
+++ b/src/Spice86.Core/Emulator/CPU/CfgCpu/ParsedInstruction/Instructions/Mixins/MovRmImm.mixin
@@ -16,7 +16,7 @@ using Spice86.Shared.Emulator.Memory;
 public partial class {{ moxy.Class.Name }} : InstructionWithModRmAndValueField<{{Type}}> {
     public {{ moxy.Class.Name }}(SegmentedAddress address, InstructionField<ushort> opcodeField, List<InstructionPrefix> prefixes,
         ModRmContext modRmContext, InstructionField<{{Type}}> valueField) : base(address, opcodeField, prefixes,
-        modRmContext, valueField) {
+        modRmContext, valueField, 1) {
     }
     
     public override void Execute(InstructionExecutionHelper helper) {

--- a/src/Spice86.Core/Emulator/CPU/CfgCpu/ParsedInstruction/Instructions/Mixins/MovRmReg.mixin
+++ b/src/Spice86.Core/Emulator/CPU/CfgCpu/ParsedInstruction/Instructions/Mixins/MovRmReg.mixin
@@ -13,7 +13,7 @@ using Spice86.Shared.Emulator.Memory;
 
 public partial class {{ moxy.Class.Name }} : InstructionWithModRm {
     public {{ moxy.Class.Name }}(SegmentedAddress address, InstructionField<ushort> opcodeField, List<InstructionPrefix> prefixes,
-        ModRmContext modRmContext) : base(address, opcodeField, prefixes, modRmContext) {
+        ModRmContext modRmContext) : base(address, opcodeField, prefixes, modRmContext, 1) {
     }
     
     public override void Execute(InstructionExecutionHelper helper) {

--- a/src/Spice86.Core/Emulator/CPU/CfgCpu/ParsedInstruction/Instructions/Mixins/MovRmSignExtend.mixin
+++ b/src/Spice86.Core/Emulator/CPU/CfgCpu/ParsedInstruction/Instructions/Mixins/MovRmSignExtend.mixin
@@ -16,7 +16,7 @@ using Spice86.Shared.Emulator.Memory;
 
 public partial class {{ moxy.Class.Name }} : InstructionWithModRm {
     public {{ moxy.Class.Name }}(SegmentedAddress address, InstructionField<ushort> opcodeField, List<InstructionPrefix> prefixes,
-        ModRmContext modRmContext) : base(address, opcodeField, prefixes, modRmContext) {
+        ModRmContext modRmContext) : base(address, opcodeField, prefixes, modRmContext, 1) {
     }
     
     public override void Execute(InstructionExecutionHelper helper) {

--- a/src/Spice86.Core/Emulator/CPU/CfgCpu/ParsedInstruction/Instructions/Mixins/MovRmSreg.mixin
+++ b/src/Spice86.Core/Emulator/CPU/CfgCpu/ParsedInstruction/Instructions/Mixins/MovRmSreg.mixin
@@ -13,7 +13,7 @@ using Spice86.Shared.Emulator.Memory;
 
 public partial class {{ moxy.Class.Name }} : InstructionWithModRm {
     public {{ moxy.Class.Name }}(SegmentedAddress address, InstructionField<ushort> opcodeField, List<InstructionPrefix> prefixes,
-        ModRmContext modRmContext) : base(address, opcodeField, prefixes, modRmContext) {
+        ModRmContext modRmContext) : base(address, opcodeField, prefixes, modRmContext, 1) {
     }
     
     public override void Execute(InstructionExecutionHelper helper) {

--- a/src/Spice86.Core/Emulator/CPU/CfgCpu/ParsedInstruction/Instructions/Mixins/MovRmZeroExtend.mixin
+++ b/src/Spice86.Core/Emulator/CPU/CfgCpu/ParsedInstruction/Instructions/Mixins/MovRmZeroExtend.mixin
@@ -14,7 +14,7 @@ using Spice86.Shared.Emulator.Memory;
 
 public partial class {{ moxy.Class.Name }} : InstructionWithModRm {
     public {{ moxy.Class.Name }}(SegmentedAddress address, InstructionField<ushort> opcodeField, List<InstructionPrefix> prefixes,
-        ModRmContext modRmContext) : base(address, opcodeField, prefixes, modRmContext) {
+        ModRmContext modRmContext) : base(address, opcodeField, prefixes, modRmContext, 1) {
     }
     
     public override void Execute(InstructionExecutionHelper helper) {

--- a/src/Spice86.Core/Emulator/CPU/CfgCpu/ParsedInstruction/Instructions/Mixins/Movs.mixin
+++ b/src/Spice86.Core/Emulator/CPU/CfgCpu/ParsedInstruction/Instructions/Mixins/Movs.mixin
@@ -15,7 +15,7 @@ using Spice86.Shared.Emulator.Memory;
 
 public partial class {{ moxy.Class.Name }} : InstructionWithSegmentRegisterIndex, StringInstruction {
     public {{ moxy.Class.Name }}(SegmentedAddress address,
-        InstructionField<ushort> opcodeField, List<InstructionPrefix> prefixes, int segmentRegisterIndex) : base(address, opcodeField, prefixes, segmentRegisterIndex) {
+        InstructionField<ushort> opcodeField, List<InstructionPrefix> prefixes, int segmentRegisterIndex) : base(address, opcodeField, prefixes, segmentRegisterIndex, 1) {
     }
 
     public bool ChangesFlags => false;

--- a/src/Spice86.Core/Emulator/CPU/CfgCpu/ParsedInstruction/Instructions/Mixins/OpAccImm.mixin
+++ b/src/Spice86.Core/Emulator/CPU/CfgCpu/ParsedInstruction/Instructions/Mixins/OpAccImm.mixin
@@ -20,7 +20,7 @@ public partial class {{ moxy.Class.Name }} : InstructionWithValueField<{{Type}}>
     public {{ moxy.Class.Name }}(SegmentedAddress address,
         InstructionField<ushort> opcodeField,
         List<InstructionPrefix> prefixes,
-        InstructionField<{{Type}}> valueField) : base(address, opcodeField, prefixes, valueField) {
+        InstructionField<{{Type}}> valueField) : base(address, opcodeField, prefixes, valueField, 1) {
     }
     
     public override void Execute(InstructionExecutionHelper helper) {

--- a/src/Spice86.Core/Emulator/CPU/CfgCpu/ParsedInstruction/Instructions/Mixins/OpRegRm.mixin
+++ b/src/Spice86.Core/Emulator/CPU/CfgCpu/ParsedInstruction/Instructions/Mixins/OpRegRm.mixin
@@ -16,7 +16,7 @@ using Spice86.Shared.Emulator.Memory;
 
 public partial class {{ moxy.Class.Name }} : InstructionWithModRm {
 
-    public {{ moxy.Class.Name }}(SegmentedAddress address, InstructionField<ushort> opcodeField, List<InstructionPrefix> prefixes, ModRmContext modRmContext) : base(address, opcodeField, prefixes, modRmContext) {
+    public {{ moxy.Class.Name }}(SegmentedAddress address, InstructionField<ushort> opcodeField, List<InstructionPrefix> prefixes, ModRmContext modRmContext) : base(address, opcodeField, prefixes, modRmContext, 1) {
     }
 
     public override void Execute(InstructionExecutionHelper helper) {

--- a/src/Spice86.Core/Emulator/CPU/CfgCpu/ParsedInstruction/Instructions/Mixins/OpRmReg.mixin
+++ b/src/Spice86.Core/Emulator/CPU/CfgCpu/ParsedInstruction/Instructions/Mixins/OpRmReg.mixin
@@ -16,7 +16,7 @@ using Spice86.Shared.Emulator.Memory;
 
 public partial class {{ moxy.Class.Name }} : InstructionWithModRm {
 
-    public {{ moxy.Class.Name }}(SegmentedAddress address, InstructionField<ushort> opcodeField, List<InstructionPrefix> prefixes, ModRmContext modRmContext) : base(address, opcodeField, prefixes, modRmContext) {
+    public {{ moxy.Class.Name }}(SegmentedAddress address, InstructionField<ushort> opcodeField, List<InstructionPrefix> prefixes, ModRmContext modRmContext) : base(address, opcodeField, prefixes, modRmContext, 1) {
     }
 
     public override void Execute(InstructionExecutionHelper helper) {

--- a/src/Spice86.Core/Emulator/CPU/CfgCpu/ParsedInstruction/Instructions/Mixins/OutAccDx.mixin
+++ b/src/Spice86.Core/Emulator/CPU/CfgCpu/ParsedInstruction/Instructions/Mixins/OutAccDx.mixin
@@ -15,7 +15,7 @@ using Spice86.Shared.Emulator.Memory;
 
 public partial class {{ moxy.Class.Name }} : CfgInstruction {
     public {{ moxy.Class.Name }}(SegmentedAddress address,
-        InstructionField<ushort> opcodeField, List<InstructionPrefix> prefixes) : base(address, opcodeField, prefixes) {
+        InstructionField<ushort> opcodeField, List<InstructionPrefix> prefixes) : base(address, opcodeField, prefixes, 1) {
     }
     
     public override void Execute(InstructionExecutionHelper helper) {

--- a/src/Spice86.Core/Emulator/CPU/CfgCpu/ParsedInstruction/Instructions/Mixins/OutAccImm.mixin
+++ b/src/Spice86.Core/Emulator/CPU/CfgCpu/ParsedInstruction/Instructions/Mixins/OutAccImm.mixin
@@ -15,7 +15,7 @@ using Spice86.Shared.Emulator.Memory;
 public partial class {{ moxy.Class.Name }} : InstructionWithValueField<byte> {
     public {{ moxy.Class.Name }}(SegmentedAddress address,
         InstructionField<ushort> opcodeField, List<InstructionPrefix> prefixes,
-        InstructionField<byte> valueField) : base(address, opcodeField, prefixes, valueField) {
+        InstructionField<byte> valueField) : base(address, opcodeField, prefixes, valueField, 1) {
     }
     
     public override void Execute(InstructionExecutionHelper helper) {

--- a/src/Spice86.Core/Emulator/CPU/CfgCpu/ParsedInstruction/Instructions/Mixins/OutsDx.mixin
+++ b/src/Spice86.Core/Emulator/CPU/CfgCpu/ParsedInstruction/Instructions/Mixins/OutsDx.mixin
@@ -16,7 +16,7 @@ using Spice86.Shared.Emulator.Memory;
 
 public partial class {{ moxy.Class.Name }} : InstructionWithSegmentRegisterIndex, StringInstruction {
     public {{ moxy.Class.Name }}(SegmentedAddress address,
-        InstructionField<ushort> opcodeField, List<InstructionPrefix> prefixes, int segmentRegisterIndex) : base(address, opcodeField, prefixes, segmentRegisterIndex) {
+        InstructionField<ushort> opcodeField, List<InstructionPrefix> prefixes, int segmentRegisterIndex) : base(address, opcodeField, prefixes, segmentRegisterIndex, 1) {
     }
 
     public bool ChangesFlags => false;

--- a/src/Spice86.Core/Emulator/CPU/CfgCpu/ParsedInstruction/Instructions/Mixins/PopF.mixin
+++ b/src/Spice86.Core/Emulator/CPU/CfgCpu/ParsedInstruction/Instructions/Mixins/PopF.mixin
@@ -12,7 +12,7 @@ using Spice86.Shared.Emulator.Memory;
 
 public partial class {{ moxy.Class.Name }} : CfgInstruction {
     public {{ moxy.Class.Name }}(SegmentedAddress address, InstructionField<ushort> opcodeField, List<InstructionPrefix> prefixes) :
-        base(address, opcodeField, prefixes) {
+        base(address, opcodeField, prefixes, 1) {
     }
 
     public override void Execute(InstructionExecutionHelper helper) {

--- a/src/Spice86.Core/Emulator/CPU/CfgCpu/ParsedInstruction/Instructions/Mixins/PopReg.mixin
+++ b/src/Spice86.Core/Emulator/CPU/CfgCpu/ParsedInstruction/Instructions/Mixins/PopReg.mixin
@@ -15,7 +15,7 @@ using Spice86.Shared.Emulator.Memory;
 
 public partial class {{ moxy.Class.Name }} : InstructionWithRegisterIndex {
     public {{ moxy.Class.Name }}(SegmentedAddress address, InstructionField<ushort> opcodeField, List<InstructionPrefix> prefixes,
-        int registerIndex) : base(address, opcodeField, prefixes, registerIndex) {
+        int registerIndex) : base(address, opcodeField, prefixes, registerIndex, 1) {
         {{ if IsSegment }}
         if(registerIndex == (int)SegmentRegisterIndex.CsIndex) {
             throw new ArgumentException("Register CS is not allowed");

--- a/src/Spice86.Core/Emulator/CPU/CfgCpu/ParsedInstruction/Instructions/Mixins/PopRm.mixin
+++ b/src/Spice86.Core/Emulator/CPU/CfgCpu/ParsedInstruction/Instructions/Mixins/PopRm.mixin
@@ -13,7 +13,7 @@ using Spice86.Shared.Emulator.Memory;
 
 public partial class {{ moxy.Class.Name }} : InstructionWithModRm {
     public {{ moxy.Class.Name }}(SegmentedAddress address, InstructionField<ushort> opcodeField, List<InstructionPrefix> prefixes,
-        ModRmContext modRmContext) : base(address, opcodeField, prefixes, modRmContext) {
+        ModRmContext modRmContext) : base(address, opcodeField, prefixes, modRmContext, 1) {
     }
     
     public override void Execute(InstructionExecutionHelper helper) {

--- a/src/Spice86.Core/Emulator/CPU/CfgCpu/ParsedInstruction/Instructions/Mixins/Popa.mixin
+++ b/src/Spice86.Core/Emulator/CPU/CfgCpu/ParsedInstruction/Instructions/Mixins/Popa.mixin
@@ -14,7 +14,7 @@ using Spice86.Shared.Emulator.Memory;
 
 public partial class {{ moxy.Class.Name }} : CfgInstruction {
     public {{ moxy.Class.Name }}(SegmentedAddress address, InstructionField<ushort> opcodeField, List<InstructionPrefix> prefixes) :
-        base(address, opcodeField, prefixes) {
+        base(address, opcodeField, prefixes, 1) {
     }
 
     public override void Execute(InstructionExecutionHelper helper) {

--- a/src/Spice86.Core/Emulator/CPU/CfgCpu/ParsedInstruction/Instructions/Mixins/PushImm.mixin
+++ b/src/Spice86.Core/Emulator/CPU/CfgCpu/ParsedInstruction/Instructions/Mixins/PushImm.mixin
@@ -15,7 +15,7 @@ using Spice86.Shared.Emulator.Memory;
 public partial class {{ moxy.Class.Name }} : InstructionWithValueField<{{ImmType}}> {
     public {{ moxy.Class.Name }}(SegmentedAddress address,
         InstructionField<ushort> opcodeField, List<InstructionPrefix> prefixes,
-        InstructionField<{{ImmType}}> valueField) : base(address, opcodeField, prefixes, valueField) {
+        InstructionField<{{ImmType}}> valueField) : base(address, opcodeField, prefixes, valueField, 1) {
     }
     
     public override void Execute(InstructionExecutionHelper helper) {

--- a/src/Spice86.Core/Emulator/CPU/CfgCpu/ParsedInstruction/Instructions/Mixins/PushImm8SignExtended.mixin
+++ b/src/Spice86.Core/Emulator/CPU/CfgCpu/ParsedInstruction/Instructions/Mixins/PushImm8SignExtended.mixin
@@ -16,7 +16,7 @@ using Spice86.Shared.Emulator.Memory;
 public partial class {{ moxy.Class.Name }} : InstructionWithValueField<sbyte> {
     public {{ moxy.Class.Name }}(SegmentedAddress address,
         InstructionField<ushort> opcodeField, List<InstructionPrefix> prefixes,
-        InstructionField<sbyte> valueField) : base(address, opcodeField, prefixes, valueField) {
+        InstructionField<sbyte> valueField) : base(address, opcodeField, prefixes, valueField, 1) {
     }
     
     public override void Execute(InstructionExecutionHelper helper) {

--- a/src/Spice86.Core/Emulator/CPU/CfgCpu/ParsedInstruction/Instructions/Mixins/PushReg.mixin
+++ b/src/Spice86.Core/Emulator/CPU/CfgCpu/ParsedInstruction/Instructions/Mixins/PushReg.mixin
@@ -14,7 +14,7 @@ using Spice86.Shared.Emulator.Memory;
 
 public partial class {{ moxy.Class.Name }} : InstructionWithRegisterIndex {
     public {{ moxy.Class.Name }}(SegmentedAddress address, InstructionField<ushort> opcodeField, List<InstructionPrefix> prefixes,
-        int registerIndex) : base(address, opcodeField, prefixes, registerIndex) {
+        int registerIndex) : base(address, opcodeField, prefixes, registerIndex, 1) {
     }
 
     public override void Execute(InstructionExecutionHelper helper) {

--- a/src/Spice86.Core/Emulator/CPU/CfgCpu/ParsedInstruction/Instructions/Mixins/Pusha.mixin
+++ b/src/Spice86.Core/Emulator/CPU/CfgCpu/ParsedInstruction/Instructions/Mixins/Pusha.mixin
@@ -15,7 +15,7 @@ using Spice86.Shared.Emulator.Memory;
 
 public partial class {{ moxy.Class.Name }} : CfgInstruction {
     public {{ moxy.Class.Name }}(SegmentedAddress address, InstructionField<ushort> opcodeField, List<InstructionPrefix> prefixes) :
-        base(address, opcodeField, prefixes) {
+        base(address, opcodeField, prefixes, 1) {
     }
 
     public override void Execute(InstructionExecutionHelper helper) {

--- a/src/Spice86.Core/Emulator/CPU/CfgCpu/ParsedInstruction/Instructions/Mixins/Scas.mixin
+++ b/src/Spice86.Core/Emulator/CPU/CfgCpu/ParsedInstruction/Instructions/Mixins/Scas.mixin
@@ -16,7 +16,7 @@ using Spice86.Shared.Emulator.Memory;
 
 public partial class {{ moxy.Class.Name }} : CfgInstruction, StringInstruction {
     public {{ moxy.Class.Name }}(SegmentedAddress address,
-        InstructionField<ushort> opcodeField, List<InstructionPrefix> prefixes) : base(address, opcodeField, prefixes) {
+        InstructionField<ushort> opcodeField, List<InstructionPrefix> prefixes) : base(address, opcodeField, prefixes, 1) {
     }
 
     public bool ChangesFlags => true;

--- a/src/Spice86.Core/Emulator/CPU/CfgCpu/ParsedInstruction/Instructions/Mixins/SetRmcc.mixin
+++ b/src/Spice86.Core/Emulator/CPU/CfgCpu/ParsedInstruction/Instructions/Mixins/SetRmcc.mixin
@@ -15,7 +15,7 @@ using Spice86.Shared.Emulator.Memory;
 
 public partial class {{ moxy.Class.Name }} : InstructionWithModRm {
     public {{ moxy.Class.Name }}(SegmentedAddress address, InstructionField<ushort> opcodeField, List<InstructionPrefix> prefixes,
-        ModRmContext modRmContext) : base(address, opcodeField, prefixes, modRmContext) {
+        ModRmContext modRmContext) : base(address, opcodeField, prefixes, modRmContext, 1) {
     }
     
     public override void Execute(InstructionExecutionHelper helper) {

--- a/src/Spice86.Core/Emulator/CPU/CfgCpu/ParsedInstruction/Instructions/Mixins/ShldCl.mixin
+++ b/src/Spice86.Core/Emulator/CPU/CfgCpu/ParsedInstruction/Instructions/Mixins/ShldCl.mixin
@@ -14,7 +14,7 @@ using Spice86.Shared.Emulator.Memory;
 
 public partial class {{ moxy.Class.Name }} : InstructionWithModRm {
     public {{ moxy.Class.Name }}(SegmentedAddress address, InstructionField<ushort> opcodeField, List<InstructionPrefix> prefixes,
-         ModRmContext modRmContext) : base(address, opcodeField, prefixes, modRmContext) {
+         ModRmContext modRmContext) : base(address, opcodeField, prefixes, modRmContext, 1) {
      }
     
     public override void Execute(InstructionExecutionHelper helper) {

--- a/src/Spice86.Core/Emulator/CPU/CfgCpu/ParsedInstruction/Instructions/Mixins/ShldImm8.mixin
+++ b/src/Spice86.Core/Emulator/CPU/CfgCpu/ParsedInstruction/Instructions/Mixins/ShldImm8.mixin
@@ -14,7 +14,7 @@ using Spice86.Shared.Emulator.Memory;
 
 public partial class {{ moxy.Class.Name }} : InstructionWithModRmAndValueField<byte> {
     public {{ moxy.Class.Name }}(SegmentedAddress address, InstructionField<ushort> opcodeField, List<InstructionPrefix> prefixes,
-         ModRmContext modRmContext, InstructionField<byte> valueField) : base(address, opcodeField, prefixes, modRmContext, valueField) {
+         ModRmContext modRmContext, InstructionField<byte> valueField) : base(address, opcodeField, prefixes, modRmContext, valueField, 1) {
      }
     
     public override void Execute(InstructionExecutionHelper helper) {

--- a/src/Spice86.Core/Emulator/CPU/CfgCpu/ParsedInstruction/Instructions/Mixins/Stos.mixin
+++ b/src/Spice86.Core/Emulator/CPU/CfgCpu/ParsedInstruction/Instructions/Mixins/Stos.mixin
@@ -16,7 +16,7 @@ using Spice86.Shared.Emulator.Memory;
 
 public partial class {{ moxy.Class.Name }} : CfgInstruction, StringInstruction {
     public {{ moxy.Class.Name }}(SegmentedAddress address,
-        InstructionField<ushort> opcodeField, List<InstructionPrefix> prefixes) : base(address, opcodeField, prefixes) {
+        InstructionField<ushort> opcodeField, List<InstructionPrefix> prefixes) : base(address, opcodeField, prefixes, 1) {
     }
 
     public bool ChangesFlags => false;

--- a/src/Spice86.Core/Emulator/CPU/CfgCpu/ParsedInstruction/Instructions/Mixins/XaddRm.mixin
+++ b/src/Spice86.Core/Emulator/CPU/CfgCpu/ParsedInstruction/Instructions/Mixins/XaddRm.mixin
@@ -13,7 +13,7 @@ using Spice86.Shared.Emulator.Memory;
 
 public partial class {{ moxy.Class.Name }} : InstructionWithModRm {
 
-    public {{ moxy.Class.Name }}(SegmentedAddress address, InstructionField<ushort> opcodeField, List<InstructionPrefix> prefixes, ModRmContext modRmContext) : base(address, opcodeField, prefixes, modRmContext) {
+    public {{ moxy.Class.Name }}(SegmentedAddress address, InstructionField<ushort> opcodeField, List<InstructionPrefix> prefixes, ModRmContext modRmContext) : base(address, opcodeField, prefixes, modRmContext, 1) {
     }
 
     public override void Execute(InstructionExecutionHelper helper) {

--- a/src/Spice86.Core/Emulator/CPU/CfgCpu/ParsedInstruction/Instructions/Mixins/XchgRegAcc.mixin
+++ b/src/Spice86.Core/Emulator/CPU/CfgCpu/ParsedInstruction/Instructions/Mixins/XchgRegAcc.mixin
@@ -14,7 +14,7 @@ using Spice86.Shared.Emulator.Memory;
 
 public partial class {{ moxy.Class.Name }} : InstructionWithRegisterIndex {
     public {{ moxy.Class.Name }}(SegmentedAddress address, InstructionField<ushort> opcodeField, List<InstructionPrefix> prefixes,
-        int registerIndex) : base(address, opcodeField, prefixes, registerIndex) {
+        int registerIndex) : base(address, opcodeField, prefixes, registerIndex, 1) {
     }
     
     public override void Execute(InstructionExecutionHelper helper) {

--- a/src/Spice86.Core/Emulator/CPU/CfgCpu/ParsedInstruction/Instructions/Mixins/XchgRm.mixin
+++ b/src/Spice86.Core/Emulator/CPU/CfgCpu/ParsedInstruction/Instructions/Mixins/XchgRm.mixin
@@ -13,7 +13,7 @@ using Spice86.Shared.Emulator.Memory;
 
 public partial class {{ moxy.Class.Name }} : InstructionWithModRm {
 
-    public {{ moxy.Class.Name }}(SegmentedAddress address, InstructionField<ushort> opcodeField, List<InstructionPrefix> prefixes, ModRmContext modRmContext) : base(address, opcodeField, prefixes, modRmContext) {
+    public {{ moxy.Class.Name }}(SegmentedAddress address, InstructionField<ushort> opcodeField, List<InstructionPrefix> prefixes, ModRmContext modRmContext) : base(address, opcodeField, prefixes, modRmContext, 1) {
     }
 
     public override void Execute(InstructionExecutionHelper helper) {

--- a/src/Spice86.Core/Emulator/CPU/CfgCpu/ParsedInstruction/Instructions/Mixins/Xlat.mixin
+++ b/src/Spice86.Core/Emulator/CPU/CfgCpu/ParsedInstruction/Instructions/Mixins/Xlat.mixin
@@ -17,7 +17,7 @@ using Spice86.Shared.Emulator.Memory;
 
 public partial class {{ moxy.Class.Name }} : InstructionWithSegmentRegisterIndex {
     public {{ moxy.Class.Name }}(SegmentedAddress address, InstructionField<ushort> opcodeField,
-        List<InstructionPrefix> prefixes, int segmentRegisterIndex) : base(address, opcodeField, prefixes, segmentRegisterIndex) {
+        List<InstructionPrefix> prefixes, int segmentRegisterIndex) : base(address, opcodeField, prefixes, segmentRegisterIndex, 1) {
     }
 
     public override void Execute(InstructionExecutionHelper helper) {

--- a/src/Spice86.Core/Emulator/CPU/CfgCpu/ParsedInstruction/Instructions/MovSregRm16.cs
+++ b/src/Spice86.Core/Emulator/CPU/CfgCpu/ParsedInstruction/Instructions/MovSregRm16.cs
@@ -14,7 +14,7 @@ public class MovSregRm16 : InstructionWithModRm {
     public MovSregRm16(SegmentedAddress address,
         InstructionField<ushort> opcodeField,
         List<InstructionPrefix> prefixes,
-        ModRmContext modRmContext) : base(address, opcodeField, prefixes, modRmContext) {
+        ModRmContext modRmContext) : base(address, opcodeField, prefixes, modRmContext, 1) {
         if (modRmContext.RegisterIndex == (uint)SegmentRegisterIndex.CsIndex) {
             throw new CpuInvalidOpcodeException("Attempted to write to CS register with MOV instruction");
         }

--- a/src/Spice86.Core/Emulator/CPU/CfgCpu/ParsedInstruction/Instructions/Nop.cs
+++ b/src/Spice86.Core/Emulator/CPU/CfgCpu/ParsedInstruction/Instructions/Nop.cs
@@ -6,7 +6,7 @@ using Spice86.Core.Emulator.CPU.CfgCpu.InstructionExecutor;
 using Spice86.Shared.Emulator.Memory;
 
 public class Nop : CfgInstruction {
-    public Nop(SegmentedAddress address, InstructionField<ushort> opcodeField) : base(address, opcodeField) {
+    public Nop(SegmentedAddress address, InstructionField<ushort> opcodeField) : base(address, opcodeField, 1) {
     }
 
     public override void Execute(InstructionExecutionHelper helper) {

--- a/src/Spice86.Core/Emulator/CPU/CfgCpu/ParsedInstruction/Instructions/PushF16.cs
+++ b/src/Spice86.Core/Emulator/CPU/CfgCpu/ParsedInstruction/Instructions/PushF16.cs
@@ -8,7 +8,7 @@ using Spice86.Shared.Emulator.Memory;
 
 public class PushF16 : CfgInstruction {
     public PushF16(SegmentedAddress address, InstructionField<ushort> opcodeField, List<InstructionPrefix> prefixes) :
-        base(address, opcodeField, prefixes) {
+        base(address, opcodeField, prefixes, 1) {
     }
     
     public override void Execute(InstructionExecutionHelper helper) {

--- a/src/Spice86.Core/Emulator/CPU/CfgCpu/ParsedInstruction/Instructions/PushF32.cs
+++ b/src/Spice86.Core/Emulator/CPU/CfgCpu/ParsedInstruction/Instructions/PushF32.cs
@@ -8,7 +8,7 @@ using Spice86.Shared.Emulator.Memory;
 
 public class PushF32 : CfgInstruction {
     public PushF32(SegmentedAddress address, InstructionField<ushort> opcodeField, List<InstructionPrefix> prefixes) :
-        base(address, opcodeField, prefixes) {
+        base(address, opcodeField, prefixes, 1) {
     }
 
     public override void Execute(InstructionExecutionHelper helper) {

--- a/src/Spice86.Core/Emulator/CPU/CfgCpu/ParsedInstruction/Instructions/RetFar.cs
+++ b/src/Spice86.Core/Emulator/CPU/CfgCpu/ParsedInstruction/Instructions/RetFar.cs
@@ -8,7 +8,7 @@ using Spice86.Shared.Emulator.Memory;
 
 public class RetFar : CfgInstruction, IReturnInstruction {
 
-    public RetFar(SegmentedAddress address, InstructionField<ushort> opcodeField) : base(address, opcodeField) {
+    public RetFar(SegmentedAddress address, InstructionField<ushort> opcodeField) : base(address, opcodeField, null) {
     }
 
     public CfgInstruction? CurrentCorrespondingCallInstruction { get; set; }

--- a/src/Spice86.Core/Emulator/CPU/CfgCpu/ParsedInstruction/Instructions/RetFarImm.cs
+++ b/src/Spice86.Core/Emulator/CPU/CfgCpu/ParsedInstruction/Instructions/RetFarImm.cs
@@ -9,7 +9,7 @@ using Spice86.Shared.Emulator.Memory;
 
 public class RetFarImm : InstructionWithValueField<ushort>, IReturnInstruction {
 
-    public RetFarImm(SegmentedAddress address, InstructionField<ushort> opcodeField, InstructionField<ushort> valueField) : base(address, opcodeField, valueField) {
+    public RetFarImm(SegmentedAddress address, InstructionField<ushort> opcodeField, InstructionField<ushort> valueField) : base(address, opcodeField, valueField, null) {
     }
 
     public CfgInstruction? CurrentCorrespondingCallInstruction { get; set; }

--- a/src/Spice86.Core/Emulator/CPU/CfgCpu/ParsedInstruction/Instructions/RetInterrupt.cs
+++ b/src/Spice86.Core/Emulator/CPU/CfgCpu/ParsedInstruction/Instructions/RetInterrupt.cs
@@ -7,7 +7,7 @@ using Spice86.Core.Emulator.CPU.CfgCpu.ParsedInstruction.Instructions.Interfaces
 using Spice86.Shared.Emulator.Memory;
 
 public class RetInterrupt : CfgInstruction, IReturnInstruction {
-    public RetInterrupt(SegmentedAddress address, InstructionField<ushort> opcodeField) : base(address, opcodeField) {
+    public RetInterrupt(SegmentedAddress address, InstructionField<ushort> opcodeField) : base(address, opcodeField, null) {
     }
 
     public CfgInstruction? CurrentCorrespondingCallInstruction { get; set; }

--- a/src/Spice86.Core/Emulator/CPU/CfgCpu/ParsedInstruction/Instructions/RetNear.cs
+++ b/src/Spice86.Core/Emulator/CPU/CfgCpu/ParsedInstruction/Instructions/RetNear.cs
@@ -8,7 +8,7 @@ using Spice86.Shared.Emulator.Memory;
 
 public class RetNear : CfgInstruction, IReturnInstruction {
 
-    public RetNear(SegmentedAddress address, InstructionField<ushort> opcodeField) : base(address, opcodeField) {
+    public RetNear(SegmentedAddress address, InstructionField<ushort> opcodeField) : base(address, opcodeField, null) {
     }
     
     public CfgInstruction? CurrentCorrespondingCallInstruction { get; set; }

--- a/src/Spice86.Core/Emulator/CPU/CfgCpu/ParsedInstruction/Instructions/RetNearImm.cs
+++ b/src/Spice86.Core/Emulator/CPU/CfgCpu/ParsedInstruction/Instructions/RetNearImm.cs
@@ -9,7 +9,7 @@ using Spice86.Shared.Emulator.Memory;
 
 public class RetNearImm : InstructionWithValueField<ushort>, IReturnInstruction {
 
-    public RetNearImm(SegmentedAddress address, InstructionField<ushort> opcodeField, InstructionField<ushort> valueField) : base(address, opcodeField, valueField) {
+    public RetNearImm(SegmentedAddress address, InstructionField<ushort> opcodeField, InstructionField<ushort> valueField) : base(address, opcodeField, valueField, null) {
     }
 
     public CfgInstruction? CurrentCorrespondingCallInstruction { get; set; }

--- a/src/Spice86.Core/Emulator/CPU/CfgCpu/ParsedInstruction/Instructions/Sahf.cs
+++ b/src/Spice86.Core/Emulator/CPU/CfgCpu/ParsedInstruction/Instructions/Sahf.cs
@@ -6,7 +6,7 @@ using Spice86.Core.Emulator.CPU.CfgCpu.InstructionExecutor;
 using Spice86.Shared.Emulator.Memory;
 
 public class Sahf : CfgInstruction {
-    public Sahf(SegmentedAddress address, InstructionField<ushort> opcodeField) : base(address, opcodeField) {
+    public Sahf(SegmentedAddress address, InstructionField<ushort> opcodeField) : base(address, opcodeField, 1) {
     }
 
     public override void Execute(InstructionExecutionHelper helper) {

--- a/src/Spice86.Core/Emulator/CPU/CfgCpu/ParsedInstruction/Instructions/Salc.cs
+++ b/src/Spice86.Core/Emulator/CPU/CfgCpu/ParsedInstruction/Instructions/Salc.cs
@@ -10,7 +10,7 @@ using Spice86.Shared.Emulator.Memory;
 /// </summary>
 public class Salc : CfgInstruction {
 
-    public Salc(SegmentedAddress address, InstructionField<ushort> opcodeField) : base(address, opcodeField) {
+    public Salc(SegmentedAddress address, InstructionField<ushort> opcodeField) : base(address, opcodeField, 1) {
     }
 
     public override void Execute(InstructionExecutionHelper helper) {

--- a/src/Spice86.Core/Emulator/CPU/CfgCpu/ParsedInstruction/ModRm/InstructionWithModRm.cs
+++ b/src/Spice86.Core/Emulator/CPU/CfgCpu/ParsedInstruction/ModRm/InstructionWithModRm.cs
@@ -4,7 +4,7 @@ using Spice86.Core.Emulator.CPU.CfgCpu.ParsedInstruction.Prefix;
 using Spice86.Shared.Emulator.Memory;
 
 public abstract class InstructionWithModRm : CfgInstruction {
-    public InstructionWithModRm(SegmentedAddress address, InstructionField<ushort> opcodeField, List<InstructionPrefix> prefixes, ModRmContext modRmContext) : base(address, opcodeField, prefixes) {
+    public InstructionWithModRm(SegmentedAddress address, InstructionField<ushort> opcodeField, List<InstructionPrefix> prefixes, ModRmContext modRmContext, int? maxSuccessorsCount) : base(address, opcodeField, prefixes, maxSuccessorsCount) {
         ModRmContext = modRmContext;
         AddFields(ModRmContext.FieldsInOrder);
     }

--- a/src/Spice86.Core/Emulator/CPU/CfgCpu/ParsedInstruction/SelfModifying/SelectorNode.cs
+++ b/src/Spice86.Core/Emulator/CPU/CfgCpu/ParsedInstruction/SelfModifying/SelectorNode.cs
@@ -12,7 +12,7 @@ using System.Linq;
 /// Node that precedes self modifying code divergence point.
 /// To decide what is next node in the graph, the only way is to compare discriminators in SuccessorsPerDiscriminator with actual memory content. 
 /// </summary>
-public class SelectorNode(SegmentedAddress address) : CfgNode(address) {
+public class SelectorNode(SegmentedAddress address) : CfgNode(address, null) {
     public override bool IsLive => true;
 
     public Dictionary<Discriminator, CfgInstruction> SuccessorsPerDiscriminator { get; private set; } =


### PR DESCRIPTION
### Description of Changes
Previously, CfgCpu had to check at each cycle if the node to execute was properly linked to previous node.
This check was costly because it involved checking if a link existed between previous and current, and when reading next node from the graph to read it from a dictionary by address.
This check doesnt have to be done each time, most instructions can have only one successor so in this case when it is already there we cache it and say we don't need to check this instruction for new nodes.

### Rationale behind Changes
Improves performances by 30%?

### Suggested Testing Steps
Tested with 3dbench, dune and krondor
