### PR TITLE
Display Flags numeric content in debug view

### DIFF
--- a/src/Spice86/ViewModels/IRegistersViewModel.cs
+++ b/src/Spice86/ViewModels/IRegistersViewModel.cs
@@ -24,6 +24,11 @@ public interface IRegistersViewModel : INotifyPropertyChanged {
     ObservableCollection<RegisterViewModel> PointerRegisters { get; }
 
     /// <summary>
+    /// Gets the eflag register.
+    /// </summary>
+    public RegisterViewModel EFlagRegister { get; }
+
+    /// <summary>
     /// Gets the CPU flags.
     /// </summary>
     ObservableCollection<FlagViewModel> Flags { get; }

--- a/src/Spice86/ViewModels/RegistersViewModel.cs
+++ b/src/Spice86/ViewModels/RegistersViewModel.cs
@@ -5,6 +5,7 @@ using CommunityToolkit.Mvvm.ComponentModel;
 using Spice86.Core.Emulator.CPU;
 
 using System.Collections.ObjectModel;
+using System.Diagnostics.CodeAnalysis;
 
 /// <summary>
 /// View model for the CPU registers panel.
@@ -26,6 +27,11 @@ public partial class RegistersViewModel : ObservableObject, IRegistersViewModel 
     /// Gets the pointer registers.
     /// </summary>
     public ObservableCollection<RegisterViewModel> PointerRegisters { get; } = [];
+    
+    /// <summary>
+    /// Gets the eflag register.
+    /// </summary>
+    public RegisterViewModel EFlagRegister { get; private set; }
 
     /// <summary>
     /// Gets the CPU flags.
@@ -41,6 +47,7 @@ public partial class RegistersViewModel : ObservableObject, IRegistersViewModel 
         InitializeRegisters();
     }
 
+    [MemberNotNull(nameof(EFlagRegister))]
     private void InitializeRegisters() {
         // General purpose registers (32-bit versions as they were in DOS era)
         GeneralRegisters.Add(new RegisterViewModel("EAX", _state, s => s.EAX));
@@ -62,6 +69,8 @@ public partial class RegistersViewModel : ObservableObject, IRegistersViewModel 
         PointerRegisters.Add(new RegisterViewModel("EBP", _state, s => s.EBP));
         PointerRegisters.Add(new RegisterViewModel("ESI", _state, s => s.ESI));
         PointerRegisters.Add(new RegisterViewModel("EDI", _state, s => s.EDI));
+
+        EFlagRegister = new RegisterViewModel("FLAG", _state, s => s.Flags.FlagRegister);
 
         // Flags
         Flags.Add(new FlagViewModel("CF", _state, s => s.CarryFlag));
@@ -90,6 +99,8 @@ public partial class RegistersViewModel : ObservableObject, IRegistersViewModel 
         foreach (RegisterViewModel register in PointerRegisters) {
             register.Update();
         }
+        
+        EFlagRegister.Update();
 
         foreach (FlagViewModel flag in Flags) {
             flag.Update();

--- a/src/Spice86/Views/RegistersView.axaml
+++ b/src/Spice86/Views/RegistersView.axaml
@@ -132,9 +132,29 @@
                 CornerRadius="4"
                 Padding="8">
             <StackPanel>
-                <TextBlock Text="Flags"
-                           FontWeight="SemiBold"
-                           Margin="0,0,0,4" />
+                <ContentControl Content="{Binding EFlagRegister}">
+                    <ContentControl.ContentTemplate>
+                        <DataTemplate DataType="viewModels:RegisterViewModel">
+                            <Grid ColumnDefinitions="Auto,*" Margin="0,2, 2, 0">
+                                <TextBlock Grid.Column="0"
+                                           Text="{Binding Name}"
+                                           FontFamily="Consolas,Menlo,Monaco,monospace"
+                                           MinWidth="40"
+                                           Foreground="#78C9B0" />
+                                <StackPanel Grid.Column="1" Orientation="Horizontal">
+                                    <SelectableTextBlock Text="{Binding UpperWordHex}"
+                                                         FontFamily="Consolas,Menlo,Monaco,monospace"
+                                                         behaviors:HighlightBehavior.IsHighlighted="{Binding UpperWordChanged}" />
+
+                                    <SelectableTextBlock Text="{Binding LowerWordHex}"
+                                                         FontFamily="Consolas,Menlo,Monaco,monospace"
+                                                         behaviors:HighlightBehavior.IsHighlighted="{Binding LowByteChanged}"
+                                                         Margin="4,0,0,0" />
+                                </StackPanel>
+                            </Grid>
+                        </DataTemplate>
+                    </ContentControl.ContentTemplate>
+                </ContentControl>
                 <ItemsControl ItemsSource="{Binding Flags}">
                     <ItemsControl.ItemsPanel>
                         <ItemsPanelTemplate>


### PR DESCRIPTION
### Description of Changes
Adds a numeric view of the CPU flag value in debugger
<img width="1146" height="927" alt="image" src="https://github.com/user-attachments/assets/dcaee3ee-3634-4797-9586-ca961d06b85d" />

### Rationale behind Changes
Useful for debugging the emulator itself

### Suggested Testing Steps
