### PR TITLE
refactor: DosMemoryManager, DosMemoryControlBlock, ModifyBlock, DosProcessManager

### DIFF
--- a/src/Spice86.Core/Emulator/InterruptHandlers/Dos/DosInt21Handler.cs
+++ b/src/Spice86.Core/Emulator/InterruptHandlers/Dos/DosInt21Handler.cs
@@ -876,7 +876,7 @@ public class DosInt21Handler : InterruptHandler {
     /// <returns>
     /// CF is cleared on success. <br/>
     /// CF is set on error. BX is set to zero on error. <br/>
-    /// Possible error code in AX: 0x08 (Insufficient memory). <br/>
+    /// Possible error code in AX: 0x08 (Insufficient memory) or 0x09 (MCB block destroyed). <br/>
     /// On success, AX is set to the size of the MCB, which is at least equal to the requested size.
     /// </returns>
     /// <param name="calledFromVm">Whether the code was called by the emulator.</param>
@@ -888,15 +888,15 @@ public class DosInt21Handler : InterruptHandler {
                 requestedSizeInParagraphs, blockSegment);
         }
         DosErrorCode errorCode = _dosMemoryManager.TryModifyBlock(blockSegment,
-            ref requestedSizeInParagraphs, out _);
+            requestedSizeInParagraphs, out DosMemoryControlBlock mcb);
         if (errorCode == DosErrorCode.NoError) {
-            State.AX = requestedSizeInParagraphs;
+            State.AX = mcb.Size;
             SetCarryFlag(false, calledFromVm);
         } else {
             LogDosError(calledFromVm);
             SetCarryFlag(true, calledFromVm);
             State.AX = (byte)errorCode;
-            State.BX = requestedSizeInParagraphs;
+            State.BX = mcb.Size;
         }
     }
 

--- a/src/Spice86.Core/Emulator/InterruptHandlers/Dos/DosInt21Handler.cs
+++ b/src/Spice86.Core/Emulator/InterruptHandlers/Dos/DosInt21Handler.cs
@@ -887,15 +887,15 @@ public class DosInt21Handler : InterruptHandler {
             LoggerService.Verbose("MODIFY MEMORY BLOCK {Size}, {BlockSegment}",
                 requestedSizeInParagraphs, blockSegment);
         }
-        if (_dosMemoryManager.TryModifyBlock(blockSegment, ref requestedSizeInParagraphs,
-            out _)) {
+        DosErrorCode errorCode = _dosMemoryManager.TryModifyBlock(blockSegment,
+            ref requestedSizeInParagraphs, out _);
+        if (errorCode == DosErrorCode.NoError) {
             State.AX = requestedSizeInParagraphs;
             SetCarryFlag(false, calledFromVm);
         } else {
             LogDosError(calledFromVm);
-            // An error occurred. Report it as not enough memory.
             SetCarryFlag(true, calledFromVm);
-            State.AX = (byte)DosErrorCode.InsufficientMemory;
+            State.AX = (byte)errorCode;
             State.BX = requestedSizeInParagraphs;
         }
     }

--- a/src/Spice86.Core/Emulator/InterruptHandlers/Dos/DosInt21Handler.cs
+++ b/src/Spice86.Core/Emulator/InterruptHandlers/Dos/DosInt21Handler.cs
@@ -875,9 +875,10 @@ public class DosInt21Handler : InterruptHandler {
     /// </summary>
     /// <returns>
     /// CF is cleared on success. <br/>
-    /// CF is set on error. BX is set to zero on error. <br/>
-    /// Possible error code in AX: 0x08 (Insufficient memory) or 0x09 (MCB block destroyed). <br/>
     /// On success, AX is set to the size of the MCB, which is at least equal to the requested size.
+    /// CF is set on error. The error is in AX. <br/>
+    /// Possible error code in AX: 0x08 (Insufficient memory) or 0x09 (MCB block destroyed). <br/>
+    /// BX is set to largest free block size in paragraphs on error. <br/>
     /// </returns>
     /// <param name="calledFromVm">Whether the code was called by the emulator.</param>
     public void ModifyMemoryBlock(bool calledFromVm) {

--- a/src/Spice86.Core/Emulator/InterruptHandlers/Dos/DosInt21Handler.cs
+++ b/src/Spice86.Core/Emulator/InterruptHandlers/Dos/DosInt21Handler.cs
@@ -354,7 +354,7 @@ public class DosInt21Handler : InterruptHandler {
             State.BX = largest.Size;
             return;
         }
-        State.AX = res.UsableSpaceSegment;
+        State.AX = res.DataBlockSegment;
     }
 
     /// <summary>
@@ -887,14 +887,14 @@ public class DosInt21Handler : InterruptHandler {
                 requestedSize, blockSegment);
         }
         if (_dosMemoryManager.TryModifyBlock(blockSegment, ref requestedSize,
-            out DosMemoryControlBlock? modifiedBlock)) {
+            out _)) {
             State.AX = requestedSize;
             SetCarryFlag(false, calledFromVm);
         } else {
             LogDosError(calledFromVm);
             // An error occurred. Report it as not enough memory.
             SetCarryFlag(true, calledFromVm);
-            State.AX = 0x08;
+            State.AX = (byte)DosErrorCode.InsufficientMemory;
             State.BX = requestedSize;
         }
     }

--- a/src/Spice86.Core/Emulator/InterruptHandlers/Dos/DosInt21Handler.cs
+++ b/src/Spice86.Core/Emulator/InterruptHandlers/Dos/DosInt21Handler.cs
@@ -27,6 +27,7 @@ using System.Text;
 public class DosInt21Handler : InterruptHandler {
     private readonly DosMemoryManager _dosMemoryManager;
     private readonly DosDriveManager _dosDriveManager;
+    private readonly DosProcessManager _dosProcessManager;
     private readonly InterruptVectorTable _interruptVectorTable;
     private readonly DosFileManager _dosFileManager;
     private readonly KeyboardInt16Handler _keyboardInt16Handler;
@@ -51,13 +52,14 @@ public class DosInt21Handler : InterruptHandler {
     /// <param name="dosFileManager">The DOS class responsible for DOS file access.</param>
     /// <param name="dosDriveManager">The DOS class responsible for DOS volumes.</param>
     /// <param name="loggerService">The logger service implementation.</param>
-    public DosInt21Handler(IMemory memory,
+    public DosInt21Handler(IMemory memory, DosProcessManager dosProcessManager,
         IFunctionHandlerProvider functionHandlerProvider, Stack stack, State state,
         KeyboardInt16Handler keyboardInt16Handler, CountryInfo countryInfo,
         DosStringDecoder dosStringDecoder, DosMemoryManager dosMemoryManager,
         DosFileManager dosFileManager, DosDriveManager dosDriveManager, Clock clock, ILoggerService loggerService)
             : base(memory, functionHandlerProvider, stack, state, loggerService) {
         _countryInfo = countryInfo;
+        _dosProcessManager = dosProcessManager;
         _dosStringDecoder = dosStringDecoder;
         _keyboardInt16Handler = keyboardInt16Handler;
         _dosMemoryManager = dosMemoryManager;
@@ -810,7 +812,7 @@ public class DosInt21Handler : InterruptHandler {
     /// The segment of the current PSP in BX.
     /// </returns>
     public void GetPspAddress() {
-        ushort pspSegment = _dosMemoryManager.PspSegment;
+        ushort pspSegment = _dosProcessManager.GetCurrentPspSegment();
         State.BX = pspSegment;
         if (LoggerService.IsEnabled(LogEventLevel.Verbose)) {
             LoggerService.Verbose("GET PSP ADDRESS {PspSegment}",

--- a/src/Spice86.Core/Emulator/InterruptHandlers/Dos/DosInt21Handler.cs
+++ b/src/Spice86.Core/Emulator/InterruptHandlers/Dos/DosInt21Handler.cs
@@ -350,7 +350,7 @@ public class DosInt21Handler : InterruptHandler {
             SetCarryFlag(true, calledFromVm);
             DosMemoryControlBlock largest = _dosMemoryManager.FindLargestFree();
             // INSUFFICIENT MEMORY
-            State.AX = 0x08;
+            State.AX = (byte)DosErrorCode.InsufficientMemory;
             State.BX = largest.Size;
             return;
         }
@@ -683,7 +683,7 @@ public class DosInt21Handler : InterruptHandler {
             LogDosError(calledFromVm);
             SetCarryFlag(true, calledFromVm);
             // INVALID MEMORY BLOCK ADDRESS
-            State.AX = 0x09;
+            State.AX = (ushort)DosErrorCode.MemoryBlockAddressInvalid;
         }
     }
 

--- a/src/Spice86.Core/Emulator/OperatingSystem/Dos.cs
+++ b/src/Spice86.Core/Emulator/OperatingSystem/Dos.cs
@@ -159,10 +159,9 @@ public sealed class Dos {
         FileManager = new DosFileManager(_memory, dosStringDecoder, DosDriveManager,
             _loggerService, this.Devices);
         ProcessManager = new(configuration, memory, state, FileManager, DosDriveManager, envVars, loggerService);
-        MemoryManager = new DosMemoryManager(_memory, loggerService, ProcessManager.PspSegment, DosProcessManager.LastFreeSegment);
-        DosSysVars.FirstMCB = ProcessManager.PspSegment;
+        MemoryManager = new DosMemoryManager(_memory, DosSysVars, ProcessManager, loggerService);
         DosInt20Handler = new DosInt20Handler(_memory, functionHandlerProvider, stack, state, _loggerService);
-        DosInt21Handler = new DosInt21Handler(_memory, functionHandlerProvider, stack, state,
+        DosInt21Handler = new DosInt21Handler(_memory, ProcessManager, functionHandlerProvider, stack, state,
             keyboardInt16Handler, CountryInfo, dosStringDecoder,
             MemoryManager, FileManager, DosDriveManager, clock, _loggerService);
         DosInt2FHandler = new DosInt2fHandler(_memory, functionHandlerProvider, stack, state, _loggerService);

--- a/src/Spice86.Core/Emulator/OperatingSystem/Dos.cs
+++ b/src/Spice86.Core/Emulator/OperatingSystem/Dos.cs
@@ -159,7 +159,7 @@ public sealed class Dos {
         FileManager = new DosFileManager(_memory, dosStringDecoder, DosDriveManager,
             _loggerService, this.Devices);
         ProcessManager = new(configuration, memory, state, FileManager, DosDriveManager, envVars, loggerService);
-        MemoryManager = new DosMemoryManager(_memory, DosSysVars, ProcessManager, loggerService);
+        MemoryManager = new DosMemoryManager(_memory, ProcessManager, loggerService);
         DosInt20Handler = new DosInt20Handler(_memory, functionHandlerProvider, stack, state, _loggerService);
         DosInt21Handler = new DosInt21Handler(_memory, ProcessManager, functionHandlerProvider, stack, state,
             keyboardInt16Handler, CountryInfo, dosStringDecoder,

--- a/src/Spice86.Core/Emulator/OperatingSystem/DosMemoryManager.cs
+++ b/src/Spice86.Core/Emulator/OperatingSystem/DosMemoryManager.cs
@@ -24,7 +24,7 @@ public class DosMemoryManager {
     /// <param name="dosSysVars">The global memory variables of the DOS kernel.</param>
     /// <param name="processManager">The class responsible to launch DOS programs and take care of the DOS PSP chain.</param>
     /// <param name="loggerService">The logger service implementation.</param>
-    public DosMemoryManager(IMemory memory, DosSysVars dosSysVars,
+    public DosMemoryManager(IMemory memory,
         DosProcessManager processManager, ILoggerService loggerService) {
         _loggerService = loggerService;
         _processManager = processManager;
@@ -40,7 +40,6 @@ public class DosMemoryManager {
         _start.SetLast();
         //const ushort ConvMemSizeInParagraphs = MemoryMap.GraphicVideoMemorySegment - MemoryMap.FreeMemoryStartSegment - 1; // -1 for MCB itself
         //uint convMemSizeInKb = MemoryUtils.ToPhysicalAddress(MemoryMap.GraphicVideoMemorySegment, 0) - MemoryUtils.ToPhysicalAddress(MemoryMap.FreeMemoryStartSegment - 1, 0);
-        dosSysVars.FirstMCB = _processManager.GetCurrentPspSegment();
     }
 
     /// <summary>

--- a/src/Spice86.Core/Emulator/OperatingSystem/DosPathResolver.cs
+++ b/src/Spice86.Core/Emulator/OperatingSystem/DosPathResolver.cs
@@ -45,7 +45,7 @@ internal class DosPathResolver {
             }
         }
         currentDir = "";
-        return DosFileOperationResult.Error(ErrorCode.InvalidDrive);
+        return DosFileOperationResult.Error(DosErrorCode.InvalidDrive);
     }
 
     private static string GetFullCurrentDosPathOnDrive(VirtualDrive virtualDrive) =>
@@ -71,14 +71,14 @@ internal class DosPathResolver {
         string fullDosPath = GetFullDosPathIncludingRoot(dosPath);
 
         if (!StartsWithDosDriveAndVolumeSeparator(fullDosPath)) {
-            return DosFileOperationResult.Error(ErrorCode.PathNotFound);
+            return DosFileOperationResult.Error(DosErrorCode.PathNotFound);
         }
 
         string? hostPath = GetFullHostPathFromDosOrDefault(fullDosPath);
         if (!string.IsNullOrWhiteSpace(hostPath)) {
             return SetCurrentDirValue(fullDosPath[0], hostPath, fullDosPath);
         } else {
-            return DosFileOperationResult.Error(ErrorCode.PathNotFound);
+            return DosFileOperationResult.Error(DosErrorCode.PathNotFound);
         }
     }
 
@@ -95,7 +95,7 @@ internal class DosPathResolver {
         if (string.IsNullOrWhiteSpace(hostFullPath) ||
             !IsWithinMountPoint(hostFullPath, _dosDriveManager[driveLetter]) ||
             Encoding.ASCII.GetByteCount(fullDosPath) > MaxPathLength) {
-            return DosFileOperationResult.Error(ErrorCode.PathNotFound);
+            return DosFileOperationResult.Error(DosErrorCode.PathNotFound);
         }
 
         _dosDriveManager[driveLetter].CurrentDosDirectory = fullDosPath[3..];

--- a/src/Spice86.Core/Emulator/OperatingSystem/DosProcessManager.cs
+++ b/src/Spice86.Core/Emulator/OperatingSystem/DosProcessManager.cs
@@ -41,6 +41,10 @@ public class DosProcessManager : DosFileLoader {
         _fileManager = dosFileManager;
         _driveManager = dosDriveManager;
         _environmentVariables = new();
+        if(_loggerService.IsEnabled(LogEventLevel.Information)) {
+            _loggerService.Information("Initial program entry point at segment: 0x{EntryPointSegment:X2}",
+                configuration.ProgramEntryPointSegment);
+        }
         _programEntryPointSegment = configuration.ProgramEntryPointSegment;
 
         envVars.Add("PATH", $"{_driveManager.CurrentDrive.DosVolume}{DosPathResolver.DirectorySeparatorChar}");

--- a/src/Spice86.Core/Emulator/OperatingSystem/DosProcessManager.cs
+++ b/src/Spice86.Core/Emulator/OperatingSystem/DosProcessManager.cs
@@ -88,6 +88,23 @@ public class DosProcessManager : DosFileLoader {
     public override byte[] LoadFile(string file, string? arguments) {
         DosProgramSegmentPrefix psp = CurrentPsp;
 
+        //ushort pspSegment = GetCurrentPspSegment();
+        //ushort startSegment = (ushort)(pspSegment - 1);
+        //ushort size = (ushort)(DosMemoryManager.LastFreeSegment - startSegment);
+        //DosMemoryControlBlock pspMcb = new DosMemoryControlBlock(_memory,
+        //    MemoryUtils.ToPhysicalAddress(startSegment, 0));
+
+        //// size -1 because the mcb itself takes 16 bytes which is 1 paragraph
+        //pspMcb.Size = (ushort)(size - 1);
+
+        //string strippedName = Path.GetFileNameWithoutExtension(file);
+        //if (!string.IsNullOrWhiteSpace(strippedName)) {
+        //    strippedName = strippedName[..Math.Min(7, strippedName.Length)];
+        //    pspMcb.Owner = strippedName;
+        //}
+        //pspMcb.PspSegment = pspSegment;
+        //pspMcb.SetLast();
+
         // Set the PSP's first 2 bytes to INT 20h.
         psp.Exit[0] = 0xCD;
         psp.Exit[1] = 0x20;

--- a/src/Spice86.Core/Emulator/OperatingSystem/DosProcessManager.cs
+++ b/src/Spice86.Core/Emulator/OperatingSystem/DosProcessManager.cs
@@ -88,23 +88,6 @@ public class DosProcessManager : DosFileLoader {
     public override byte[] LoadFile(string file, string? arguments) {
         DosProgramSegmentPrefix psp = CurrentPsp;
 
-        //ushort pspSegment = GetCurrentPspSegment();
-        //ushort startSegment = (ushort)(pspSegment - 1);
-        //ushort size = (ushort)(DosMemoryManager.LastFreeSegment - startSegment);
-        //DosMemoryControlBlock pspMcb = new DosMemoryControlBlock(_memory,
-        //    MemoryUtils.ToPhysicalAddress(startSegment, 0));
-
-        //// size -1 because the mcb itself takes 16 bytes which is 1 paragraph
-        //pspMcb.Size = (ushort)(size - 1);
-
-        //string strippedName = Path.GetFileNameWithoutExtension(file);
-        //if (!string.IsNullOrWhiteSpace(strippedName)) {
-        //    strippedName = strippedName[..Math.Min(7, strippedName.Length)];
-        //    pspMcb.Owner = strippedName;
-        //}
-        //pspMcb.PspSegment = pspSegment;
-        //pspMcb.SetLast();
-
         // Set the PSP's first 2 bytes to INT 20h.
         psp.Exit[0] = 0xCD;
         psp.Exit[1] = 0x20;

--- a/src/Spice86.Core/Emulator/OperatingSystem/Enums/DosErrorCode.cs
+++ b/src/Spice86.Core/Emulator/OperatingSystem/Enums/DosErrorCode.cs
@@ -3,7 +3,7 @@ namespace Spice86.Core.Emulator.OperatingSystem.Enums;
 /// <summary>
 /// Defines error codes for MS-DOS operations.
 /// </summary>
-public enum ErrorCode : byte
+public enum DosErrorCode : byte
 {
     /// <summary>
     /// No error occurred during the operation.

--- a/src/Spice86.Core/Emulator/OperatingSystem/Structures/DosFileOperationResult.cs
+++ b/src/Spice86.Core/Emulator/OperatingSystem/Structures/DosFileOperationResult.cs
@@ -21,7 +21,7 @@ public class DosFileOperationResult {
     /// </summary>
     /// <param name="errorCode">The error code.</param>
     /// <returns>A new instance of the class indicating an error.</returns>
-    public static DosFileOperationResult Error(ErrorCode errorCode) {
+    public static DosFileOperationResult Error(DosErrorCode errorCode) {
         return new DosFileOperationResult(true, false, (uint?)errorCode);
     }
 

--- a/src/Spice86.Core/Emulator/OperatingSystem/Structures/DosMemoryControlBlock.cs
+++ b/src/Spice86.Core/Emulator/OperatingSystem/Structures/DosMemoryControlBlock.cs
@@ -1,23 +1,24 @@
 ﻿namespace Spice86.Core.Emulator.OperatingSystem.Structures;
 
-using System.ComponentModel.DataAnnotations;
-using System.Text;
-
-using Spice86.Core.Emulator.Memory;
 using Spice86.Core.Emulator.Memory.ReaderWriter;
 using Spice86.Core.Emulator.ReverseEngineer.DataStructure;
 using Spice86.Shared.Utils;
 
+using System.ComponentModel.DataAnnotations;
+using System.Diagnostics;
+using System.Text;
+
 /// <summary>
 /// Represents a MCB in memory.
 /// </summary>
+[DebuggerDisplay("Owner = {Owner}, AllocationSizeInBytes = {AllocationSizeInBytes}, IsFree = {IsFree}, IsValid = {IsValid}, IsLast = {IsLast}")]
 public class DosMemoryControlBlock : MemoryBasedDataStructure {
     private const int FilenameFieldSize = 8;
     private const int TypeFieldOffset = 0;
     private const int PspSegmentFieldOffset = TypeFieldOffset + 1;
     private const int SizeFieldOffset = PspSegmentFieldOffset + 2;
     private const int FilenameFieldOffset = SizeFieldOffset + 2 + 3;
-    private const byte FreeMcbMarker = 0x0;
+    public const byte FreeMcbMarker = 0x0;
     private const byte McbLastEntry = 0x5A;
     private const byte McbNonLastEntry = 0x4D;
 
@@ -28,24 +29,6 @@ public class DosMemoryControlBlock : MemoryBasedDataStructure {
     /// <param name="baseAddress">the address of the structure in memory.</param>
     public DosMemoryControlBlock(IByteReaderWriter byteReaderWriter, uint baseAddress) : base(byteReaderWriter, baseAddress) {
     }
-    /// <summary>
-    /// Gets or sets the name of the file associated with the MCB.
-    /// </summary>
-    [Range(0, 8)]
-    public string FileName { get => GetZeroTerminatedString(FilenameFieldOffset, FilenameFieldSize); set => SetZeroTerminatedString(FilenameFieldOffset, value, FilenameFieldSize); }
-
-    /// <summary>
-    /// Gets or sets the PSP segment associated with the MCB.
-    /// </summary>
-    public ushort PspSegment { get => UInt16[PspSegmentFieldOffset]; set => UInt16[PspSegmentFieldOffset] = value; }
-
-    /// <summary>
-    /// Gets or sets the size of the MCB in paragraphs.
-    /// </summary>
-    /// <remarks>
-    /// The size of an MCB is always specified in paragraphs.
-    /// </remarks>
-    public ushort Size { get => UInt16[SizeFieldOffset]; set => UInt16[SizeFieldOffset] = value; }
 
     /// <summary>
     /// Gets or sets the type field of the MCB.
@@ -56,13 +39,40 @@ public class DosMemoryControlBlock : MemoryBasedDataStructure {
     public byte TypeField { get => UInt8[TypeFieldOffset]; set => UInt8[TypeFieldOffset] = value; }
 
     /// <summary>
+    /// Gets or sets the name of the file associated with the MCB.
+    /// </summary>
+    [Range(0, 8)]
+    public string Owner { get => GetZeroTerminatedString(FilenameFieldOffset, FilenameFieldSize); set => SetZeroTerminatedString(FilenameFieldOffset, value, FilenameFieldSize); }
+
+    /// <summary>
+    /// Gets or sets the PSP segment associated with the MCB.
+    /// </summary>
+    public ushort PspSegment { get => UInt16[PspSegmentFieldOffset]; set => UInt16[PspSegmentFieldOffset] = value; }
+
+    /// <summary>
+    /// Gets or sets the size of the MCB in paragraphs (16 bytes).
+    /// </summary>
+    /// <remarks>
+    /// The size of an MCB is always specified in paragraphs.
+    /// </remarks>
+    public ushort Size { get => UInt16[SizeFieldOffset]; set => UInt16[SizeFieldOffset] = value; }
+
+    public int AllocationSizeInBytes => Size * 16;
+
+    /// <summary>
     /// Gets the usable space segment associated with the MCB.
     /// </summary>
-    public ushort UsableSpaceSegment => (ushort)(MemoryUtils.ToSegment(BaseAddress) + 1);
+    /// <remarks>
+    /// Allocation starts here and extends for <see cref="Size"/> * 16 bytes.
+    /// </remarks>
+    public ushort DataBlockSegment => (ushort)(MemoryUtils.ToSegment(BaseAddress) + 1);
 
     /// <summary>
     /// Gets a value indicating whether the MCB is free.
     /// </summary>
+    /// <remarks>
+    /// It is free only if the PspSegment is <c>0</c>
+    /// </remarks>
     public bool IsFree => PspSegment == FreeMcbMarker;
 
     /// <summary>
@@ -76,15 +86,15 @@ public class DosMemoryControlBlock : MemoryBasedDataStructure {
     public bool IsNonLast => TypeField == McbNonLastEntry;
 
     /// <summary>
-    /// Returns if the MCB is valid.
+    /// Returns if the MCB is valid (must be Last or NonLast).
     /// </summary>
     public bool IsValid => IsLast || IsNonLast;
 
     /// <summary>
     /// Returns the next MCB in the MCB in chain, or null if not found.
     /// </summary>
-    /// <returns>The next MCB if found, <c>null</c> otherwise.</returns>
-    public DosMemoryControlBlock? Next() {
+    /// <returns>The next MCB if found, <see langword="null" /> otherwise.</returns>
+    public DosMemoryControlBlock? GetNextOrDefault() {
         uint baseAddress = BaseAddress + MemoryUtils.ToPhysicalAddress((ushort)(Size + 1), 0);
         if (baseAddress >= ByteReaderWriter.Length) {
             return null;
@@ -94,11 +104,18 @@ public class DosMemoryControlBlock : MemoryBasedDataStructure {
     }
 
     /// <summary>
+    /// Gets the Psp as <see cref="DosProgramSegmentPrefix"/> structure,
+    /// or <see langword="null"/> if <see cref="PspSegment"/> is not set.
+    /// </summary>
+    public DosProgramSegmentPrefix? ProgramSegmentPrefix => PspSegment == 0 ? null :
+        new DosProgramSegmentPrefix(ByteReaderWriter, MemoryUtils.ToPhysicalAddress(PspSegment, 0));
+
+    /// <summary>
     /// Releases the MCB.
     /// </summary>
     public void SetFree() {
         PspSegment = FreeMcbMarker;
-        FileName = "";
+        Owner = "";
     }
 
     /// <summary>
@@ -122,11 +139,11 @@ public class DosMemoryControlBlock : MemoryBasedDataStructure {
             .Append(" IsLast:").Append(IsLast)
             .Append(" IsNonLast:").Append(IsNonLast)
             .Append(" BaseAddress: ").Append(BaseAddress)
-            .Append(" UsableSpaceSegment: ").Append(UsableSpaceSegment)
+            .Append(" UsableSpaceSegment: ").Append(DataBlockSegment)
             .Append(" TypeField: ").Append(TypeField)
             .Append(" PspSegment: ").Append(PspSegment)
             .Append(" Size: ").Append(Size)
-            .Append(" FileName: ").Append(FileName)
+            .Append(" FileName: ").Append(Owner)
             .ToString();
     }
 }

--- a/src/Spice86.Core/Emulator/OperatingSystem/Structures/DosProgramSegmentPrefix.cs
+++ b/src/Spice86.Core/Emulator/OperatingSystem/Structures/DosProgramSegmentPrefix.cs
@@ -4,9 +4,12 @@ using Spice86.Core.Emulator.Memory.ReaderWriter;
 using Spice86.Core.Emulator.ReverseEngineer.DataStructure;
 using Spice86.Core.Emulator.ReverseEngineer.DataStructure.Array;
 
+using System.Diagnostics;
+
 /// <summary>
 /// Represents the Program Segment Prefix (PSP)
 /// </summary>
+[DebuggerDisplay("BaseAddress={BaseAddress}, Parent={ParentProgramSegmentPrefix}, EnvSegment={EnvironmentTableSegment}, NextSegment={NextSegment}, StackPointer={StackPointer}, Cmd={DosCommandTail.Command}")]
 public sealed class DosProgramSegmentPrefix : MemoryBasedDataStructure {
     public const ushort MaxLength = 0x80 + 128;
 

--- a/src/Spice86.Core/Emulator/OperatingSystem/Structures/DosSysVars.cs
+++ b/src/Spice86.Core/Emulator/OperatingSystem/Structures/DosSysVars.cs
@@ -13,6 +13,7 @@ using Spice86.Core.Emulator.ReverseEngineer.DataStructure.Array;
 /// In DOSBox, this is the 'DOS_InfoBlock' class 
 /// </remarks>
 public class DosSysVars : MemoryBasedDataStructure {
+    public const int FirstMcbSegment = 0x16F;
     private readonly DosDeviceHeader _nullDeviceHeader;
     /// <summary>
     /// Initializes a new instance of the <see cref="DosSysVars"/> class.
@@ -30,7 +31,7 @@ public class DosSysVars : MemoryBasedDataStructure {
         ExtendedMemorySize = (ushort)(byteReaderWriter.Length / 1024);
         MinMemForExec = 0x0;
         A20GateFixRoutineOffset = 0x0;
-        MemAllocScanStart = 0x16f;
+        MemAllocScanStart = FirstMcbSegment;
         MaxSectorLength = 0x200;
         RegCXfrom5e = 0x0;
         CountLRUCache = 0x0;
@@ -38,7 +39,7 @@ public class DosSysVars : MemoryBasedDataStructure {
         SharingCount = 0x0;
         SharingDelay = 0x0;
         PtrCONInput = 0x0;
-        FirstMCB = 0x16F;
+        FirstMCB = FirstMcbSegment;
         DirtyDiskBuffers = 0x0;
         LookaheadBufPt = 0x0;
         LookaheadBufNumber = 0x0;

--- a/src/Spice86.Core/Emulator/OperatingSystem/Structures/DosSysVars.cs
+++ b/src/Spice86.Core/Emulator/OperatingSystem/Structures/DosSysVars.cs
@@ -38,7 +38,7 @@ public class DosSysVars : MemoryBasedDataStructure {
         SharingCount = 0x0;
         SharingDelay = 0x0;
         PtrCONInput = 0x0;
-        FirstMCB = 0x0;
+        FirstMCB = 0x16F;
         DirtyDiskBuffers = 0x0;
         LookaheadBufPt = 0x0;
         LookaheadBufNumber = 0x0;


### PR DESCRIPTION
### Description of Changes

Makes DosMemoryManager and DosProcessManager more object oriented.

Clarifies a lot about DOS MCB with renamed properties and documentation.

Makes ModifiyBlock return the proper error code if the MCB is destroyed.

DosProcessManager has a CurrentPsp property now.

### Rationale behind Changes

Those refactoring enable more refactorings later to support:

- Games demanding 604+ KB of free conv. memory (for example: Tom Long)
- DOS Processes
- TSRs

### Suggested Testing Steps

Already tested with prince of persia, Dune, Krondor, Dune 2, and PoP2 (well, until it stops because of other bugs)