### PR TITLE
Improve headless mode

### DIFF
--- a/src/Spice86/ViewModels/HeadlessGui.cs
+++ b/src/Spice86/ViewModels/HeadlessGui.cs
@@ -1,0 +1,143 @@
+﻿namespace Spice86.ViewModels;
+
+using Spice86.Shared.Emulator.Keyboard;
+using Spice86.Shared.Emulator.Mouse;
+using Spice86.Shared.Emulator.Video;
+using Spice86.Shared.Interfaces;
+
+/// <inheritdoc cref="Spice86.Shared.Interfaces.IGui" />
+public sealed class HeadlessGui : IGui, IDisposable {
+    private const double ScreenRefreshHz = 60;
+    private static readonly TimeSpan RefreshInterval = TimeSpan.FromMilliseconds(1000.0 / ScreenRefreshHz);
+    private readonly SemaphoreSlim? _drawingSemaphoreSlim = new(1, 1);
+
+    private bool _disposed;
+
+    private Timer? _drawTimer;
+    private bool _isAppClosing;
+    private bool _isSettingResolution;
+
+    private byte[]? _pixelBuffer;
+    private bool _renderingTimerInitialized;
+
+    public HeadlessGui() {
+        AppDomain.CurrentDomain.ProcessExit += OnProcessExit;
+        Console.CancelKeyPress += OnProcessExit;
+    }
+
+    public void Dispose() {
+        Dispose(true);
+        GC.SuppressFinalize(this);
+    }
+
+    public void ShowMouseCursor() {
+    }
+
+    public void HideMouseCursor() {
+    }
+
+    public event EventHandler<KeyboardEventArgs>? KeyUp;
+    public event EventHandler<KeyboardEventArgs>? KeyDown;
+    public event EventHandler<MouseMoveEventArgs>? MouseMoved;
+    public event EventHandler<MouseButtonEventArgs>? MouseButtonDown;
+    public event EventHandler<MouseButtonEventArgs>? MouseButtonUp;
+    public event EventHandler<UIRenderEventArgs>? RenderScreen;
+
+    public int Width { get; private set; }
+
+    public int Height { get; private set; }
+
+    public double MouseX { get; set; }
+
+    public double MouseY { get; set; }
+
+    public void SetResolution(int width, int height) {
+        if (width <= 0 || height <= 0) {
+            throw new ArgumentOutOfRangeException($"Invalid resolution: {width}x{height}");
+        }
+
+        _isSettingResolution = true;
+        try {
+            if (Width != width || Height != height) {
+                Width = width;
+                Height = height;
+                if (_disposed) {
+                    return;
+                }
+
+                int bufferSize = width * height * 4;
+
+                _drawingSemaphoreSlim?.Wait();
+                try {
+                    if (_pixelBuffer == null || _pixelBuffer.Length != bufferSize) {
+                        _pixelBuffer = new byte[bufferSize];
+                    }
+
+                    Array.Clear(_pixelBuffer, 0, _pixelBuffer.Length);
+                } finally {
+                    if (!_disposed) {
+                        _drawingSemaphoreSlim?.Release();
+                    }
+                }
+            }
+        } finally {
+            _isSettingResolution = false;
+        }
+
+        InitializeRenderingTimer();
+    }
+
+    private void OnProcessExit(object? sender, EventArgs e) {
+        _isAppClosing = true;
+    }
+
+    private void InitializeRenderingTimer() {
+        if (_renderingTimerInitialized) {
+            return;
+        }
+
+        _renderingTimerInitialized = true;
+        _drawTimer = new Timer(DrawScreenCallback, null, RefreshInterval, RefreshInterval);
+    }
+
+    private void DrawScreenCallback(object? state) {
+        DrawScreen();
+    }
+
+    private unsafe void DrawScreen() {
+        if (_disposed || _isSettingResolution || _isAppClosing || _pixelBuffer is null || RenderScreen is null) {
+            return;
+        }
+
+        _drawingSemaphoreSlim?.Wait();
+        try {
+            fixed (byte* bufferPtr = _pixelBuffer) {
+                int rowBytes = Width * 4; // 4 bytes per pixel (BGRA)
+                int length = rowBytes * Height / 4;
+
+                var uiRenderEventArgs = new UIRenderEventArgs((IntPtr)bufferPtr, length);
+                RenderScreen.Invoke(this, uiRenderEventArgs);
+            }
+        } finally {
+            if (!_disposed) {
+                _drawingSemaphoreSlim?.Release();
+            }
+        }
+    }
+
+    private void Dispose(bool disposing) {
+        if (_disposed) {
+            return;
+        }
+
+        _disposed = true;
+        if (!disposing) {
+            return;
+        }
+
+        _drawTimer?.Dispose();
+
+        _pixelBuffer = null;
+        _drawingSemaphoreSlim?.Dispose();
+    }
+}


### PR DESCRIPTION
The original implementation did not use a GUI, which made it so that applications behave differently in headless mode - some waiting for certain register values for example.

I noticed this difference in Space Job which throws an exception in GUI mode but just loops indefinitely in headless mode.

I also tried Avalonias Headless mode which also works fine but obviously requires more resources.

### Description of Changes
Introduce a headless GUI to simulate rendering at 60 Hz with a fake framebuffer.

### Rationale behind Changes
Improve headless mode to behave similarly to GUI mode.

### Suggested Testing Steps
Run some games in headless mode.
