### PR TITLE
Feature: add Avalonia headless mode

### DIFF
--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -10,6 +10,7 @@
     <PackageVersion Include="Avalonia.Desktop" Version="11.3.2" />
     <PackageVersion Include="Avalonia.Diagnostics" Version="11.3.2" />
     <PackageVersion Include="Avalonia.Fonts.Inter" Version="11.3.2" />
+    <PackageVersion Include="Avalonia.Headless" Version="11.3.2"/>
     <PackageVersion Include="AvaloniaGraphControl" Version="0.6.1" />
     <PackageVersion Include="AvaloniaHex" Version="0.1.8" />
     <PackageVersion Include="BenchmarkDotNet" Version="0.15.2" />

--- a/src/Spice86.Core/CLI/Configuration.cs
+++ b/src/Spice86.Core/CLI/Configuration.cs
@@ -54,9 +54,25 @@ public sealed class Configuration {
     /// <summary> Gets a value indicating whether the <see cref="UseCodeOverride"/> option is set to true. </summary>
     public bool UseCodeOverrideOption => UseCodeOverride ?? true;
 
-    /// <summary> Headless mode. If true, no GUI is shown. </summary>
-    [Option('h', nameof(HeadlessMode), Default = false, Required = false, HelpText = "Headless mode. If true, no GUI is shown.")]
+    /// <summary>
+    ///     Flag indicating if headless mode is enabled. Using this option without a value sets it to Default.
+    /// </summary>
+    [Option('h', nameof(HeadlessMode), Default = false, Required = false,
+        HelpText =
+            "Headless mode. Use without parameter for default headless mode, or specify 'Default' or 'Avalonia'.")]
     public bool HeadlessMode { get; init; }
+
+    /// <summary>
+    ///     The type of headless mode to use if headless mode is enabled.
+    /// </summary>
+    [Value(0, MetaName = "HeadlessType", Default = HeadlessType.Default, Required = false,
+        HelpText = "Type of headless mode to use: Default or Avalonia")]
+    public HeadlessType HeadlessType { get; init; }
+
+    /// <summary>
+    ///     Gets the effective headless type based on the HeadlessMode flag and HeadlessType value.
+    /// </summary>
+    public HeadlessType? EffectiveHeadlessType => HeadlessMode ? HeadlessType : null;
 
     /// <summary> When true, records data at runtime and dumps them at exit time. </summary>
     [Option('d', nameof(DumpDataOnExit), Default = null, Required = false, HelpText = "When true, records data at runtime and dumps them at exit time")]

--- a/src/Spice86.Core/CLI/HeadlessType.cs
+++ b/src/Spice86.Core/CLI/HeadlessType.cs
@@ -1,0 +1,13 @@
+﻿namespace Spice86.Core.CLI;
+
+public enum HeadlessType {
+    /// <summary>
+    ///     Use the default headless mode, which doesn't render any UI elements
+    /// </summary>
+    Default,
+
+    /// <summary>
+    ///     Use Avalonia headless mode, which uses the full UI and consumes a bit more memory
+    /// </summary>
+    Avalonia
+}

--- a/src/Spice86/Program.cs
+++ b/src/Spice86/Program.cs
@@ -1,9 +1,10 @@
 ﻿namespace Spice86;
 
-using Spice86.Logging;
-using Spice86.Core.CLI;
-using Spice86.Shared.Interfaces;
 using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Headless;
+
+using Spice86.Core.CLI;
 
 /// <summary>
 /// Entry point for Spice86 application.
@@ -35,12 +36,22 @@ public class Program {
         if (configuration == null) {
             return;
         }
-        if (configuration.HeadlessMode) {
-            Spice86DependencyInjection spice86DependencyInjection = new(configuration);
-            spice86DependencyInjection.HeadlessModeStart();
-        } else {
-            // Run in GUI mode
-            BuildAvaloniaApp().StartWithClassicDesktopLifetime(args);
+
+        switch (configuration.EffectiveHeadlessType) {
+            case HeadlessType.Default: {
+                Spice86DependencyInjection spice86DependencyInjection = new(configuration);
+                spice86DependencyInjection.HeadlessModeStart();
+                break;
+            }
+            case HeadlessType.Avalonia:
+                BuildAvaloniaApp().UseSkia().UseHeadless(new AvaloniaHeadlessPlatformOptions {
+                    UseHeadlessDrawing = false
+                }).StartWithClassicDesktopLifetime(args, ShutdownMode.OnLastWindowClose);
+                break;
+            default:
+                // Start the application
+                BuildAvaloniaApp().StartWithClassicDesktopLifetime(args);
+                break;
         }
     }
 

--- a/src/Spice86/Spice86.csproj
+++ b/src/Spice86/Spice86.csproj
@@ -26,6 +26,7 @@
     <!--Condition below is needed to remove Avalonia.Diagnostics package from build output in Release configuration.-->
     <PackageReference Condition="'$(Configuration)' == 'Debug'" Include="Avalonia.Diagnostics" />
     <PackageReference Include="Avalonia.Fonts.Inter" />
+    <PackageReference Include="Avalonia.Headless"/>
     <PackageReference Include="PanAndZoom" />
     <PackageReference Include="AvaloniaGraphControl" />
     <PackageReference Include="AvaloniaHex" />

--- a/src/Spice86/Spice86DependencyInjection.cs
+++ b/src/Spice86/Spice86DependencyInjection.cs
@@ -46,8 +46,6 @@ using Spice86.ViewModels;
 using Spice86.ViewModels.Services;
 using Spice86.Views;
 
-using System;
-
 /// <summary>
 /// Class responsible for compile-time dependency injection and runtime emulator lifecycle management
 /// </summary>
@@ -304,7 +302,7 @@ public class Spice86DependencyInjection : IDisposable {
         UIDispatcher? uiDispatcher = null;
         HostStorageProvider? hostStorageProvider = null;
         TextClipboard? textClipboard = null;
-
+        
         if(mainWindow != null) {
             uiDispatcher = new UIDispatcher(Dispatcher.UIThread);
             hostStorageProvider = new HostStorageProvider(
@@ -316,9 +314,13 @@ public class Spice86DependencyInjection : IDisposable {
 
             mainWindow.PerformanceViewModel = performanceViewModel;
 
-            mainWindowViewModel = new(
+            IExceptionHandler exceptionHandler = configuration.EffectiveHeadlessType != null
+                ? new HeadlessModeExceptionHandler(uiDispatcher)
+                : new MainWindowExceptionHandler(pauseHandler);
+
+            mainWindowViewModel = new MainWindowViewModel(
                 timer, uiDispatcher, hostStorageProvider, textClipboard, configuration,
-                loggerService, pauseHandler, performanceViewModel);
+                loggerService, pauseHandler, performanceViewModel, exceptionHandler);
             _gui = mainWindowViewModel;
         } else {
             _gui = new HeadlessGui();

--- a/src/Spice86/ViewModels/MainWindowViewModel.cs
+++ b/src/Spice86/ViewModels/MainWindowViewModel.cs
@@ -33,6 +33,7 @@ public sealed partial class MainWindowViewModel : ViewModelWithErrorDialog, IGui
     private readonly IPauseHandler _pauseHandler;
     private readonly ITimeMultiplier _pit;
     private readonly PerformanceViewModel _performanceViewModel;
+    private readonly IExceptionHandler _exceptionHandler;
 
     [ObservableProperty]
     private Configuration _configuration;
@@ -58,10 +59,11 @@ public sealed partial class MainWindowViewModel : ViewModelWithErrorDialog, IGui
         ITimeMultiplier pit, IUIDispatcher uiDispatcher,
         IHostStorageProvider hostStorageProvider, ITextClipboard textClipboard,
         Configuration configuration, ILoggerService loggerService,
-        IPauseHandler pauseHandler, PerformanceViewModel performanceViewModel)
+        IPauseHandler pauseHandler, PerformanceViewModel performanceViewModel, IExceptionHandler exceptionHandler)
         : base(uiDispatcher, textClipboard) {
         _pit = pit;
         _performanceViewModel = performanceViewModel;
+        _exceptionHandler = exceptionHandler;
         _avaloniaKeyScanCodeConverter = new AvaloniaKeyScanCodeConverter();
         Configuration = configuration;
         _loggerService = loggerService;
@@ -386,7 +388,7 @@ public sealed partial class MainWindowViewModel : ViewModelWithErrorDialog, IGui
     }
 
     private void OnEmulatorErrorOccured(Exception e) {
-        _pauseHandler.RequestPause("Inspect emulator error");
+        _exceptionHandler.Handle(e);
         _uiDispatcher.Post(() => {
             StatusMessage = "Emulator crashed.";
             ShowError(e);

--- a/src/Spice86/ViewModels/Services/IExceptionHandler.cs
+++ b/src/Spice86/ViewModels/Services/IExceptionHandler.cs
@@ -1,0 +1,36 @@
+﻿namespace Spice86.ViewModels.Services;
+
+using Avalonia;
+using Avalonia.Controls.ApplicationLifetimes;
+
+using Spice86.Core.Emulator.VM;
+
+using System.Runtime.InteropServices;
+
+public interface IExceptionHandler {
+    void Handle(Exception e);
+}
+
+/// <summary>
+///     Handles exceptions when the application is running in headless mode.
+/// </summary>
+/// <remarks>
+///     If the application lifetime exists, it will attempt a graceful shutdown.
+///     Otherwise, it terminates the application with an exit code.
+/// </remarks>
+public class HeadlessModeExceptionHandler(IUIDispatcher uiDispatcher) : IExceptionHandler {
+    public void Handle(Exception e) {
+        int resultCode = Marshal.GetHRForException(e);
+        if (Application.Current?.ApplicationLifetime is IControlledApplicationLifetime lifetime) {
+            uiDispatcher.Post(() => lifetime.Shutdown(resultCode));
+        } else {
+            Environment.Exit(resultCode);
+        }
+    }
+}
+
+public class MainWindowExceptionHandler(IPauseHandler pauseHandler) : IExceptionHandler {
+    public void Handle(Exception e) {
+        pauseHandler.RequestPause("Inspect emulator error");
+    }
+}


### PR DESCRIPTION
### Description of Changes
This MR adds Avalonias own headless mode which uses the same application lifecycle as the GUI-mode minus the rendering. This can be used for future end-to-end tests, for test automation and other fancy things.

As the default application would not exit on exceptions, I had to introduce a new exception handler which reacts to exceptions appropriately.

The user can start the headless mode in multiple ways:

-h | --HeadlessMode    =    Run with Default (fake Headless GUI)
-h Default | --HeadlessMode Default    =    Run with Default (fake Headless GUI)
-h Avalonia | --HeadlessMode Avalonia    =    Run with Avalonia Headless

### Rationale behind Changes
More flexibility and a headless environment which is as close to the GUI as possible. It allows fancy things like taking screenshots, unit/integration tests and so on.

### Suggested Testing Steps
Run the application with different headless modes
