### PR TITLE
fix: headless param should now be properly parsed

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ If there is already data there the emulator will load it first and complete it, 
   -i, --InstructionsPerSecond        <number of instructions that have to be executed by the emulator to consider a second passed> if blank will use time based timer.
   -t, --TimeMultiplier               (Default: 1) <time multiplier> if >1 will go faster, if <1 will go slower.
   -d, --DumpDataOnExit               (Default: true) When true, records data at runtime and dumps them at exit time
-  -h, --HeadlessMode                 (Default: false) Headless mode. If true, no GUI is shown.
+  -h, --HeadlessMode [Mode]          (Default: false) Headless mode. The mode 'Minimal' does not use any UI components, 'Avalonia' uses the full UI and consumes a bit more memory.
   -l, --VerboseLogs                  (Default: false) Enable verbose level logs
   -w, --WarningLogs                  (Default: false) Enable warning level logs
   -s, --SilencedLogs                 (Default: false) Disable all logs

--- a/src/Spice86.Core/CLI/Configuration.cs
+++ b/src/Spice86.Core/CLI/Configuration.cs
@@ -57,22 +57,10 @@ public sealed class Configuration {
     /// <summary>
     ///     Flag indicating if headless mode is enabled. Using this option without a value sets it to Default.
     /// </summary>
-    [Option('h', nameof(HeadlessMode), Default = false, Required = false,
+    [Option('h', nameof(HeadlessMode), Default = null, Required = false,
         HelpText =
-            "Headless mode. Use without parameter for default headless mode, or specify 'Default' or 'Avalonia'.")]
-    public bool HeadlessMode { get; init; }
-
-    /// <summary>
-    ///     The type of headless mode to use if headless mode is enabled.
-    /// </summary>
-    [Value(0, MetaName = "HeadlessType", Default = HeadlessType.Default, Required = false,
-        HelpText = "Type of headless mode to use: Default or Avalonia")]
-    public HeadlessType HeadlessType { get; init; }
-
-    /// <summary>
-    ///     Gets the effective headless type based on the HeadlessMode flag and HeadlessType value.
-    /// </summary>
-    public HeadlessType? EffectiveHeadlessType => HeadlessMode ? HeadlessType : null;
+            "Headless mode. 'Minimal' does not use any UI components, 'Avalonia' uses the full UI and consumes a bit more memory.")]
+    public HeadlessType? HeadlessMode { get; init; }
 
     /// <summary> When true, records data at runtime and dumps them at exit time. </summary>
     [Option('d', nameof(DumpDataOnExit), Default = null, Required = false, HelpText = "When true, records data at runtime and dumps them at exit time")]

--- a/src/Spice86.Core/CLI/HeadlessType.cs
+++ b/src/Spice86.Core/CLI/HeadlessType.cs
@@ -2,9 +2,9 @@
 
 public enum HeadlessType {
     /// <summary>
-    ///     Use the default headless mode, which doesn't render any UI elements
+    ///     Use the minimal headless mode, which doesn't render any UI elements
     /// </summary>
-    Default,
+    Minimal,
 
     /// <summary>
     ///     Use Avalonia headless mode, which uses the full UI and consumes a bit more memory

--- a/src/Spice86/Program.cs
+++ b/src/Spice86/Program.cs
@@ -37,8 +37,8 @@ public class Program {
             return;
         }
 
-        switch (configuration.EffectiveHeadlessType) {
-            case HeadlessType.Default: {
+        switch (configuration.HeadlessMode) {
+            case HeadlessType.Minimal: {
                 Spice86DependencyInjection spice86DependencyInjection = new(configuration);
                 spice86DependencyInjection.HeadlessModeStart();
                 break;

--- a/src/Spice86/Spice86DependencyInjection.cs
+++ b/src/Spice86/Spice86DependencyInjection.cs
@@ -314,9 +314,10 @@ public class Spice86DependencyInjection : IDisposable {
 
             mainWindow.PerformanceViewModel = performanceViewModel;
 
-            IExceptionHandler exceptionHandler = configuration.EffectiveHeadlessType != null
-                ? new HeadlessModeExceptionHandler(uiDispatcher)
-                : new MainWindowExceptionHandler(pauseHandler);
+            IExceptionHandler exceptionHandler = configuration.HeadlessMode switch {
+                null => new MainWindowExceptionHandler(pauseHandler),
+                _ => new HeadlessModeExceptionHandler(uiDispatcher)
+            };
 
             mainWindowViewModel = new MainWindowViewModel(
                 timer, uiDispatcher, hostStorageProvider, textClipboard, configuration,

--- a/tests/Spice86.Tests/Spice86Creator.cs
+++ b/tests/Spice86.Tests/Spice86Creator.cs
@@ -4,8 +4,6 @@ using Spice86.Core.CLI;
 using Spice86.Core.Emulator.Devices.Sound;
 using Spice86.Core.Emulator.VM.Breakpoint;
 
-using System;
-
 using Xunit;
 
 public class Spice86Creator {
@@ -23,7 +21,7 @@ public class Spice86Creator {
             DumpDataOnExit = recordData,
             TimeMultiplier = enablePit ? 1 : 0,
             //Don"t need nor want to instantiate the UI in emulator unit tests
-            HeadlessMode = true,
+            HeadlessMode = HeadlessType.Minimal,
             // Use instructions per second based timer for predictability if timer is enabled
             InstructionsPerSecond = enablePit ? 100000 : null,
             CfgCpu = enableCfgCpu,


### PR DESCRIPTION
### Description of Changes
Fix headless parameters, update README.

### Rationale behind Changes
The previous implementation was wrong and the README was also missing the new parameters.

Moreover, I also renamed "Default" to "Minimal" to make clear that it's just a lightweight headless implementation.

### Suggested Testing Steps
Run Spice86 with different (headless) configurations.
