### PR TITLE
Make CFG CPU Dump execution flow

### DIFF
--- a/src/Spice86.Core/Emulator/CPU/CfgCpu/Feeder/CfgNodeFeeder.cs
+++ b/src/Spice86.Core/Emulator/CPU/CfgCpu/Feeder/CfgNodeFeeder.cs
@@ -8,8 +8,6 @@ using Spice86.Core.Emulator.CPU.CfgCpu.ParsedInstruction.SelfModifying;
 using Spice86.Core.Emulator.Memory;
 using Spice86.Core.Emulator.VM.Breakpoint;
 
-using System.Diagnostics.CodeAnalysis;
-
 /// <summary>
 /// Handles coherency between the memory and the graph of instructions executed by the CPU.
 /// Next node to execute is normally the next node from the graph but several checks are done to make sure it is really it:
@@ -41,8 +39,13 @@ public class CfgNodeFeeder {
         ICfgNode toExecute = DetermineToExecute(executionContext.NodeToExecuteNextAccordingToGraph);
         ICfgNode? lastExecuted = executionContext.LastExecuted;
         if (lastExecuted is { CanHaveMoreSuccessors: true }) {
+            InstructionSuccessorType type = executionContext.CpuFault
+                ? InstructionSuccessorType.CpuFault
+                : InstructionSuccessorType.Normal;
+            // Reset it
+            executionContext.CpuFault = false;
             // Node can still have successors, try to register the link in the graph
-            _nodeLinker.Link(lastExecuted, toExecute);
+            _nodeLinker.Link(type,lastExecuted, toExecute);
         }
 
         return toExecute;

--- a/src/Spice86.Core/Emulator/CPU/CfgCpu/Feeder/CurrentInstructions.cs
+++ b/src/Spice86.Core/Emulator/CPU/CfgCpu/Feeder/CurrentInstructions.cs
@@ -32,6 +32,10 @@ public class CurrentInstructions : InstructionReplacer {
         _emulatorBreakpointsManager = emulatorBreakpointsManager;
     }
 
+    public IEnumerable<CfgInstruction> GetAll() {
+        return _currentInstructionAtAddress.Values;
+    }
+
     public CfgInstruction? GetAtAddress(SegmentedAddress address) {
         _currentInstructionAtAddress.TryGetValue(address, out CfgInstruction? res);
         return res;

--- a/src/Spice86.Core/Emulator/CPU/CfgCpu/Feeder/PreviousInstructions.cs
+++ b/src/Spice86.Core/Emulator/CPU/CfgCpu/Feeder/PreviousInstructions.cs
@@ -3,6 +3,7 @@ namespace Spice86.Core.Emulator.CPU.CfgCpu.Feeder;
 using Spice86.Core.Emulator.CPU.CfgCpu.ParsedInstruction;
 using Spice86.Core.Emulator.Memory;
 using Spice86.Shared.Emulator.Memory;
+using System.Linq;
 
 /// <summary>
 /// Cache of previous instructions that existed in a memory address at a time.
@@ -18,6 +19,10 @@ public class PreviousInstructions : InstructionReplacer {
     public PreviousInstructions(IMemory memory, InstructionReplacerRegistry replacerRegistry) : base(
         replacerRegistry) {
         _memoryInstructionMatcher = new MemoryInstructionMatcher(memory);
+    }
+
+    public List<CfgInstruction> GetAll() {
+        return _previousInstructionsAtAddress.Values.SelectMany(x => x).ToList();
     }
 
     public HashSet<CfgInstruction>? GetAtAddress(SegmentedAddress address) {

--- a/src/Spice86.Core/Emulator/CPU/CfgCpu/Linker/ExecutionContext.cs
+++ b/src/Spice86.Core/Emulator/CPU/CfgCpu/Linker/ExecutionContext.cs
@@ -1,6 +1,7 @@
 namespace Spice86.Core.Emulator.CPU.CfgCpu.Linker;
 
 using Spice86.Core.Emulator.CPU.CfgCpu.ControlFlowGraph;
+using Spice86.Core.Emulator.CPU.CfgCpu.ParsedInstruction;
 using Spice86.Core.Emulator.Function;
 using Spice86.Shared.Emulator.Memory;
 
@@ -40,4 +41,9 @@ public class ExecutionContext {
     /// Next node to execute according to the CFG Graph.
     /// </summary>
     public ICfgNode? NodeToExecuteNextAccordingToGraph { get; set; }
+    
+    /// <summary>
+    /// True when last executed triggered a CPU fault
+    /// </summary>
+    public bool CpuFault { get; set; } = false;
 }

--- a/src/Spice86.Core/Emulator/CPU/CfgCpu/ParsedInstruction/InstructionSuccessorType.cs
+++ b/src/Spice86.Core/Emulator/CPU/CfgCpu/ParsedInstruction/InstructionSuccessorType.cs
@@ -3,5 +3,6 @@
 public enum InstructionSuccessorType {
     Normal,
     CallToReturn,
-    CallToMisalignedReturn
+    CallToMisalignedReturn,
+    CpuFault
 }

--- a/src/Spice86.Core/Emulator/CPU/CfgCpu/ParsedInstruction/Instructions/Grp5RmJumpFar.cs
+++ b/src/Spice86.Core/Emulator/CPU/CfgCpu/ParsedInstruction/Instructions/Grp5RmJumpFar.cs
@@ -4,11 +4,12 @@ using Spice86.Core.Emulator.CPU.CfgCpu.Ast;
 using Spice86.Core.Emulator.CPU.CfgCpu.Ast.Builder;
 using Spice86.Core.Emulator.CPU.CfgCpu.Ast.Instruction;
 using Spice86.Core.Emulator.CPU.CfgCpu.InstructionExecutor;
+using Spice86.Core.Emulator.CPU.CfgCpu.ParsedInstruction.Instructions.Interfaces;
 using Spice86.Core.Emulator.CPU.CfgCpu.ParsedInstruction.ModRm;
 using Spice86.Core.Emulator.CPU.CfgCpu.ParsedInstruction.Prefix;
 using Spice86.Shared.Emulator.Memory;
 
-public class Grp5RmJumpFar : InstructionWithModRm {
+public class Grp5RmJumpFar : InstructionWithModRm, IJumpInstruction {
     public Grp5RmJumpFar(SegmentedAddress address, InstructionField<ushort> opcodeField,
         List<InstructionPrefix> prefixes, ModRmContext modRmContext) : base(address, opcodeField, prefixes,
         modRmContext, null) {

--- a/src/Spice86.Core/Emulator/CPU/CfgCpu/ParsedInstruction/Instructions/Grp5RmJumpNear.cs
+++ b/src/Spice86.Core/Emulator/CPU/CfgCpu/ParsedInstruction/Instructions/Grp5RmJumpNear.cs
@@ -4,11 +4,12 @@ using Spice86.Core.Emulator.CPU.CfgCpu.Ast;
 using Spice86.Core.Emulator.CPU.CfgCpu.Ast.Builder;
 using Spice86.Core.Emulator.CPU.CfgCpu.Ast.Instruction;
 using Spice86.Core.Emulator.CPU.CfgCpu.InstructionExecutor;
+using Spice86.Core.Emulator.CPU.CfgCpu.ParsedInstruction.Instructions.Interfaces;
 using Spice86.Core.Emulator.CPU.CfgCpu.ParsedInstruction.ModRm;
 using Spice86.Core.Emulator.CPU.CfgCpu.ParsedInstruction.Prefix;
 using Spice86.Shared.Emulator.Memory;
 
-public class Grp5RmJumpNear : InstructionWithModRm {
+public class Grp5RmJumpNear : InstructionWithModRm, IJumpInstruction {
     public Grp5RmJumpNear(SegmentedAddress address, InstructionField<ushort> opcodeField,
         List<InstructionPrefix> prefixes, ModRmContext modRmContext) : base(address, opcodeField, prefixes,
         modRmContext, null) {

--- a/src/Spice86.Core/Emulator/CPU/CfgCpu/ParsedInstruction/Instructions/Interfaces/ICallInstruction.cs
+++ b/src/Spice86.Core/Emulator/CPU/CfgCpu/ParsedInstruction/Instructions/Interfaces/ICallInstruction.cs
@@ -1,0 +1,4 @@
+namespace Spice86.Core.Emulator.CPU.CfgCpu.ParsedInstruction.Instructions.Interfaces;
+
+public interface ICallInstruction {
+}

--- a/src/Spice86.Core/Emulator/CPU/CfgCpu/ParsedInstruction/Instructions/Interfaces/IJumpInstruction.cs
+++ b/src/Spice86.Core/Emulator/CPU/CfgCpu/ParsedInstruction/Instructions/Interfaces/IJumpInstruction.cs
@@ -1,0 +1,4 @@
+namespace Spice86.Core.Emulator.CPU.CfgCpu.ParsedInstruction.Instructions.Interfaces;
+
+public interface IJumpInstruction {
+}

--- a/src/Spice86.Core/Emulator/CPU/CfgCpu/ParsedInstruction/Instructions/Interrupt.cs
+++ b/src/Spice86.Core/Emulator/CPU/CfgCpu/ParsedInstruction/Instructions/Interrupt.cs
@@ -4,9 +4,10 @@ using Spice86.Core.Emulator.CPU.CfgCpu.Ast.Builder;
 using Spice86.Core.Emulator.CPU.CfgCpu.Ast.Instruction;
 using Spice86.Core.Emulator.CPU.CfgCpu.InstructionExecutor;
 using Spice86.Core.Emulator.CPU.CfgCpu.ParsedInstruction.Instructions.CommonGrammar;
+using Spice86.Core.Emulator.CPU.CfgCpu.ParsedInstruction.Instructions.Interfaces;
 using Spice86.Shared.Emulator.Memory;
 
-public class Interrupt : InstructionWithValueField<byte> {
+public class Interrupt : InstructionWithValueField<byte>, ICallInstruction {
     public Interrupt(SegmentedAddress address, InstructionField<ushort> opcodeField,
         InstructionField<byte> valueField) : base(address, opcodeField, valueField, null) {
     }

--- a/src/Spice86.Core/Emulator/CPU/CfgCpu/ParsedInstruction/Instructions/Interrupt3.cs
+++ b/src/Spice86.Core/Emulator/CPU/CfgCpu/ParsedInstruction/Instructions/Interrupt3.cs
@@ -3,9 +3,10 @@
 using Spice86.Core.Emulator.CPU.CfgCpu.Ast.Builder;
 using Spice86.Core.Emulator.CPU.CfgCpu.Ast.Instruction;
 using Spice86.Core.Emulator.CPU.CfgCpu.InstructionExecutor;
+using Spice86.Core.Emulator.CPU.CfgCpu.ParsedInstruction.Instructions.Interfaces;
 using Spice86.Shared.Emulator.Memory;
 
-public class Interrupt3 : CfgInstruction {
+public class Interrupt3 : CfgInstruction, ICallInstruction {
     public Interrupt3(SegmentedAddress address, InstructionField<ushort> opcodeField) : base(address, opcodeField, null) {
     }
 

--- a/src/Spice86.Core/Emulator/CPU/CfgCpu/ParsedInstruction/Instructions/InterruptOverflow.cs
+++ b/src/Spice86.Core/Emulator/CPU/CfgCpu/ParsedInstruction/Instructions/InterruptOverflow.cs
@@ -3,9 +3,10 @@
 using Spice86.Core.Emulator.CPU.CfgCpu.Ast.Builder;
 using Spice86.Core.Emulator.CPU.CfgCpu.Ast.Instruction;
 using Spice86.Core.Emulator.CPU.CfgCpu.InstructionExecutor;
+using Spice86.Core.Emulator.CPU.CfgCpu.ParsedInstruction.Instructions.Interfaces;
 using Spice86.Shared.Emulator.Memory;
 
-public class InterruptOverflow : CfgInstruction {
+public class InterruptOverflow : CfgInstruction, ICallInstruction {
     public InterruptOverflow(SegmentedAddress address, InstructionField<ushort> opcodeField) : base(address, opcodeField, null) {
     }
 

--- a/src/Spice86.Core/Emulator/CPU/CfgCpu/ParsedInstruction/Instructions/JmpFarImm.cs
+++ b/src/Spice86.Core/Emulator/CPU/CfgCpu/ParsedInstruction/Instructions/JmpFarImm.cs
@@ -4,10 +4,11 @@ using Spice86.Core.Emulator.CPU.CfgCpu.Ast.Builder;
 using Spice86.Core.Emulator.CPU.CfgCpu.Ast.Instruction;
 using Spice86.Core.Emulator.CPU.CfgCpu.InstructionExecutor;
 using Spice86.Core.Emulator.CPU.CfgCpu.ParsedInstruction.Instructions.CommonGrammar;
+using Spice86.Core.Emulator.CPU.CfgCpu.ParsedInstruction.Instructions.Interfaces;
 using Spice86.Core.Emulator.CPU.CfgCpu.ParsedInstruction.Prefix;
 using Spice86.Shared.Emulator.Memory;
 
-public class JmpFarImm : InstructionWithSegmentedAddressField {
+public class JmpFarImm : InstructionWithSegmentedAddressField, IJumpInstruction {
     private readonly SegmentedAddress _targetAddress;
 
     public JmpFarImm(

--- a/src/Spice86.Core/Emulator/CPU/CfgCpu/ParsedInstruction/Instructions/Mixins/CallFarImm.mixin
+++ b/src/Spice86.Core/Emulator/CPU/CfgCpu/ParsedInstruction/Instructions/Mixins/CallFarImm.mixin
@@ -9,11 +9,12 @@ using Spice86.Core.Emulator.CPU.CfgCpu.Ast.Instruction;
 using Spice86.Core.Emulator.CPU.CfgCpu.Ast.Value;
 using Spice86.Core.Emulator.CPU.CfgCpu.InstructionExecutor;
 using Spice86.Core.Emulator.CPU.CfgCpu.ParsedInstruction.Instructions.CommonGrammar;
+using Spice86.Core.Emulator.CPU.CfgCpu.ParsedInstruction.Instructions.Interfaces;
 using Spice86.Core.Emulator.CPU.CfgCpu.ParsedInstruction.Prefix;
 
 using Spice86.Shared.Emulator.Memory;
 
-public partial class {{ moxy.Class.Name }} : InstructionWithSegmentedAddressField {
+public partial class {{ moxy.Class.Name }} : InstructionWithSegmentedAddressField, ICallInstruction {
     public {{ moxy.Class.Name }} (
         SegmentedAddress address,
         InstructionField<ushort> opcodeField,

--- a/src/Spice86.Core/Emulator/CPU/CfgCpu/ParsedInstruction/Instructions/Mixins/CallNearImm.mixin
+++ b/src/Spice86.Core/Emulator/CPU/CfgCpu/ParsedInstruction/Instructions/Mixins/CallNearImm.mixin
@@ -10,11 +10,12 @@ using Spice86.Core.Emulator.CPU.CfgCpu.Ast.Instruction;
 using Spice86.Core.Emulator.CPU.CfgCpu.Ast.Value;
 using Spice86.Core.Emulator.CPU.CfgCpu.InstructionExecutor;
 using Spice86.Core.Emulator.CPU.CfgCpu.ParsedInstruction.Instructions.CommonGrammar;
+using Spice86.Core.Emulator.CPU.CfgCpu.ParsedInstruction.Instructions.Interfaces;
 using Spice86.Core.Emulator.CPU.CfgCpu.ParsedInstruction.Prefix;
 
 using Spice86.Shared.Emulator.Memory;
 
-public partial class {{ moxy.Class.Name }} : InstructionWithOffsetField<{{SignedType}}> {
+public partial class {{ moxy.Class.Name }} : InstructionWithOffsetField<{{SignedType}}>, ICallInstruction {
     private readonly ushort _targetIp;
 
     public {{ moxy.Class.Name }}(

--- a/src/Spice86.Core/Emulator/CPU/CfgCpu/ParsedInstruction/Instructions/Mixins/Grp5RmCallFar.mixin
+++ b/src/Spice86.Core/Emulator/CPU/CfgCpu/ParsedInstruction/Instructions/Mixins/Grp5RmCallFar.mixin
@@ -8,11 +8,12 @@ using Spice86.Core.Emulator.CPU.CfgCpu.Ast;
 using Spice86.Core.Emulator.CPU.CfgCpu.Ast.Builder;
 using Spice86.Core.Emulator.CPU.CfgCpu.Ast.Instruction;
 using Spice86.Core.Emulator.CPU.CfgCpu.InstructionExecutor;
+using Spice86.Core.Emulator.CPU.CfgCpu.ParsedInstruction.Instructions.Interfaces;
 using Spice86.Core.Emulator.CPU.CfgCpu.ParsedInstruction.ModRm;
 using Spice86.Core.Emulator.CPU.CfgCpu.ParsedInstruction.Prefix;
 using Spice86.Shared.Emulator.Memory;
 
-public partial class {{ moxy.Class.Name }} : InstructionWithModRm {
+public partial class {{ moxy.Class.Name }} : InstructionWithModRm, ICallInstruction {
     public {{ moxy.Class.Name }}(SegmentedAddress address, InstructionField<ushort> opcodeField,
         List<InstructionPrefix> prefixes, ModRmContext modRmContext) : base(address, opcodeField, prefixes,
         modRmContext, null) {

--- a/src/Spice86.Core/Emulator/CPU/CfgCpu/ParsedInstruction/Instructions/Mixins/Grp5RmCallNear.mixin
+++ b/src/Spice86.Core/Emulator/CPU/CfgCpu/ParsedInstruction/Instructions/Mixins/Grp5RmCallNear.mixin
@@ -8,11 +8,12 @@ using Spice86.Core.Emulator.CPU.CfgCpu.Ast;
 using Spice86.Core.Emulator.CPU.CfgCpu.Ast.Builder;
 using Spice86.Core.Emulator.CPU.CfgCpu.Ast.Instruction;
 using Spice86.Core.Emulator.CPU.CfgCpu.InstructionExecutor;
+using Spice86.Core.Emulator.CPU.CfgCpu.ParsedInstruction.Instructions.Interfaces;
 using Spice86.Core.Emulator.CPU.CfgCpu.ParsedInstruction.ModRm;
 using Spice86.Core.Emulator.CPU.CfgCpu.ParsedInstruction.Prefix;
 using Spice86.Shared.Emulator.Memory;
 
-public partial class {{ moxy.Class.Name }} : InstructionWithModRm {
+public partial class {{ moxy.Class.Name }} : InstructionWithModRm, ICallInstruction {
     public {{ moxy.Class.Name }}(SegmentedAddress address, InstructionField<ushort> opcodeField,
         List<InstructionPrefix> prefixes, ModRmContext modRmContext) : base(address, opcodeField, prefixes,
         modRmContext, null) {

--- a/src/Spice86.Core/Emulator/CPU/CfgCpu/ParsedInstruction/Instructions/Mixins/JmpNearImm.mixin
+++ b/src/Spice86.Core/Emulator/CPU/CfgCpu/ParsedInstruction/Instructions/Mixins/JmpNearImm.mixin
@@ -9,11 +9,12 @@ using Spice86.Core.Emulator.CPU.CfgCpu.Ast.Instruction;
 using Spice86.Core.Emulator.CPU.CfgCpu.Ast.Value;
 using Spice86.Core.Emulator.CPU.CfgCpu.InstructionExecutor;
 using Spice86.Core.Emulator.CPU.CfgCpu.ParsedInstruction.Instructions.CommonGrammar;
+using Spice86.Core.Emulator.CPU.CfgCpu.ParsedInstruction.Instructions.Interfaces;
 using Spice86.Core.Emulator.CPU.CfgCpu.ParsedInstruction.Prefix;
 
 using Spice86.Shared.Emulator.Memory;
 
-public partial class {{ moxy.Class.Name }} : InstructionWithOffsetField<{{SignedType}}> {
+public partial class {{ moxy.Class.Name }} : InstructionWithOffsetField<{{SignedType}}>, IJumpInstruction {
     private readonly ushort _targetIp;
 
     public {{ moxy.Class.Name }}(SegmentedAddress address, InstructionField<ushort> opcodeField, List<InstructionPrefix> prefixes, InstructionField<{{SignedType}}> offsetField) :

--- a/src/Spice86.Core/Emulator/Function/CfgCpuFlowDumper.cs
+++ b/src/Spice86.Core/Emulator/Function/CfgCpuFlowDumper.cs
@@ -1,0 +1,82 @@
+namespace Spice86.Core.Emulator.Function;
+
+using Spice86.Core.Emulator.CPU.CfgCpu;
+using Spice86.Core.Emulator.CPU.CfgCpu.ControlFlowGraph;
+using Spice86.Core.Emulator.CPU.CfgCpu.ParsedInstruction;
+using Spice86.Core.Emulator.CPU.CfgCpu.ParsedInstruction.Instructions.Interfaces;
+using Spice86.Core.Emulator.Function.Dump;
+using Spice86.Shared.Emulator.Memory;
+
+using System.Linq;
+
+public class CfgCpuFlowDumper : IExecutionDumpFactory {
+    private readonly CfgCpu _cfgCpu;
+    private readonly ExecutionDump _previousDump;
+
+
+    public CfgCpuFlowDumper(CfgCpu cfgCpu, ExecutionDump previousDump) {
+        _cfgCpu = cfgCpu;
+        _previousDump = previousDump;
+    }
+
+    public ExecutionDump Dump() {
+        // List all instructions currently in memory. Those info are meant to go along with the memory dump.
+        IEnumerable<CfgInstruction> all = _cfgCpu.CfgNodeFeeder.InstructionsFeeder.CurrentInstructions.GetAll();
+        foreach (CfgInstruction instruction in all) {
+            switch (instruction) {
+                case IJumpInstruction:
+                    FillResultWithSuccessorsOfType(InstructionSuccessorType.Normal, instruction, true,
+                        _previousDump.JumpsFromTo);
+                    break;
+                case ICallInstruction:
+                    FillResultWithSuccessorsOfType(InstructionSuccessorType.Normal, instruction, false,
+                        _previousDump.CallsFromTo);
+                    break;
+                case IReturnInstruction:
+                    FillResultWithSuccessorsOfType(InstructionSuccessorType.Normal, instruction, false,
+                        _previousDump.RetsFromTo);
+                    break;
+            }
+
+            FillResultWithSuccessorsOfType(InstructionSuccessorType.CpuFault, instruction, false,
+                _previousDump.CallsFromTo);
+            _previousDump.ExecutedInstructions.Add(instruction.Address);
+        }
+
+        return _previousDump;
+    }
+
+    private void FillResultWithSuccessorsOfType(InstructionSuccessorType type, CfgInstruction instruction,
+        bool ignoreNextInMemory, IDictionary<uint, HashSet<SegmentedAddress>> result) {
+        if (instruction.SuccessorsPerType.TryGetValue(type, out ISet<ICfgNode>? successors)) {
+            FillResultWithSuccessors(instruction, successors, ignoreNextInMemory, result);
+        }
+    }
+
+    private void FillResultWithSuccessors(CfgInstruction instruction, ISet<ICfgNode> successors,
+        bool ignoreNextInMemory, IDictionary<uint, HashSet<SegmentedAddress>> result) {
+        ISet<ICfgNode> filteredSuccessors = FilterSuccessors(instruction, successors, ignoreNextInMemory);
+        if (filteredSuccessors.Count == 0) {
+            return;
+        }
+
+        if (!result.TryGetValue(instruction.Address.Linear, out HashSet<SegmentedAddress>? set)) {
+            set = new();
+            result[instruction.Address.Linear] = set;
+        }
+
+        foreach (ICfgNode successor in filteredSuccessors) {
+            set.Add(successor.Address);
+        }
+    }
+
+    private ISet<ICfgNode> FilterSuccessors(CfgInstruction instruction, ISet<ICfgNode> successors,
+        bool ignoreNextInMemory) {
+        if (!ignoreNextInMemory) {
+            return successors;
+        }
+
+        SegmentedAddress next = instruction.NextInMemoryAddress;
+        return successors.Where(i => i.Address != next).ToHashSet();
+    }
+}

--- a/src/Spice86.Core/Emulator/Function/Dump/EmulatorStateSerializer.cs
+++ b/src/Spice86.Core/Emulator/Function/Dump/EmulatorStateSerializer.cs
@@ -10,7 +10,7 @@ using Spice86.Shared.Interfaces;
 /// </summary>
 public class EmulatorStateSerializer {
     private readonly State _state;
-    private readonly ExecutionFlowRecorder _executionFlowRecorder;
+    private readonly IExecutionDumpFactory _executionDumpFactory;
     private readonly FunctionCatalogue _functionCatalogue;
     private readonly ILoggerService _loggerService;
 
@@ -20,10 +20,10 @@ public class EmulatorStateSerializer {
     /// Initializes a new instance of <see cref="EmulatorStateSerializer"/>.
     /// </summary>
     public EmulatorStateSerializer(MemoryDataExporter memoryDataExporter, State state,
-        ExecutionFlowRecorder executionFlowRecorder, FunctionCatalogue functionCatalogue, ILoggerService loggerService) {
+        IExecutionDumpFactory executionDumpFactory, FunctionCatalogue functionCatalogue, ILoggerService loggerService) {
         _state = state;
         _memoryDataExporter = memoryDataExporter;
-        _executionFlowRecorder = executionFlowRecorder;
+        _executionDumpFactory = executionDumpFactory;
         _functionCatalogue = functionCatalogue;
         _loggerService = loggerService;
     }
@@ -34,11 +34,12 @@ public class EmulatorStateSerializer {
     /// </summary>
     /// <param name="path">The directory used for dumping the emulator state.</param>
     public void SerializeEmulatorStateToDirectory(string path) {
-        new RecorderDataWriter(
+        new RecordedDataWriter(
                 _state,
-                _executionFlowRecorder,
+                _executionDumpFactory,
                 _memoryDataExporter,
+                _functionCatalogue,
                 path, _loggerService)
-            .DumpAll(_executionFlowRecorder, _functionCatalogue);
+            .DumpAll();
     }
 }

--- a/src/Spice86.Core/Emulator/Function/Dump/ExecutionDump.cs
+++ b/src/Spice86.Core/Emulator/Function/Dump/ExecutionDump.cs
@@ -1,0 +1,37 @@
+namespace Spice86.Core.Emulator.Function.Dump;
+
+using Spice86.Shared.Emulator.Memory;
+
+public class ExecutionDump {
+    /// <summary>
+    /// Gets a dictionary of calls from one address to another.
+    /// </summary>
+    public IDictionary<uint, HashSet<SegmentedAddress>> CallsFromTo { get; set; } = new Dictionary<uint, HashSet<SegmentedAddress>>();
+
+    /// <summary>
+    /// Gets a dictionary of jumps from one address to another.
+    /// </summary>
+    public IDictionary<uint, HashSet<SegmentedAddress>> JumpsFromTo { get; set; } = new Dictionary<uint, HashSet<SegmentedAddress>>();
+    
+    /// <summary>
+    /// Gets a dictionary of returns from one address to another.
+    /// </summary>
+    public IDictionary<uint, HashSet<SegmentedAddress>> RetsFromTo { get; set; } = new Dictionary<uint, HashSet<SegmentedAddress>>();
+    
+    /// <summary>
+    /// Gets a dictionary of unaligned returns from one address to another.
+    /// </summary>
+    public IDictionary<uint, HashSet<SegmentedAddress>> UnalignedRetsFromTo { get; set; } = new Dictionary<uint, HashSet<SegmentedAddress>>();
+    
+    /// <summary>
+    /// Gets the set of executed instructions.
+    /// </summary>
+    public HashSet<SegmentedAddress> ExecutedInstructions { get; set; } = new();
+
+    /// <summary>
+    /// Gets a dictionary of executable addresses written by modifying instructions.
+    /// The key of the outer dictionary is the modified byte address.
+    /// The value of the outer dictionary is a dictionary of modifying instructions, where the key is the instruction address and the value is a set of possible changes that the instruction did.
+    /// </summary>
+    public IDictionary<uint, IDictionary<uint, HashSet<ByteModificationRecord>>> ExecutableAddressWrittenBy { get; } = new Dictionary<uint, IDictionary<uint, HashSet<ByteModificationRecord>>>();
+}

--- a/src/Spice86.Core/Emulator/Function/Dump/ExecutionFlowDumper.cs
+++ b/src/Spice86.Core/Emulator/Function/Dump/ExecutionFlowDumper.cs
@@ -27,11 +27,11 @@ public class ExecutionFlowDumper {
     /// <summary>
     /// Dumps the execution flow recorded by the provided executionFlowRecorder to a JSON file at the specified <paramref name="destinationFilePath"/>
     /// </summary>
-    /// <param name="executionFlowRecorder">The execution flow recorder to dump.</param>
+    /// <param name="executionDump">The execution flow recorder to dump.</param>
     /// <param name="destinationFilePath">The path to the destination file to create and write the execution flow data to.</param>
-    public void Dump(ExecutionFlowRecorder executionFlowRecorder, string destinationFilePath) {
+    public void Dump(ExecutionDump executionDump, string destinationFilePath) {
         using StreamWriter printWriter = new StreamWriter(destinationFilePath);
-        string jsonString = JsonSerializer.Serialize(executionFlowRecorder);
+        string jsonString = JsonSerializer.Serialize(executionDump);
         printWriter.WriteLine(jsonString);
     }
 
@@ -41,7 +41,7 @@ public class ExecutionFlowDumper {
     /// <param name="filePath">The path to the execution flow data file to read.</param>
     /// <returns>An <see cref="ExecutionFlowRecorder"/> instance containing the data read from the file or a new <see cref="ExecutionFlowRecorder"/> object if the file does not exist.</returns>
     /// <exception cref="UnrecoverableException">Thrown if the file at the specified <paramref name="filePath"/> is not valid JSON.</exception>
-    public ExecutionFlowRecorder ReadFromFileOrCreate(string filePath) {
+    public ExecutionDump ReadFromFileOrCreate(string filePath) {
         if (string.IsNullOrWhiteSpace(filePath) || !File.Exists(filePath)) {
             if (_loggerService.IsEnabled(LogEventLevel.Debug)) {
                 _loggerService.Debug("File path \"{FilePath}\" is blank or doesn't exist", filePath);
@@ -49,7 +49,7 @@ public class ExecutionFlowDumper {
             return new ();
         }
         try {
-            return JsonSerializer.Deserialize<ExecutionFlowRecorder>(File.ReadAllText(filePath)) ?? new();
+            return JsonSerializer.Deserialize<ExecutionDump>(File.ReadAllText(filePath)) ?? new();
         } catch (JsonException e) {
             throw new UnrecoverableException($"File {filePath} is not valid", e);
         }

--- a/src/Spice86.Core/Emulator/Function/Dump/GhidraSymbolsDumper.cs
+++ b/src/Spice86.Core/Emulator/Function/Dump/GhidraSymbolsDumper.cs
@@ -6,7 +6,6 @@ using System.Linq;
 using Serilog.Events;
 
 using Spice86.Core.Emulator.Function;
-using Spice86.Core.Emulator.VM;
 using Spice86.Shared.Emulator.Memory;
 using Spice86.Shared.Interfaces;
 using Spice86.Shared.Utils;
@@ -26,22 +25,22 @@ public class GhidraSymbolsDumper {
     /// <summary>
     /// Dumps function information and labels to a file.
     /// </summary>
-    /// <param name="executionFlowRecorder">The class that records machine code execution flow.</param>
+    /// <param name="executionDump">The class that holds machine code execution flow.</param>
     /// <param name="functionCatalogue">List of all functions.</param>
     /// <param name="destinationFilePath">The path of the file to write the dumped information to.</param>
-    public void Dump(ExecutionFlowRecorder executionFlowRecorder, FunctionCatalogue functionCatalogue, string destinationFilePath) {
+    public void Dump(ExecutionDump executionDump, FunctionCatalogue functionCatalogue, string destinationFilePath) {
         ICollection<FunctionInformation> functionInformationsValues = functionCatalogue.FunctionInformations.Values;
         List<string> lines = new();
         // keep addresses in a set in order not to write a label where a function was, ghidra will otherwise overwrite functions with labels and this is not cool.
         HashSet<SegmentedAddress> dumpedAddresses = new HashSet<SegmentedAddress>();
         DumpFunctionInformations(lines, dumpedAddresses, functionInformationsValues);
-        DumpLabels(lines, dumpedAddresses, executionFlowRecorder);
+        DumpLabels(lines, dumpedAddresses, executionDump);
         using StreamWriter printWriter = new StreamWriter(destinationFilePath);
         lines.ForEach(line => printWriter.WriteLine(line));
     }
 
-    private void DumpLabels(List<string> lines, HashSet<SegmentedAddress> dumpedAddresses, ExecutionFlowRecorder executionFlowRecorder) {
-        executionFlowRecorder.JumpsFromTo
+    private void DumpLabels(List<string> lines, HashSet<SegmentedAddress> dumpedAddresses, ExecutionDump executionDump) {
+        executionDump.JumpsFromTo
             .SelectMany(x => x.Value)
             .Where(address => !dumpedAddresses.Contains(address))
             .OrderBy(x => x)

--- a/src/Spice86.Core/Emulator/Function/Dump/IExecutionDumpFactory.cs
+++ b/src/Spice86.Core/Emulator/Function/Dump/IExecutionDumpFactory.cs
@@ -1,0 +1,5 @@
+namespace Spice86.Core.Emulator.Function.Dump;
+
+public interface IExecutionDumpFactory {
+    public ExecutionDump Dump();
+}

--- a/src/Spice86.Core/Emulator/Function/Dump/RecordedDataReader.cs
+++ b/src/Spice86.Core/Emulator/Function/Dump/RecordedDataReader.cs
@@ -23,15 +23,10 @@ public class RecordedDataReader : RecordedDataIoHandler {
     /// <summary>
     /// Reads the execution flow recorder data from a file or creates a new one if the file does not exist.
     /// </summary>
-    /// <param name="recordData">A value indicating whether the execution flow recorder should record data.</param>
-    /// <returns>The execution flow recorder read from the file, or a new instance if the file does not exist.</returns>
-    public ExecutionFlowRecorder ReadExecutionFlowRecorderFromFileOrCreate(bool recordData) {
-        ExecutionFlowRecorder executionFlowRecorder =
-            new ExecutionFlowDumper(
-                    _loggerService)
+    /// <returns>The execution dump read from the file, or a new instance if the file does not exist.</returns>
+    public ExecutionDump ReadExecutionDumpFromFileOrCreate() {
+           return new ExecutionFlowDumper(_loggerService)
                 .ReadFromFileOrCreate(ExecutionFlowFile);
-        executionFlowRecorder.RecordData = recordData;
-        return executionFlowRecorder;
     }
 
     /// <summary>

--- a/src/Spice86.Core/Emulator/Function/Dump/RecordedDataWriter.cs
+++ b/src/Spice86.Core/Emulator/Function/Dump/RecordedDataWriter.cs
@@ -2,57 +2,61 @@ namespace Spice86.Core.Emulator.Function.Dump;
 
 using Serilog.Events;
 
-using System.Text.Json;
-
 using Spice86.Core.Emulator.CPU;
-using Spice86.Core.Emulator.InterruptHandlers.Common.Callback;
-using Spice86.Core.Emulator.Memory;
 using Spice86.Shared.Interfaces;
+
+using System.Text.Json;
 
 /// <summary>
 /// A class that provides functionality for writing various recorded data to files.
 /// </summary>
-public class RecorderDataWriter : RecordedDataIoHandler {
+public class RecordedDataWriter : RecordedDataIoHandler {
     private readonly ILoggerService _loggerService;
     private readonly State _state;
-    private readonly ExecutionFlowRecorder _executionFlowRecorder;
+    private readonly IExecutionDumpFactory _executionDumpFactory;
     private readonly MemoryDataExporter _memoryDataExporter;
-
+    private readonly FunctionCatalogue _functionCatalogue;
+    
     /// <summary>
     /// Initializes a new instance.
     /// </summary>
-    /// <param name="executionFlowRecorder">The class that records machine code execution flow.</param>
+    /// <param name="executionDumpFactory">The class that dumps machine code execution flow.</param>
     /// <param name="memoryDataExporter">The class used to dump main memory data properly.</param>
+    /// <param name="functionCatalogue">The list of functions encountered.</param>
     /// <param name="state">The CPU state.</param>
     /// <param name="dumpDirectory">Where to dump the data.</param>
     /// <param name="loggerService">The logger service implementation.</param>
-    public RecorderDataWriter(State state,
-        ExecutionFlowRecorder executionFlowRecorder, MemoryDataExporter memoryDataExporter,
+    public RecordedDataWriter(State state,
+        IExecutionDumpFactory executionDumpFactory,
+        MemoryDataExporter memoryDataExporter, 
+        FunctionCatalogue functionCatalogue,
         string dumpDirectory, ILoggerService loggerService) : base(dumpDirectory) {
         _loggerService = loggerService;
-        _executionFlowRecorder = executionFlowRecorder;
+        _executionDumpFactory = executionDumpFactory;
         _state = state;
         _memoryDataExporter = memoryDataExporter;
+        _functionCatalogue = functionCatalogue;
     }
 
     /// <summary>
     /// Dumps all recorded data to their respective files.
     /// </summary>
-    public void DumpAll(ExecutionFlowRecorder executionFlowRecorder, FunctionCatalogue functionCatalogue) {
+    public void DumpAll() {
         if (_loggerService.IsEnabled(LogEventLevel.Information)) {
             _loggerService.Information("Dumping all data to {DumpDirectory}", DumpDirectory);
         }
         DumpCpuRegisters("");
         DumpMemory("");
-        DumpGhidraSymbols(executionFlowRecorder, functionCatalogue);
-        DumpExecutionFlow();
+        ExecutionDump executionDump = _executionDumpFactory.Dump();
+        DumpGhidraSymbols(executionDump);
+        DumpExecutionFlow(executionDump);
     }
 
     /// <summary>
     /// Dumps the Ghidra symbols to the file system.
     /// </summary>
-    private void DumpGhidraSymbols(ExecutionFlowRecorder executionFlowRecorder, FunctionCatalogue functionCatalogue) {
-        new GhidraSymbolsDumper(_loggerService).Dump(executionFlowRecorder, functionCatalogue, SymbolsFile);
+    private void DumpGhidraSymbols(ExecutionDump executionDump) {
+        new GhidraSymbolsDumper(_loggerService).Dump(executionDump, _functionCatalogue, SymbolsFile);
     }
 
     /// <summary>
@@ -75,5 +79,5 @@ public class RecorderDataWriter : RecordedDataIoHandler {
     /// <summary>
     /// Dumps the execution flow data to the file system.
     /// </summary>
-    private void DumpExecutionFlow() => new ExecutionFlowDumper(_loggerService).Dump(_executionFlowRecorder, ExecutionFlowFile);
+    private void DumpExecutionFlow(ExecutionDump executionDump) => new ExecutionFlowDumper(_loggerService).Dump(executionDump, ExecutionFlowFile);
 }

--- a/src/Spice86.Core/Emulator/Gdb/GdbServer.cs
+++ b/src/Spice86.Core/Emulator/Gdb/GdbServer.cs
@@ -23,7 +23,7 @@ public sealed class GdbServer : IDisposable {
     private readonly IPauseHandler _pauseHandler;
     private readonly IMemory _memory;
     private readonly State _state;
-    private readonly ExecutionFlowRecorder _executionFlowRecorder;
+    private readonly IExecutionDumpFactory _executionDumpFactory;
     private readonly FunctionCatalogue _functionCatalogue;
     private readonly EmulatorBreakpointsManager _emulatorBreakpointsManager;
 
@@ -38,13 +38,14 @@ public sealed class GdbServer : IDisposable {
     /// <param name="memoryDataExporter">The class used to dump main memory data properly.</param>
     /// <param name="state">The CPU state.</param>
     /// <param name="functionCatalogue">List of all functions.</param>
-    /// <param name="executionFlowRecorder">The class that records machine code execution flow.</param>
+    /// <param name="executionDumpFactory">The class that dumps machine code execution flow.</param>
     /// <param name="emulatorBreakpointsManager">The class that handles breakpoints.</param>
     /// <param name="pauseHandler">The class used to support pausing/resuming the emulation via GDB commands.</param>
     /// <param name="loggerService">The ILoggerService implementation used to log messages.</param>
     public GdbServer(Configuration configuration, IMemory memory,
         IFunctionHandlerProvider functionHandlerProvider, 
-        State state, MemoryDataExporter memoryDataExporter, FunctionCatalogue functionCatalogue, ExecutionFlowRecorder executionFlowRecorder,
+        State state, MemoryDataExporter memoryDataExporter, FunctionCatalogue functionCatalogue, 
+        IExecutionDumpFactory executionDumpFactory,
         EmulatorBreakpointsManager emulatorBreakpointsManager, IPauseHandler pauseHandler,
         ILoggerService loggerService) {
         _loggerService = loggerService;
@@ -53,7 +54,7 @@ public sealed class GdbServer : IDisposable {
         _functionCatalogue = functionCatalogue;
         _state = state;
         _memory = memory;
-        _executionFlowRecorder = executionFlowRecorder;
+        _executionDumpFactory = executionDumpFactory;
         _emulatorBreakpointsManager = emulatorBreakpointsManager;
         _configuration = configuration;
         _functionHandlerProvider = functionHandlerProvider;
@@ -94,7 +95,7 @@ public sealed class GdbServer : IDisposable {
         gdbIo.WaitForConnection();
         GdbCommandHandler gdbCommandHandler = new GdbCommandHandler(
             _memory, _functionHandlerProvider, _state, _memoryDataExporter, _pauseHandler,
-            _emulatorBreakpointsManager, _executionFlowRecorder, _functionCatalogue,
+            _emulatorBreakpointsManager, _executionDumpFactory, _functionCatalogue,
             gdbIo,
             _loggerService,
             _configuration);

--- a/src/Spice86.Core/Emulator/ProgramExecutor.cs
+++ b/src/Spice86.Core/Emulator/ProgramExecutor.cs
@@ -54,7 +54,7 @@ public sealed class ProgramExecutor : IDisposable {
         IMemory memory, IFunctionHandlerProvider functionHandlerProvider,
         MemoryDataExporter memoryDataExporter, State state, Dos dos,
         FunctionCatalogue functionCatalogue,
-        ExecutionFlowRecorder executionFlowRecorder, IPauseHandler pauseHandler,
+        IExecutionDumpFactory executionDumpFactory, IPauseHandler pauseHandler,
         IScreenPresenter? screenPresenter, ILoggerService loggerService) {
         _configuration = configuration;
         _emulationLoop = emulationLoop;
@@ -64,7 +64,7 @@ public sealed class ProgramExecutor : IDisposable {
         if (configuration.GdbPort.HasValue) {
             _gdbServer = CreateGdbServer(configuration, memory, memoryDataExporter, functionHandlerProvider,
                 state, functionCatalogue,
-                executionFlowRecorder,
+                executionDumpFactory,
                 emulatorBreakpointsManager, pauseHandler, _loggerService);
         }
         ExecutableFileLoader loader = CreateExecutableFileLoader(configuration,
@@ -131,14 +131,14 @@ public sealed class ProgramExecutor : IDisposable {
 
     private static GdbServer? CreateGdbServer(Configuration configuration, IMemory memory,
         MemoryDataExporter memoryDataExporter, IFunctionHandlerProvider functionHandlerProvider, State state,
-        FunctionCatalogue functionCatalogue, ExecutionFlowRecorder executionFlowRecorder,
+        FunctionCatalogue functionCatalogue, IExecutionDumpFactory executionDumpFactory,
         EmulatorBreakpointsManager emulatorBreakpointsManager,
         IPauseHandler pauseHandler, ILoggerService loggerService) {
         if (configuration.GdbPort is null) {
             return null;
         }
         return new GdbServer(configuration, memory, functionHandlerProvider, state, memoryDataExporter,
-                functionCatalogue, executionFlowRecorder,
+                functionCatalogue, executionDumpFactory,
             emulatorBreakpointsManager, pauseHandler, loggerService);
     }
 

--- a/src/Spice86/Spice86DependencyInjection.cs
+++ b/src/Spice86/Spice86DependencyInjection.cs
@@ -86,9 +86,8 @@ public class Spice86DependencyInjection : IDisposable {
             loggerService.Information("Recorded data reader created...");
         }
 
-        ExecutionFlowRecorder executionFlowRecorder =
-            reader.ReadExecutionFlowRecorderFromFileOrCreate(
-                configuration.DumpDataOnExit is not false);
+        ExecutionDump executionDump =  reader.ReadExecutionDumpFromFileOrCreate();
+        ExecutionFlowRecorder executionFlowRecorder = new(configuration.DumpDataOnExit is not false, executionDump);
 
         if (loggerService.IsEnabled(LogEventLevel.Information)) {
             loggerService.Information("Execution flow recorder created...");
@@ -215,6 +214,8 @@ public class Spice86DependencyInjection : IDisposable {
 
         IInstructionExecutor instructionExecutor = configuration.CfgCpu ? cfgCpu : cpu;
         IFunctionHandlerProvider functionHandlerProvider = configuration.CfgCpu ? cfgCpu : cpu;
+        IExecutionDumpFactory executionDumpFactory =
+            configuration.CfgCpu ? new CfgCpuFlowDumper(cfgCpu, executionDump) : executionFlowRecorder;
         if (loggerService.IsEnabled(LogEventLevel.Information)) {
             string cpuType = configuration.CfgCpu ? nameof(CfgCpu) : nameof(Cpu);
             loggerService.Information("Execution will be done with {CpuType}", cpuType);
@@ -287,7 +288,7 @@ public class Spice86DependencyInjection : IDisposable {
         }
 
         EmulatorStateSerializer emulatorStateSerializer = new(memoryDataExporter, state,
-            executionFlowRecorder, functionCatalogue, loggerService);
+            executionDumpFactory, functionCatalogue, loggerService);
 
         if (loggerService.IsEnabled(LogEventLevel.Information)) {
             loggerService.Information("Emulator state serializer created...");
@@ -472,7 +473,7 @@ public class Spice86DependencyInjection : IDisposable {
         ProgramExecutor programExecutor = new(configuration, emulationLoop,
             emulatorBreakpointsManager, emulatorStateSerializer, memory,
             functionHandlerProvider, memoryDataExporter, state, dos,
-            functionCatalogue, executionFlowRecorder, pauseHandler,
+            functionCatalogue, executionDumpFactory, pauseHandler,
             mainWindowViewModel, loggerService);
 
         if (loggerService.IsEnabled(LogEventLevel.Information)) {

--- a/tests/Spice86.Tests/Dos/DosFileManagerTests.cs
+++ b/tests/Spice86.Tests/Dos/DosFileManagerTests.cs
@@ -102,8 +102,7 @@ public class DosFileManagerTests {
         IPauseHandler pauseHandler = new PauseHandler(loggerService);
 
         RecordedDataReader reader = new(configuration.RecordedDataDirectory, loggerService);
-        ExecutionFlowRecorder executionFlowRecorder =
-            reader.ReadExecutionFlowRecorderFromFileOrCreate(configuration.DumpDataOnExit is not false);
+        ExecutionFlowRecorder executionFlowRecorder = new(configuration.DumpDataOnExit is not false, new());
         State state = new();
         EmulatorBreakpointsManager emulatorBreakpointsManager = new(pauseHandler, state);
         IOPortDispatcher ioPortDispatcher = new(emulatorBreakpointsManager.IoReadWriteBreakpoints, state, loggerService, configuration.FailOnUnhandledPort);

--- a/tests/Spice86.Tests/MachineTest.cs
+++ b/tests/Spice86.Tests/MachineTest.cs
@@ -179,9 +179,9 @@ public class MachineTest
             Assert.NotNull(divBy0HandlerEntry);
             Assert.NotNull(divBy0HandlerIret);
             Assert.NotNull(divBy0NextInstruction);
-            // Check that the int handler is linked to the division by 0 as a normal successor
+            // Check that the int handler is linked to the division by 0 as a cpu fault type successor
             Assert.Contains(divBy0HandlerEntry, divBy0.Successors);
-            Assert.Contains(divBy0HandlerEntry, divBy0.SuccessorsPerType[InstructionSuccessorType.Normal]);
+            Assert.Contains(divBy0HandlerEntry, divBy0.SuccessorsPerType[InstructionSuccessorType.CpuFault]);
             // Check that the instruction next to the div by 0 to which the handler returned to  is linked to the division by 0 as a regular "Call to return" link.
             // Side-note, normally, div by 0 int handler should return to the div instruction. However, here the handler edits the call stack making it return to the next instruction which is how a regular function call in a high level language would behave
             Assert.Contains(divBy0NextInstruction, divBy0.Successors);


### PR DESCRIPTION
### Description of Changes
Make CFG CPU dump the execution flow in the same format as the regular CPU for compatibility with ghidra plugin.

This implies:
- Extracting the dumped json data structure to be useable by more than one implementation of data collector (and changing boilerplate code around that for regular CPU)
- Creating a new data dumper that can be used in place of the one used in CPU. It is only called when dumping data so no perf hit.
- Marking some cfginstruction classes to know whether they are call / ret / jump
- Handling cpu fault linking better

Node: We only dump the fields the fields used by the importer part of the plugin. Fields related to self modifying code in ghidra are not exported since the strategy we implemented in the ghidra plugin cant work well.

### Rationale behind Changes
This is part of the work needed to make cfgcpu mainstream

### Suggested Testing Steps
Tested with dune, 3dbench2 and krondor demo.