### PR TITLE
fix: EMS and XMS could not be disabled

### DIFF
--- a/src/Spice86.Core/CLI/Configuration.cs
+++ b/src/Spice86.Core/CLI/Configuration.cs
@@ -141,8 +141,8 @@ public sealed class Configuration {
     /// <summary>
     /// Determines whether EMS (Expanded Memory Specification) should be enabled or not.
     /// </summary>
-    [Option(nameof(Ems), Default = true, Required = false, HelpText = "Enable EMS")]
-    public bool Ems { get; init; }
+    [Option(nameof(Ems), Default = null, Required = false, HelpText = "Enable EMS")]
+    public bool? Ems { get; init; }
 
     /// <summary>
     /// Specify the type of mouse to use.
@@ -168,6 +168,6 @@ public sealed class Configuration {
     [Option(nameof(AudioEngine), Default = AudioEngine.PortAudio, Required = false, HelpText = "Audio engine to use. Values are PortAudio or Dummy")]
     public AudioEngine AudioEngine { get; init; }
 
-    [Option(nameof(Xms), Default = true, Required = false, HelpText = "Enable XMS. Default is true.")]
-    public bool Xms { get; init; }
+    [Option(nameof(Xms), Default = null, Required = false, HelpText = "Enable XMS. Default is true.")]
+    public bool? Xms { get; init; }
 }

--- a/src/Spice86.Core/Emulator/OperatingSystem/Dos.cs
+++ b/src/Spice86.Core/Emulator/OperatingSystem/Dos.cs
@@ -184,12 +184,12 @@ public sealed class Dos {
         }
         OpenDefaultFileHandles(dosDevices);
 
-        if (configuration.Xms && xms is not null) {
+        if (configuration.Xms is not false && xms is not null) {
             Xms = xms;
             AddDevice(xms, ExtendedMemoryManager.DosDeviceSegment, 0);
         }
 
-        if (configuration.Ems) {
+        if (configuration.Ems is not false) {
             Ems = new(_memory, functionHandlerProvider, stack, state, _loggerService);
             AddDevice(Ems.AsCharacterDevice(), ExpandedMemoryManager.DosDeviceSegment, 0);
         }

--- a/src/Spice86.Core/Emulator/OperatingSystem/Structures/DosSysVars.cs
+++ b/src/Spice86.Core/Emulator/OperatingSystem/Structures/DosSysVars.cs
@@ -32,7 +32,7 @@ public class DosSysVars : MemoryBasedDataStructure {
         ClockDeviceHeaderPointer = 0x0;
         MagicWord = 0x1;
         BootDrive = 0x0;
-        if (configuration.Xms) {
+        if (configuration.Xms is not false) {
             ExtendedMemorySize = ExtendedMemoryManager.XmsMemorySize;
         } else {
             // Size of HMA

--- a/src/Spice86/Spice86DependencyInjection.cs
+++ b/src/Spice86/Spice86DependencyInjection.cs
@@ -282,10 +282,10 @@ public class Spice86DependencyInjection : IDisposable {
 
         DosTables dosTables = new();
 
-        if (configuration.Xms) {
+        if (configuration.Xms is not false) {
             xms = new(memory, state, a20Gate, memoryAsmWriter, dosTables, loggerService);
         }
-        if (configuration.Xms && loggerService.IsEnabled(
+        if (configuration.Xms is not false && loggerService.IsEnabled(
             LogEventLevel.Information)) {
             loggerService.Information("DOS XMS driver created...");
         }


### PR DESCRIPTION
A flaw in CommandLine when bool parameters are true by default, they can not be disable with false.

Now they can.