### PR TITLE
fix: vga sequencer register access

### DIFF
--- a/src/Spice86.Core/Emulator/Devices/Video/Registers/SequencerRegisters.cs
+++ b/src/Spice86.Core/Emulator/Devices/Video/Registers/SequencerRegisters.cs
@@ -11,7 +11,11 @@ public class SequencerRegisters {
     ///     The Sequencer Address field (bits 2− 0) contains the index value that points to the data register to be
     ///     accessed.
     /// </summary>
-    public SequencerRegister Address { get; set; }
+    private SequencerRegister _address;
+    public SequencerRegister Address {
+        get => _address;
+        set => _address = (SequencerRegister)((int)value & 0x07);
+    }
 
     /// <summary>
     ///     Gets the Reset register.


### PR DESCRIPTION
Only the first three bits are used for the register access. If I read the VGA documentation correctly, everything above should be ignored.

This fixes the error in "Avoid the Noid".

Reference: http://www.osdever.net/FreeVGA/vga/seqreg.htm#04

### Description of Changes
Only use the first three bits for register access.

### Rationale behind Changes
Avoid the Noid crashes

### Suggested Testing Steps
Start the game
