### PR TITLE
Determine whether a DOS executable is a COM or EXE file based on file content and not extension

### DIFF
--- a/src/Spice86.Core/Emulator/LoadableFile/Dos/DosExeFile.cs
+++ b/src/Spice86.Core/Emulator/LoadableFile/Dos/DosExeFile.cs
@@ -9,6 +9,11 @@ using Spice86.Shared.Emulator.Memory;
 /// </summary>
 public class DosExeFile : MemoryBasedDataStructure {
     /// <summary>
+    /// Minimal size an exe file can have to be parseable.
+    /// </summary>
+    public const int MinExeSize = 0x1C;
+
+    /// <summary>
     /// Creates a new instance of the ExeFile class.
     /// </summary>
     /// <param name="byteReaderWriter">The class that allows writing and reading at specific addresses in memory.</param>


### PR DESCRIPTION
### Description of Changes
Some programs ship as COM files but they are actually EXE files (MZ header).
Let's not care about extension to differentiate the formats.

### Suggested Testing Steps
Working with stunts.com which is an EXE file although it has a COM extension
Working with dune / krondor