### PR TITLE
fix: clamp program size calculation

### DIFF
--- a/src/Spice86.Core/Emulator/LoadableFile/Dos/DosExeFile.cs
+++ b/src/Spice86.Core/Emulator/LoadableFile/Dos/DosExeFile.cs
@@ -133,7 +133,7 @@ public class DosExeFile : MemoryBasedDataStructure {
     /// <summary>
     /// Number of paragraphs that are need to load the program code in the executable file.
     /// </summary>
-    public ushort ProgramSizeInParagraphs => (ushort)((Pages << 5) - HeaderSizeInParagraphs);
+    public ushort ProgramSizeInParagraphsPerHeader => (ushort)((Pages << 5) - HeaderSizeInParagraphs);
 
     /// <summary>
     /// True when represented EXE is valid.

--- a/src/Spice86.Core/Emulator/OperatingSystem/DosMemoryManager.cs
+++ b/src/Spice86.Core/Emulator/OperatingSystem/DosMemoryManager.cs
@@ -320,7 +320,7 @@ public class DosMemoryManager {
     private AllocRange CalculateSizeForExe(DosExeFile exeFile, ushort pspSegment) {
         // Every program requires at least enough space for itself and the 16 paragraph (256 byte)
         // PSP that precedes it.
-        ushort baseSizeInParagraphs = (ushort)(exeFile.ProgramSizeInParagraphs + 0x10);
+        ushort baseSizeInParagraphs = (ushort)(exeFile.ProgramSizeInParagraphsPerHeader + 0x10);
 
         ushort minSizeInParagraphs = (ushort)(baseSizeInParagraphs + exeFile.MinAlloc);
         ushort maxSizeInParagraphs = (ushort)(baseSizeInParagraphs + exeFile.MaxAlloc);

--- a/src/Spice86.Core/Emulator/OperatingSystem/DosProcessManager.cs
+++ b/src/Spice86.Core/Emulator/OperatingSystem/DosProcessManager.cs
@@ -186,7 +186,7 @@ public class DosProcessManager : DosFileLoader {
         // immediately after the PSP like we normally do. This will give the program extra space
         // between the PSP and the start of the program image that it can use however it wants.
         if (exeFile.MinAlloc == 0 && exeFile.MaxAlloc == 0) {
-            ushort programEntryPointOffset = (ushort)(block.Size - exeFile.ProgramSizeInParagraphs);
+            ushort programEntryPointOffset = (ushort)(block.Size - exeFile.ProgramSizeInParagraphsPerHeader);
             programEntryPointSegment = (ushort)(block.DataBlockSegment + programEntryPointOffset);
         }
 


### PR DESCRIPTION
Take either the declared size or exe size, whatever is smaller

### Description of Changes
Fixes loading when the requested size (per header) is larger than the exe size.