### PR TITLE
fix: correct image size calculation

### DIFF
--- a/src/Spice86.Core/Emulator/LoadableFile/Dos/DosExeFile.cs
+++ b/src/Spice86.Core/Emulator/LoadableFile/Dos/DosExeFile.cs
@@ -125,8 +125,9 @@ public class DosExeFile : MemoryBasedDataStructure {
 
             uint headerSize = HeaderSizeInBytes;
             uint fileLength = ByteReaderWriter.Length;
+            uint declaredImageSize = declaredTotalSize > headerSize ? declaredTotalSize - headerSize : 0;
             uint availableAfterHeader = fileLength > headerSize ? fileLength - headerSize : 0;
-            return declaredTotalSize <= availableAfterHeader ? declaredTotalSize : availableAfterHeader;
+            return declaredImageSize <= availableAfterHeader ? declaredImageSize : availableAfterHeader;
         }
     }
 


### PR DESCRIPTION
### Description of Changes
The previous calculation was wrong and some games that used to work crashed.

### Rationale behind Changes
Fix crash issues.
