### PR TITLE
Various fixes to make debugging smoother.

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ When there is already data in the specified location, the emulator will load it 
 ## Command line options
 
 ```
-  --Debug                            (Default: false) Starts the program paused.
+  --Debug                            (Default: false) Starts the program paused and pauses once again when stopping.
   --Cycles                           (Default: null) Target CPU cycles per ms, for the rare speed sensitive game. Unused by default. Overrides Instructions per second option below if used.
   --Xms                              (Default: true) Enables 15 MB of XMS memory.
   --Ems                              (Default: true) Enables EMS memory. EMS adds 8 MB of memory accessible to DOS programs through the EMM Page Frame.
@@ -71,7 +71,7 @@ When there is already data in the specified location, the emulator will load it 
   -a, --ExeArgs                      List of parameters to give to the emulated program
   -x, --ExpectedChecksum             Hexadecimal string representing the expected SHA256 checksum of the emulated program
   -f, --FailOnUnhandledPort          (Default: false) If true, will fail when encountering an unhandled IO port. Useful to check for unimplemented hardware. false by default.
-  -g, --GdbPort                      gdb port, if empty gdb server will not be created. If not empty, application will pause until gdb connects
+  -g, --GdbPort                      GDB port. If 0, GDB server will be disabled. Default is 10000.
   -o, --OverrideSupplierClassName    Name of a class that will generate the initial function information. See documentation for more information.
   -p, --ProgramEntryPointSegment     (Default: 4096) Segment where to load the program. DOS PSP and MCB will be created before it.
   -u, --UseCodeOverride              (Default: true) <true or false> if false it will use the names provided by overrideSupplierClassName but not the code
@@ -94,12 +94,10 @@ Spice86 speaks the [GDB](https://www.gnu.org/software/gdb/) remote protocol:
 - it also provides custom GDB commands to do dynamic analysis.
 
 ### Connecting to GDB
-You need to specify a port for the GDB server to start when launching Spice86:
-```
-Spice86 --GdbPort=10000
-```
+The GDB server is always started along with the program to execute unless option is set to 0.
+Default port is 10000.
 
-Spice86 will wait for GDB to connect before starting execution so that you can setup breakpoints and so on.
+If you want to pause before starting execution to setup breakpoints and so on, use the --Debug option.
 
 Here is how to connect from GDB command line client and how to set the architecture:
 ```
@@ -160,18 +158,11 @@ Break at the end of the emulated program:
 (gdb) monitor breakStop
 ```
 
-#Refreshing screen or buffers while debugging
-```
-(gdb) monitor vbuffer refresh
-```
-
 ## Seer
 For a pleasing and productive experience with GDB, the
 [seerGDB](https://github.com/epasveer/seer) client is highly recommended.
 
-At best, use the configuration file `spice86.seer` provided in the `doc`
-directory ([here](doc/spice86.seer)): start Spice86 with `--GdbPort=10000`, and
-run Seer with `seergdb --project spice86.seer`.
+At best, use the configuration file `spice86.seer` provided in the `doc` directory ([here](doc/spice86.seer)): run Seer with `seergdb --project spice86.seer`.
 
 If you use a different port for gdb, adjust `spice86.seer` correspondingly.
 

--- a/src/Spice86.Core/CLI/Configuration.cs
+++ b/src/Spice86.Core/CLI/Configuration.cs
@@ -22,9 +22,9 @@ public sealed class Configuration {
     public bool A20Gate { get; init; }
     
     /// <summary>
-    /// Gets if the program will be paused on startup. If <see cref="GdbPort"/> is set, the program will be paused anyway.
+    /// Gets if the program will be paused on start and stop. If <see cref="GdbPort"/> is set, the program will be paused anyway.
     /// </summary>
-    [Option(nameof(Debug), Default = false, Required = false, HelpText = "Gets if the program will be paused on startup.")]
+    [Option(nameof(Debug), Default = false, Required = false, HelpText = "Starts the program paused and pauses once again when stopping.")]
     public bool Debug { get; init; }
 
     /// <summary> Path to C drive, default is exe parent. </summary>
@@ -79,10 +79,10 @@ public sealed class Configuration {
     public bool FailOnUnhandledPort { get; init; }
 
     /// <summary>
-    /// gdb port, if empty gdb server will not be created. If not empty, application will pause until gdb connects.
+    /// GDB port spice86 will listen to.
     /// </summary>
-    [Option('g', nameof(GdbPort), Default = null, Required = false, HelpText = "gdb port, if empty gdb server will not be created. If not empty, application will pause until gdb connects")]
-    public int? GdbPort { get; init; }
+    [Option('g', nameof(GdbPort), Default = 10000, Required = false, HelpText = "GDB port. If 0, GDB server will be disabled.")]
+    public int GdbPort { get; init; }
 
     /// <summary>
     /// Directory to dump data to when not specified otherwise. If blank dumps to SPICE86_DUMPS_FOLDER, and if not defined dumps to working directory.

--- a/src/Spice86.Core/Emulator/Devices/Timer/CounterConfiguratorFactory.cs
+++ b/src/Spice86.Core/Emulator/Devices/Timer/CounterConfiguratorFactory.cs
@@ -32,14 +32,6 @@ public class CounterConfiguratorFactory {
     /// </summary>
     public virtual CounterActivator InstantiateCounterActivator() {
         long? instructionsPerSecond = _configuration.InstructionsPerSecond;
-        if (instructionsPerSecond == null && _configuration.GdbPort != null) {
-            // With GDB, force to instructions per seconds as time based timers could perturbate steps
-            instructionsPerSecond = DefaultInstructionsPerSecond;
-            if (_loggerService.IsEnabled(Serilog.Events.LogEventLevel.Warning)) {
-                _loggerService.Warning("Forcing Counter to use instructions per seconds since in GDB mode. If speed is too slow or too fast adjust the --InstructionsPerSecond parameter");
-            }
-        }
-
         if (instructionsPerSecond != null) {
             return new CyclesCounterActivator(_state, _pauseHandler, instructionsPerSecond.Value, _configuration.TimeMultiplier);
         }

--- a/src/Spice86.Core/Emulator/Gdb/GdbCommandBreakPointHandler.cs
+++ b/src/Spice86.Core/Emulator/Gdb/GdbCommandBreakPointHandler.cs
@@ -89,7 +89,7 @@ public class GdbCommandBreakpointHandler {
         if (_loggerService.IsEnabled(LogEventLevel.Debug)) {
             _loggerService.Debug("Breakpoint reached!\n@{@BreakPoint}", breakPoint);
         }
-        if (!_gdbIo.IsClientConnected) {
+        if (!_gdbIo.IsClientConnected()) {
             if (_loggerService.IsEnabled(LogEventLevel.Verbose)) {
                 _loggerService.Verbose("Breakpoint reached but client is not connected. Nothing to do.\n{@BreakPoint}", breakPoint);
             }

--- a/src/Spice86.Core/Emulator/VM/Breakpoint/BreakPointType.cs
+++ b/src/Spice86.Core/Emulator/VM/Breakpoint/BreakPointType.cs
@@ -51,6 +51,9 @@ public enum BreakPointType {
     /// </summary>
     IO_ACCESS,
 
+    /// <summary> Breakpoint is triggered when the machine starts. </summary>
+    MACHINE_START,
+
     /// <summary> Breakpoint is triggered when the machine stops. </summary>
     MACHINE_STOP
 }

--- a/src/Spice86.Core/Emulator/VM/Breakpoint/EmulatorBreakpointsManager.cs
+++ b/src/Spice86.Core/Emulator/VM/Breakpoint/EmulatorBreakpointsManager.cs
@@ -10,6 +10,7 @@ public sealed class EmulatorBreakpointsManager {
     private readonly BreakPointHolder _executionBreakPoints;
     private readonly State _state;
     private readonly IPauseHandler _pauseHandler;
+    private BreakPoint? _machineStartBreakPoint;
     private BreakPoint? _machineStopBreakPoint;
 
     /// <summary>
@@ -33,9 +34,20 @@ public sealed class EmulatorBreakpointsManager {
     /// <summary>
     /// Called when the machine stops.
     /// </summary>
+    public void OnMachineStart() {
+        WaitSingleBreakpoint(_machineStartBreakPoint);
+    }
+
+    /// <summary>
+    /// Called when the machine stops.
+    /// </summary>
     public void OnMachineStop() {
-        if (_machineStopBreakPoint is not null) {
-            _machineStopBreakPoint.Trigger();
+        WaitSingleBreakpoint(_machineStopBreakPoint);
+    }
+
+    private void WaitSingleBreakpoint(BreakPoint? breakPoint) {
+        if (breakPoint is not null) {
+            breakPoint.Trigger();
             _pauseHandler.WaitIfPaused();
         }
     }
@@ -56,6 +68,9 @@ public sealed class EmulatorBreakpointsManager {
                 break;
             case BreakPointType.CPU_INTERRUPT:
                 InterruptBreakPoints.ToggleBreakPoint(breakPoint, on);
+                break;
+            case BreakPointType.MACHINE_START:
+                _machineStartBreakPoint = breakPoint;
                 break;
             case BreakPointType.MACHINE_STOP:
                 _machineStopBreakPoint = breakPoint;

--- a/src/Spice86.Core/Emulator/VM/EmulationLoop.cs
+++ b/src/Spice86.Core/Emulator/VM/EmulationLoop.cs
@@ -78,6 +78,7 @@ public class EmulationLoop : ICyclesLimiter {
     /// <exception cref="InvalidVMOperationException">When an unhandled exception occurs. <br/>
     /// This can occur if the target program is not supported (yet).</exception>
     public void Run() {
+        _emulatorBreakpointsManager.OnMachineStart();
         try {
             StartRunLoop(_functionHandler);
         } catch (HaltRequestedException) {
@@ -104,6 +105,7 @@ public class EmulationLoop : ICyclesLimiter {
         // Entry could be overridden and could throw exceptions
         functionHandler.Call(CallType.MACHINE, _cpuState.IpSegmentedAddress, null, null, "entry", false);
         RunLoop();
+        functionHandler.Ret(CallType.MACHINE, null);
     }
 
     private void RunLoop() {

--- a/src/Spice86/ViewModels/CfgCpuViewModel.cs
+++ b/src/Spice86/ViewModels/CfgCpuViewModel.cs
@@ -61,7 +61,9 @@ public partial class CfgCpuViewModel : ViewModelBase {
 
         pauseHandler.Paused += () => {
             if (AutoFollow) {
-                UpdateGraphCommand.Execute(null);
+                Avalonia.Threading.Dispatcher.UIThread.Post(() => {
+                    UpdateGraphCommand.Execute(null);
+                });
             }
         };
     }
@@ -258,13 +260,13 @@ public partial class CfgCpuViewModel : ViewModelBase {
         string label = string.Empty;
 
         // Check if it's the current execution node
-        ICfgNode? currentNode = _executionContextManager.CurrentExecutionContext?.LastExecuted;
-        bool isNodeCurrent = node.Id == currentNode?.Id;
-        bool isSuccessorCurrent = successor.Id == currentNode?.Id;
+        ICfgNode? lastExecutedNode = _executionContextManager.CurrentExecutionContext?.LastExecuted;
+        bool isNodeLastExecuted = node.Id == lastExecutedNode?.Id;
+        bool isSuccessorLastExecuted = successor.Id == lastExecutedNode?.Id;
 
         // Format node text with visual indicators for node type
-        string nodeText = FormatNodeText(node, isNodeCurrent);
-        string successorText = FormatNodeText(successor, isSuccessorCurrent);
+        string nodeText = FormatNodeText(node, isNodeLastExecuted);
+        string successorText = FormatNodeText(successor, isSuccessorLastExecuted);
 
         // Add more detailed labels for different edge types
         switch (node) {
@@ -297,7 +299,7 @@ public partial class CfgCpuViewModel : ViewModelBase {
         return new Edge(nodeText, successorText, label);
     }
 
-    private string FormatNodeText(ICfgNode node, bool isCurrent) {
+    private string FormatNodeText(ICfgNode node, bool isLastExecuted) {
         // Get the basic text representation
         string headerText = _nodeToString.ToHeaderString(node);
         string assemblyText = _nodeToString.ToAssemblyString(node);
@@ -305,9 +307,9 @@ public partial class CfgCpuViewModel : ViewModelBase {
         // Add visual indicators for node type and current execution node
         string prefix = "";
 
-        // Mark current execution node
-        if (isCurrent) {
-            prefix += "🔴 current ";
+        // Mark last executed node
+        if (isLastExecuted) {
+            prefix += "🔴 last run ";
         }
 
         // Add node type indicators

--- a/src/Spice86/Views/CfgCpuView.axaml
+++ b/src/Spice86/Views/CfgCpuView.axaml
@@ -110,7 +110,7 @@
 			
 			<Border Grid.Column="1" Background="#AAFFFFFF" CornerRadius="3" Padding="5" Margin="0,5,5,5">
 				<StackPanel Orientation="Horizontal" Spacing="8">
-					<TextBlock Text="🔴 Current node" />
+					<TextBlock Text="🔴 Last run" />
 					<TextBlock Text="→ Jump" />
 					<TextBlock Text="⟱ Call" />
 					<TextBlock Text="⟰ Return" />


### PR DESCRIPTION
### Description of Changes
GDB server is now always started unless --GdbPort option is set to 0.
If emulation needs to be started paused, --Debug flag should be used.
Also pause the emulator before shutdown when --Debug is used to show last display.
Support connecting to GDB via IPv4 or IPv6.
Some fixes and changes in the cfgcpu view to make it not crash when pausing from GDB.

### Suggested Testing Steps
Tested various scenarios:
- GDB server disabled
- GDB server enabled and --Debug flag given
- GDB server enabled and --Debug flag not given, connecting in the middle of the run
- Disconnecting from GDB
- Closing the application while GDB is still connected
