### PR TITLE
fix: package upgrade broke master (font resource ?)

### DIFF
--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -23,7 +23,7 @@
     <PackageVersion Include="Deadpikle.AvaloniaProgressRing" Version="0.10.10" />
     <PackageVersion Include="DialogHost.Avalonia" Version="0.9.3" />
     <PackageVersion Include="ErrorProne.NET.CoreAnalyzers" Version="0.1.2" />
-    <PackageVersion Include="FluentIcons.Avalonia.Fluent" Version="1.1.309" />
+    <PackageVersion Include="FluentIcons.Avalonia.Fluent" Version="1.1.303" />
     <PackageVersion Include="Iced" Version="1.21.0" />
     <PackageVersion Include="JetBrains.Annotations" Version="2025.2.2" />
     <PackageVersion Include="JvE.Structurizer" Version="1.2.0" />


### PR DESCRIPTION
reverts fluentIcons 'minor' upgrade from 303 to 309 for now, as it breaks master on font creation.