### PR TITLE
Feature: implement interrupt shadowing

### DIFF
--- a/src/Spice86.Core/Emulator/CPU/CfgCpu/ParsedInstruction/Instructions/Mixins/FlagControl.mixin
+++ b/src/Spice86.Core/Emulator/CPU/CfgCpu/ParsedInstruction/Instructions/Mixins/FlagControl.mixin
@@ -16,6 +16,13 @@ public partial class {{ moxy.Class.Name }} : CfgInstruction {
     }
 
     public override void Execute(InstructionExecutionHelper helper) {
+{{ if Mnemonic == "STI" }}
+        // Intel® 64 and IA-32 Architectures Software Developer’s Manual: Execution of STI with RFLAGS.IF = 0
+        // blocks maskable interrupts on the instruction boundary following its execution
+        if(!helper.State.InterruptFlag) {
+            helper.State.InterruptShadowing = true;
+        }
+{{ end }}    
         helper.State.{{FlagName}} = {{FlagValue}};
         helper.MoveIpAndSetNextNode(this);
     }

--- a/src/Spice86.Core/Emulator/CPU/CfgCpu/ParsedInstruction/Instructions/Mixins/PopReg.mixin
+++ b/src/Spice86.Core/Emulator/CPU/CfgCpu/ParsedInstruction/Instructions/Mixins/PopReg.mixin
@@ -16,15 +16,20 @@ using Spice86.Shared.Emulator.Memory;
 public partial class {{ moxy.Class.Name }} : InstructionWithRegisterIndex {
     public {{ moxy.Class.Name }}(SegmentedAddress address, InstructionField<ushort> opcodeField, List<InstructionPrefix> prefixes,
         int registerIndex) : base(address, opcodeField, prefixes, registerIndex, 1) {
-        {{ if IsSegment }}
+{{ if IsSegment }}
         if(registerIndex == (int)SegmentRegisterIndex.CsIndex) {
             throw new ArgumentException("Register CS is not allowed");
         }
-        {{ end }}
+{{ end }}
     }
 
     public override void Execute(InstructionExecutionHelper helper) {
         helper.{{ if IsSegment }}SegmentRegisters{{ else }}UInt{{Size}}Registers{{ end }}[RegisterIndex] = helper.Stack.Pop{{Size}}();
+{{ if IsSegment }}        
+        if (RegisterIndex == (int)SegmentRegisterIndex.SsIndex) {
+            helper.State.InterruptShadowing = true;
+        }
+{{ end }}        
         helper.MoveIpAndSetNextNode(this);
     }
 

--- a/src/Spice86.Core/Emulator/CPU/CfgCpu/ParsedInstruction/Instructions/MovSregRm16.cs
+++ b/src/Spice86.Core/Emulator/CPU/CfgCpu/ParsedInstruction/Instructions/MovSregRm16.cs
@@ -23,6 +23,9 @@ public class MovSregRm16 : InstructionWithModRm {
     public override void Execute(InstructionExecutionHelper helper) {
         helper.ModRm.RefreshWithNewModRmContext(ModRmContext);
         helper.State.SegmentRegisters.UInt16[ModRmContext.RegisterIndex] = helper.ModRm.RM16;
+        if (ModRmContext.RegisterIndex == (uint)SegmentRegisterIndex.SsIndex) {
+            helper.State.InterruptShadowing = true;
+        }
         helper.MoveIpAndSetNextNode(this);
     }
 

--- a/src/Spice86.Core/Emulator/CPU/InstructionsImpl/Instructions16.cs
+++ b/src/Spice86.Core/Emulator/CPU/InstructionsImpl/Instructions16.cs
@@ -1,13 +1,13 @@
-using Spice86.Core.Emulator.CPU.Exceptions;
-
 namespace Spice86.Core.Emulator.CPU.InstructionsImpl;
 
+using Spice86.Core.Emulator.CPU.Exceptions;
 using Spice86.Core.Emulator.CPU.Registers;
+using Spice86.Core.Emulator.Memory;
 
 public class Instructions16 : Instructions16Or32 {
     private readonly Alu16 _alu16;
 
-    public Instructions16(State state, Cpu cpu, Memory.IMemory memory, ModRM modRm)
+    public Instructions16(State state, Cpu cpu, IMemory memory, ModRM modRm)
         : base(cpu, memory, modRm) {
         _alu16 = new(state);
     }
@@ -469,6 +469,10 @@ public class Instructions16 : Instructions16Or32 {
             throw new CpuInvalidOpcodeException("Attempted to write to CS register with MOV instruction");
         }
         ModRM.SegmentRegister = ModRM.GetRm16();
+        if (ModRM.RegisterIndex == (uint)SegmentRegisterIndex.SsIndex) {
+            // Loading SS requires interrupt shadowing for one subsequent instruction
+            State.InterruptShadowing = true;
+        }
     }
 
     public override void Lea() {

--- a/src/Spice86.Core/Emulator/CPU/State.cs
+++ b/src/Spice86.Core/Emulator/CPU/State.cs
@@ -2,10 +2,9 @@
 
 using Spice86.Core.Emulator.CPU.Registers;
 using Spice86.Shared.Emulator.Memory;
+using Spice86.Shared.Utils;
 
 using System.Text;
-
-using Spice86.Shared.Utils;
 
 /// <summary>
 /// Represents the state of the CPU Registers and Flags.
@@ -388,9 +387,22 @@ public class State {
             res.Append(" (");
             res.Append(Flags);
             res.Append(')');
+            res.Append(" " + nameof(InterruptShadowing) + "=").Append(InterruptShadowing);
             return res.ToString();
         }
     }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether interrupt shadowing is enabled for the current CPU state.
+    /// <para>
+    /// Interrupt shadowing temporarily prevents external interrupts from being handled for a limited duration,
+    /// typically during the execution of certain critical instructions such as POP SS, MOV SS/sreg, or STI.
+    /// Once the shadowing period ends, external interrupts can be processed as usual.
+    ///
+    /// More details in the Intel Manual Volume 3A, 6.8.3 - Masking Exceptions and Interrupts When Switching Stacks
+    /// </para>
+    /// </summary>
+    public bool InterruptShadowing { get; set; }
 
     /// <summary>
     /// Returns all the CPU registers dumped into a string


### PR DESCRIPTION
### Description of Changes
According to this documentation:
https://cdrdv2-public.intel.com/782161/326019-sdm-vol-3c.pdf
https://cdrdv2-public.intel.com/825750/326019-sdm-vol-3c.pdf

STI (if IF 0 => 1), MOV SS and POP SS need to inhibit the execution of interrupts.

This MR implements this behavior to prevent possible stack corruption.

### Rationale behind Changes
Prevent bugs, may fix some compatibility issues.
