### PR TITLE
fix: crash on SingleOrDefault with Linear comparison

### DIFF
--- a/src/Spice86/ViewModels/Services/InstructionsDecoder.cs
+++ b/src/Spice86/ViewModels/Services/InstructionsDecoder.cs
@@ -89,7 +89,7 @@ internal class InstructionsDecoder(IMemory memory, IDictionary<SegmentedAddress,
 
         return new EnrichedInstruction(customInstruction) {
             Bytes = memory.ReadRam(CallbackOpcodeLength, address.Linear),
-            Function = functions.SingleOrDefault(pair => pair.Key.Linear == address.Linear).Value,
+            Function = functions.SingleOrDefault(pair => pair.Key == address).Value,
             SegmentedAddress = address,
             Breakpoints = breakpointsViewModel.GetExecutionBreakPointsAtAddress(address.Linear).ToImmutableList(),
             InstructionFormatOverride = [
@@ -111,7 +111,7 @@ internal class InstructionsDecoder(IMemory memory, IDictionary<SegmentedAddress,
     private EnrichedInstruction CreateStandardInstruction(Instruction instruction, SegmentedAddress address) {
         return new EnrichedInstruction(instruction) {
             Bytes = memory.ReadRam((uint)instruction.Length, address.Linear),
-            Function = functions.SingleOrDefault(pair => pair.Key.Linear == address.Linear).Value,
+            Function = functions.SingleOrDefault(pair => pair.Key == address).Value,
             SegmentedAddress = address,
             Breakpoints = breakpointsViewModel.GetExecutionBreakPointsAtAddress(address.Linear).ToImmutableList(),
         };


### PR DESCRIPTION
fixes this crash:

<img width="3291" height="1924" alt="image" src="https://github.com/user-attachments/assets/eea9276b-befa-4a46-a828-215f41dcf227" />

when two functions in the functions dict resolve to the same Linear address.

Tested with Dune 2.