### PR TITLE
fix: XMS hookable jmp offset was not 16 bit.

### DIFF
--- a/src/Spice86.Core/Emulator/InterruptHandlers/Common/MemoryWriter/MemoryAsmWriter.cs
+++ b/src/Spice86.Core/Emulator/InterruptHandlers/Common/MemoryWriter/MemoryAsmWriter.cs
@@ -67,9 +67,9 @@ public class MemoryAsmWriter : MemoryWriter {
         WriteUInt8(vectorNumber);
     }
 
-    public void WriteJumpNear(uint offset) {
+    public void WriteJumpNear(ushort offset) {
         WriteUInt8(0xE9);
-        WriteUInt32(offset);
+        WriteUInt16(offset);
     }
 
     /// <summary>


### PR DESCRIPTION

Updated the `WriteJumpNear` method in the `MemoryAsmWriter` class to change the parameter type from `uint` to `ushort`. This change allows the method to write a 16-bit value instead of a 32-bit value, since it is a near jump in x86_16 mode.

Tested fine with Wolf3D.