### PR TITLE
fix: crash in threadpool thread accessing ui object

### DIFF
--- a/src/Spice86/ViewModels/CfgCpuViewModel.cs
+++ b/src/Spice86/ViewModels/CfgCpuViewModel.cs
@@ -188,7 +188,10 @@ public partial class CfgCpuViewModel : ViewModelBase {
         try {
             IsLoading = true;
             StatusMessage = "Generating graph...";
-            
+
+            _searchableNodes.Clear();
+            _tableNodesList.Clear();
+
             await Task.Run(async () => {
                 long localNumberOfNodes = 0;
                 Graph currentGraph = new();
@@ -197,9 +200,6 @@ public partial class CfgCpuViewModel : ViewModelBase {
                 HashSet<ICfgNode> visitedNodes = new();
                 HashSet<(int, int)> existingEdges = new();
                 Stopwatch stopwatch = new();
-
-                _searchableNodes.Clear();
-                _tableNodesList.Clear();
 
                 while (queue.Count > 0 && localNumberOfNodes < MaxNodesToDisplay) {
                     ICfgNode node = queue.Dequeue();


### PR DESCRIPTION
fix: crash in threadpool thread accessing ui object

System.InvalidOperationException when .Clear() was called inside the Task.Run call.

await Task.Run is used to perform CPU Bound operations outside the UI thread, and wait for the result while the UI thread continues to run in the mean time.