### PR TITLE
fix: some minor mouse-related fixes and refactorings

### DIFF
--- a/src/Spice86.Core/Emulator/InterruptHandlers/Input/Mouse/BiosMouseInt74Handler.cs
+++ b/src/Spice86.Core/Emulator/InterruptHandlers/Input/Mouse/BiosMouseInt74Handler.cs
@@ -21,7 +21,7 @@ public class BiosMouseInt74Handler : IInterruptHandler {
     /// <param name="memory">The memory bus.</param>
     public BiosMouseInt74Handler(DualPic hardwareInterruptHandler, IIndexable memory) {
         _hardwareInterruptHandler = hardwareInterruptHandler;
-        _driverAddressSwitcher = new(memory);
+        _driverAddressSwitcher = new InMemoryAddressSwitcher(memory);
     }
 
     /// <inheritdoc />

--- a/src/Spice86.Core/Emulator/InterruptHandlers/Input/Mouse/IMouseDevice.cs
+++ b/src/Spice86.Core/Emulator/InterruptHandlers/Input/Mouse/IMouseDevice.cs
@@ -48,10 +48,10 @@ public interface IMouseDevice : IIOPortHandler {
     MouseEventMask LastTrigger { get; }
 
     /// <summary>
-    ///     The sample rate of the mouse.
+    ///     The sample rate of the mouse. Currently unused.
     /// </summary>
     int SampleRate { get; set; }
-
+    
     /// <summary>
     ///     The amount of movement in the Y direction since the last update.
     /// </summary>

--- a/src/Spice86.Core/Emulator/InterruptHandlers/Input/Mouse/MouseStatus.cs
+++ b/src/Spice86.Core/Emulator/InterruptHandlers/Input/Mouse/MouseStatus.cs
@@ -6,10 +6,10 @@ namespace Spice86.Core.Emulator.InterruptHandlers.Input.Mouse;
 /// <param name="X">The X axis position</param>
 /// <param name="Y">They Y axis position</param>
 /// <param name="ButtonFlags">The state of the button flags</param>
-public record struct MouseStatus(int X, int Y, int ButtonFlags) {
+public readonly record struct MouseStatus(int X, int Y, int ButtonFlags) {
     /// <inheritdoc />
     public override string ToString() {
-        return string.Format("x = {0}, y = {1}, leftButton = {2}, rightButton = {3}, middleButton = {4}"
-            , X, Y, (ButtonFlags & 1) == 1 ? "down" : "up", (ButtonFlags & 2) == 2 ? "down" : "up", (ButtonFlags & 4) == 4 ? "down" : "up");
+        return
+            $"x = {X}, y = {Y}, leftButton = {((ButtonFlags & 1) == 1 ? "down" : "up")}, rightButton = {((ButtonFlags & 2) == 2 ? "down" : "up")}, middleButton = {((ButtonFlags & 4) == 4 ? "down" : "up")}";
     }
 }


### PR DESCRIPTION
### Description of Changes
Some minor refactorings. There are five categories of changes:
- avoid local variable allocation of mouse buttons
- Documentation fix
- Safe inspection fixes
- Safety measures
- Real bugs (SetMouseMickeyPixelRatio, GetLastPressedY, GetLastReleasedY)

Regarding the real bugs:

**SetMouseMickeyPixelRatio**
I read the documentation and implementation and it should be divided by 8 instead of multiplied by 8.

**GetLastPressedY** & **GetLastReleasedY**
Both used LastPressedX instead of LastPressedY

### Rationale behind Changes
Safety, correctness