### PR TITLE
fix: No Keyboard, Mouse, Render events on Paused

### DIFF
--- a/src/Spice86/ViewModels/MainWindowViewModel.cs
+++ b/src/Spice86/ViewModels/MainWindowViewModel.cs
@@ -137,6 +137,9 @@ public sealed partial class MainWindowViewModel : ViewModelWithErrorDialog, IGui
     internal void OnMainWindowClosing() => _isAppClosing = true;
 
     internal void OnKeyUp(KeyEventArgs e) {
+        if (_pauseHandler.IsPaused) {
+            return;
+        }
         KeyUp?.Invoke(this,
             new KeyboardEventArgs((Key)e.Key,
                 false,
@@ -188,6 +191,9 @@ public sealed partial class MainWindowViewModel : ViewModelWithErrorDialog, IGui
 
 
     internal void OnKeyDown(KeyEventArgs e) {
+        if (_pauseHandler.IsPaused) {
+            return;
+        }
         KeyDown?.Invoke(this,
             new KeyboardEventArgs((Key)e.Key,
                 true,
@@ -216,17 +222,23 @@ public sealed partial class MainWindowViewModel : ViewModelWithErrorDialog, IGui
     public double MouseY { get; set; }
     
     public void OnMouseButtonDown(PointerPressedEventArgs @event, Image image) {
+        if (_pauseHandler.IsPaused) {
+            return;
+        }
         Avalonia.Input.MouseButton mouseButton = @event.GetCurrentPoint(image).Properties.PointerUpdateKind.GetMouseButton();
         MouseButtonDown?.Invoke(this, new MouseButtonEventArgs((MouseButton)mouseButton, true));
     }
 
     public void OnMouseButtonUp(PointerReleasedEventArgs @event, Image image) {
+        if(_pauseHandler.IsPaused) {
+            return;
+        }
         Avalonia.Input.MouseButton mouseButton = @event.GetCurrentPoint(image).Properties.PointerUpdateKind.GetMouseButton();
         MouseButtonUp?.Invoke(this, new MouseButtonEventArgs((MouseButton)mouseButton, false));
     }
 
     public void OnMouseMoved(PointerEventArgs @event, Image image) {
-        if (image.Source is null) {
+        if (image.Source is null || _pauseHandler.IsPaused) {
             return;
         }
         MouseX = @event.GetPosition(image).X / image.Source.Size.Width;
@@ -317,7 +329,8 @@ public sealed partial class MainWindowViewModel : ViewModelWithErrorDialog, IGui
     }
 
     private void DrawScreen() {
-        if (_disposed || _isSettingResolution || _isAppClosing || Bitmap is null || RenderScreen is null) {
+        if (_disposed || _pauseHandler.IsPaused || _isSettingResolution ||
+            _isAppClosing || Bitmap is null || RenderScreen is null) {
             return;
         }
         _drawingSemaphoreSlim?.Wait();

--- a/src/Spice86/Views/MainWindow.axaml
+++ b/src/Spice86/Views/MainWindow.axaml
@@ -96,9 +96,9 @@
 		</Menu>
 		<StackPanel IsEnabled="{Binding IsEmulatorRunning}" Grid.Row="0" Margin="160,0,0,0" HorizontalAlignment="Left" VerticalAlignment="Top" Orientation="Horizontal">
 			<Label Focusable="False" VerticalAlignment="Center" Content="Cycles/ms:" />
-			<Button Margin="10,0,5,0" HotKey="Ctrl+F11" Focusable="False" Command="{Binding DecreaseTargetCyclesCommand}" Content="-" />
-			<NumericUpDown Focusable="False" FormatString="0" Minimum="100" Text="{Binding TargetCyclesPerMs}" Maximum="60000" />
-			<Button Margin="5,0,10,0" HotKey="Ctrl+F12" Focusable="False" Command="{Binding IncreaseTargetCyclesCommand}" Content="+" />
+			<Button Margin="10,0,5,0" HotKey="Ctrl+F11" Focusable="False" IsEnabled="{Binding !IsPaused}" Command="{Binding DecreaseTargetCyclesCommand}" Content="-" />
+			<NumericUpDown Focusable="False" FormatString="0" Minimum="100" IsEnabled="{Binding !IsPaused}" Text="{Binding TargetCyclesPerMs}" Maximum="60000" />
+			<Button Margin="5,0,10,0" HotKey="Ctrl+F12" Focusable="False" IsEnabled="{Binding !IsPaused}" Command="{Binding IncreaseTargetCyclesCommand}" Content="+" />
 			<Button Focusable="False" Command="{Binding PauseCommand}" Margin="5,0,5,0" ToolTip.Tip="Pause (Ctrl+Shift+F5)" HotKey="Ctrl+Shift+F5" IsVisible="{Binding !IsPaused}">
 				<fluent:SymbolIcon Symbol="Pause" />
 			</Button>


### PR DESCRIPTION
MainWindowViewModel no longer fires Mouse, Keyboard, and Render events if the emulator is paused.

It just makes sense. :)