### PR TITLE
fix wildcard matching for SimCity (1994)

### DIFF
--- a/tests/Spice86.Tests/Emulator/OperatingSystem/DosPathResolverTest.cs
+++ b/tests/Spice86.Tests/Emulator/OperatingSystem/DosPathResolverTest.cs
@@ -101,6 +101,7 @@ public class DosPathResolverTest {
     [InlineData("MYTEST.TXT", "MY*.T*", true)]
     [InlineData("MYTEST.TXT", "MY*.TXT", true)]
     [InlineData("MYTEST.TXT", "MY*.TET", false)]
+    [InlineData("MYTEST.TXT", ".TXT", true)]
     public void DosWildcard_Spec_Cases(string file, string pattern, bool expected) {
         DoCmp(file, pattern).Should().Be(expected,
             $"file '{file}' should {(expected ? "" : "NOT ")}match '{pattern}' per DOS 8.3 wildcard rules");


### PR DESCRIPTION
SimCity (1994) asks for files through this pattern: `C:\mcga\.pgf`

The old implementation did not treat that as a wildcard.