### PR TITLE
Add support for saving the video card info to a file

### DIFF
--- a/src/Spice86/Spice86DependencyInjection.cs
+++ b/src/Spice86/Spice86DependencyInjection.cs
@@ -521,7 +521,7 @@ public class Spice86DependencyInjection : IDisposable {
 
             SoftwareMixerViewModel softwareMixerViewModel = new(softwareMixer);
 
-            VideoCardViewModel videoCardViewModel = new(vgaRenderer, videoState);
+            VideoCardViewModel videoCardViewModel = new(vgaRenderer, videoState, hostStorageProvider);
 
             CpuViewModel cpuViewModel = new(state, memory, pauseHandler, uiDispatcher);
 

--- a/src/Spice86/ViewModels/Services/HostStorageProvider.cs
+++ b/src/Spice86/ViewModels/Services/HostStorageProvider.cs
@@ -77,6 +77,24 @@ public class HostStorageProvider : IHostStorageProvider {
         }
     }
 
+    public async Task SaveVideoCardInfoFile(string videoCardInfoJson) {
+        if (CanSave && CanPickFolder) {
+            FilePickerSaveOptions options = new() {
+                Title = "Save video card info...",
+                SuggestedFileName = "VideoCardInfo.json",
+                DefaultExtension = "json",
+                SuggestedStartLocation = await TryGetFolderFromPathAsync(_configuration.RecordedDataDirectory)
+            };
+            if (!Directory.Exists(_configuration.RecordedDataDirectory)) {
+                options.SuggestedStartLocation = await TryGetWellKnownFolderAsync(WellKnownFolder.Documents);
+            }
+            string? file = (await SaveFilePickerAsync(options))?.TryGetLocalPath();
+            if (!string.IsNullOrWhiteSpace(file)) {
+                await File.WriteAllTextAsync(file, videoCardInfoJson);
+            }
+        }
+    }
+
     public async Task DumpEmulatorStateToFile() {
         if (CanSave && CanPickFolder) {
             FolderPickerOpenOptions options = new() {
@@ -164,4 +182,11 @@ public interface IHostStorageProvider {
     /// <param name="bytes">The binary content of the file.</param>
     /// <returns>The operation as an awaitable Task.</returns>
     Task SaveBinaryFile(byte[] bytes);
+
+    /// <summary>
+    /// Spawns the file picker to save the video card information to a file.
+    /// </summary>
+    /// <param name="videoCardInfoJson">The serialized video card information in JSON format.</param>
+    /// <returns>The operation as an awaitable Task.</returns>
+    Task SaveVideoCardInfoFile(string videoCardInfoJson);
 }

--- a/src/Spice86/ViewModels/VideoCardViewModel.cs
+++ b/src/Spice86/ViewModels/VideoCardViewModel.cs
@@ -1,23 +1,35 @@
 namespace Spice86.ViewModels;
 
 using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
 
 using Spice86.Core.Emulator.Devices.Video;
 using Spice86.ViewModels.ValueViewModels.Debugging;
 using Spice86.ViewModels.PropertiesMappers;
+using Spice86.ViewModels.Services;
+
+using System.Text.Json;
 
 public partial class VideoCardViewModel  : ViewModelBase, IEmulatorObjectViewModel {
     [ObservableProperty]
     private VideoCardInfo _videoCard = new();
     private readonly IVgaRenderer _vgaRenderer;
     private readonly IVideoState _videoState;
-    
-    public VideoCardViewModel(IVgaRenderer vgaRenderer, IVideoState videoState) {
+    private readonly IHostStorageProvider _storageProvider;
+
+    public VideoCardViewModel(IVgaRenderer vgaRenderer, IVideoState videoState,
+        IHostStorageProvider storageProvider) {
         _vgaRenderer = vgaRenderer;
         _videoState = videoState;
+        _storageProvider = storageProvider;
     }
 
     public bool IsVisible { get; set; }
+
+    [RelayCommand]
+    public async Task SaveVideoCardInfo() {
+        await _storageProvider.SaveVideoCardInfoFile(JsonSerializer.Serialize(VideoCard));
+    }
 
     public void UpdateValues(object? sender, EventArgs e) {
         if (!IsVisible) {

--- a/src/Spice86/Views/VideoCardView.axaml
+++ b/src/Spice86/Views/VideoCardView.axaml
@@ -17,168 +17,168 @@
             <Grid Margin="5" RowDefinitions="Auto,*">
                 <Label HorizontalAlignment="Center" FontWeight="Bold">General registers</Label>
                 <WrapPanel Grid.Row="1" Orientation="Vertical">
-                    <TextBlock Text="{Binding VideoCard.GeneralMiscellaneousOutputRegister, StringFormat='MiscellaneousOutputRegister: {0:X2}'}" TextAlignment="Right" />
-                    <TextBlock Text="{Binding VideoCard.GeneralClockSelect, StringFormat='ClockSelect: {0}'}" TextAlignment="Right" />
-                    <TextBlock Text="{Binding VideoCard.GeneralEnableRam, StringFormat='EnableRam: {0}'}" TextAlignment="Right" />
-                    <TextBlock Text="{Binding VideoCard.GeneralVerticalSize, StringFormat='VerticalSize: {0}'}" TextAlignment="Right" />
-                    <TextBlock Text="{Binding VideoCard.GeneralHorizontalSyncPolarity, StringFormat='HorizontalSyncPolarity: {0}'}" TextAlignment="Right" />
-                    <TextBlock Text="{Binding VideoCard.GeneralVerticalSyncPolarity, StringFormat='VerticalSyncPolarity: {0}'}" TextAlignment="Right" />
-                    <TextBlock Text="{Binding VideoCard.GeneralIoAddressSelect, StringFormat='IoAddressSelect: {0}'}" TextAlignment="Right" />
-                    <TextBlock Text="{Binding VideoCard.GeneralOddPageSelect, StringFormat='OddPageSelect: {0}'}" TextAlignment="Right" />
-                    <TextBlock Text="{Binding VideoCard.GeneralInputStatusRegister0, StringFormat='InputStatusRegister0: {0:X2}'}" TextAlignment="Right" />
-                    <TextBlock Text="{Binding VideoCard.GeneralCrtInterrupt, StringFormat='CrtInterrupt: {0}'}" TextAlignment="Right" />
-                    <TextBlock Text="{Binding VideoCard.GeneralSwitchSense, StringFormat='SwitchSense: {0}'}" TextAlignment="Right" />
-                    <TextBlock Text="{Binding VideoCard.GeneralInputStatusRegister1, StringFormat='InputStatusRegister1: {0:X2}'}" TextAlignment="Right" />
-                    <TextBlock Text="{Binding VideoCard.GeneralDisplayDisabled, StringFormat='DisplayDisabled: {0}'}" TextAlignment="Right" />
-                    <TextBlock Text="{Binding VideoCard.GeneralVerticalRetrace, StringFormat='VerticalRetrace: {0}'}" TextAlignment="Right" />
+                    <TextBox IsReadOnly="True" Text="{Binding VideoCard.GeneralMiscellaneousOutputRegister, StringFormat='MiscellaneousOutputRegister: {0:X2}'}" TextAlignment="Right" />
+                    <TextBox IsReadOnly="True" Text="{Binding VideoCard.GeneralClockSelect, StringFormat='ClockSelect: {0}'}" TextAlignment="Right" />
+                    <TextBox IsReadOnly="True" Text="{Binding VideoCard.GeneralEnableRam, StringFormat='EnableRam: {0}'}" TextAlignment="Right" />
+                    <TextBox IsReadOnly="True" Text="{Binding VideoCard.GeneralVerticalSize, StringFormat='VerticalSize: {0}'}" TextAlignment="Right" />
+                    <TextBox IsReadOnly="True" Text="{Binding VideoCard.GeneralHorizontalSyncPolarity, StringFormat='HorizontalSyncPolarity: {0}'}" TextAlignment="Right" />
+                    <TextBox IsReadOnly="True" Text="{Binding VideoCard.GeneralVerticalSyncPolarity, StringFormat='VerticalSyncPolarity: {0}'}" TextAlignment="Right" />
+                    <TextBox IsReadOnly="True" Text="{Binding VideoCard.GeneralIoAddressSelect, StringFormat='IoAddressSelect: {0}'}" TextAlignment="Right" />
+                    <TextBox IsReadOnly="True" Text="{Binding VideoCard.GeneralOddPageSelect, StringFormat='OddPageSelect: {0}'}" TextAlignment="Right" />
+                    <TextBox IsReadOnly="True" Text="{Binding VideoCard.GeneralInputStatusRegister0, StringFormat='InputStatusRegister0: {0:X2}'}" TextAlignment="Right" />
+                    <TextBox IsReadOnly="True" Text="{Binding VideoCard.GeneralCrtInterrupt, StringFormat='CrtInterrupt: {0}'}" TextAlignment="Right" />
+                    <TextBox IsReadOnly="True" Text="{Binding VideoCard.GeneralSwitchSense, StringFormat='SwitchSense: {0}'}" TextAlignment="Right" />
+                    <TextBox IsReadOnly="True" Text="{Binding VideoCard.GeneralInputStatusRegister1, StringFormat='InputStatusRegister1: {0:X2}'}" TextAlignment="Right" />
+                    <TextBox IsReadOnly="True" Text="{Binding VideoCard.GeneralDisplayDisabled, StringFormat='DisplayDisabled: {0}'}" TextAlignment="Right" />
+                    <TextBox IsReadOnly="True" Text="{Binding VideoCard.GeneralVerticalRetrace, StringFormat='VerticalRetrace: {0}'}" TextAlignment="Right" />
                 </WrapPanel>
             </Grid>
             <Grid Margin="5" RowDefinitions="Auto,*">
                 <Label HorizontalAlignment="Center" FontWeight="Bold">Dac</Label>
                 <WrapPanel Grid.Row="1" Orientation="Vertical">
-                    <TextBlock Text="{Binding VideoCard.DacReadIndex, StringFormat='ReadIndex: {0:X2}'}" TextAlignment="Right" />
-                    <TextBlock Text="{Binding VideoCard.DacWriteIndex, StringFormat='WriteIndex: {0:X2}'}" TextAlignment="Right" />
-                    <TextBlock Text="{Binding VideoCard.DacPixelMask, StringFormat='PixelMask: {0:X2}'}" TextAlignment="Right" />
-                    <TextBlock Text="{Binding VideoCard.DacData, StringFormat='Data: {0:X2}'}" TextAlignment="Right" />
+                    <TextBox IsReadOnly="True" Text="{Binding VideoCard.DacReadIndex, StringFormat='ReadIndex: {0:X2}'}" TextAlignment="Right" />
+                    <TextBox IsReadOnly="True" Text="{Binding VideoCard.DacWriteIndex, StringFormat='WriteIndex: {0:X2}'}" TextAlignment="Right" />
+                    <TextBox IsReadOnly="True" Text="{Binding VideoCard.DacPixelMask, StringFormat='PixelMask: {0:X2}'}" TextAlignment="Right" />
+                    <TextBox IsReadOnly="True" Text="{Binding VideoCard.DacData, StringFormat='Data: {0:X2}'}" TextAlignment="Right" />
                 </WrapPanel>
             </Grid>
             <Grid Margin="5" RowDefinitions="Auto,*">
                 <Label HorizontalAlignment="Center" FontWeight="Bold">Graphics</Label>
                 <WrapPanel Grid.Row="1" Orientation="Vertical">
-                    <TextBlock Text="{Binding VideoCard.GraphicsSetReset, StringFormat='SetResetExpanded: {0:X2}'}" TextAlignment="Right" />
-                    <TextBlock Text="{Binding VideoCard.GraphicsEnableSetReset, StringFormat='EnableSetReset: {0:X2}'}" TextAlignment="Right" />
-                    <TextBlock Text="{Binding VideoCard.GraphicsColorCompare, StringFormat='ColorCompare: {0:X2}'}" TextAlignment="Right" />
-                    <TextBlock Text="{Binding VideoCard.GraphicsDataRotate, StringFormat='DataRotate: {0:X2}'}" TextAlignment="Right" />
-                    <TextBlock Text="{Binding VideoCard.GraphicsReadMapSelect, StringFormat='ReadMapSelect: {0:X2}'}" TextAlignment="Right" />
-                    <TextBlock Text="{Binding VideoCard.GraphicsModeRegister, StringFormat='GraphicsMode: {0:X2}'}" TextAlignment="Right" />
-                    <TextBlock Text="{Binding VideoCard.GraphicsMiscellaneousGraphics, StringFormat='MiscellaneousGraphics: {0:X2}'}" TextAlignment="Right" />
-                    <TextBlock Text="{Binding VideoCard.GraphicsColorDontCare, StringFormat='ColorDontCare: {0:X2}'}" TextAlignment="Right" />
-                    <TextBlock Text="{Binding VideoCard.GraphicsBitMask, StringFormat='BitMask: {0:X2}'}" TextAlignment="Right" />
-                    <TextBlock Text="{Binding VideoCard.GraphicsRotateCount, StringFormat='RotateCount:  {0}'}" TextAlignment="Right" />
-                    <TextBlock Text="{Binding VideoCard.GraphicsFunctionSelect, StringFormat='Function: {0}'}" TextAlignment="Right" />
-                    <TextBlock Text="{Binding VideoCard.GraphicsReadMode, StringFormat='ReadMode: {0}'}" TextAlignment="Right" />
-                    <TextBlock Text="{Binding VideoCard.GraphicsWriteMode, StringFormat='WriteMode: {0}'}" TextAlignment="Right" />
-                    <TextBlock Text="{Binding VideoCard.GraphicsOddEven, StringFormat='OddEven: {0}'}" TextAlignment="Right" />
-                    <TextBlock Text="{Binding VideoCard.GraphicsShiftRegisterMode, StringFormat='ShiftRegisterMode: {0}'}" TextAlignment="Right" />
-                    <TextBlock Text="{Binding VideoCard.GraphicsIn256ColorMode, StringFormat='In256ColorMode: {0}'}" TextAlignment="Right" />
-                    <TextBlock Text="{Binding VideoCard.GraphicsGraphicsMode, StringFormat='GraphicsMode: {0}'}" TextAlignment="Right" />
-                    <TextBlock Text="{Binding VideoCard.GraphicsChainOddMapsToEven, StringFormat='ChainOddMapsToEven: {0}'}" TextAlignment="Right" />
+                    <TextBox IsReadOnly="True" Text="{Binding VideoCard.GraphicsSetReset, StringFormat='SetResetExpanded: {0:X2}'}" TextAlignment="Right" />
+                    <TextBox IsReadOnly="True" Text="{Binding VideoCard.GraphicsEnableSetReset, StringFormat='EnableSetReset: {0:X2}'}" TextAlignment="Right" />
+                    <TextBox IsReadOnly="True" Text="{Binding VideoCard.GraphicsColorCompare, StringFormat='ColorCompare: {0:X2}'}" TextAlignment="Right" />
+                    <TextBox IsReadOnly="True" Text="{Binding VideoCard.GraphicsDataRotate, StringFormat='DataRotate: {0:X2}'}" TextAlignment="Right" />
+                    <TextBox IsReadOnly="True" Text="{Binding VideoCard.GraphicsReadMapSelect, StringFormat='ReadMapSelect: {0:X2}'}" TextAlignment="Right" />
+                    <TextBox IsReadOnly="True" Text="{Binding VideoCard.GraphicsModeRegister, StringFormat='GraphicsMode: {0:X2}'}" TextAlignment="Right" />
+                    <TextBox IsReadOnly="True" Text="{Binding VideoCard.GraphicsMiscellaneousGraphics, StringFormat='MiscellaneousGraphics: {0:X2}'}" TextAlignment="Right" />
+                    <TextBox IsReadOnly="True" Text="{Binding VideoCard.GraphicsColorDontCare, StringFormat='ColorDontCare: {0:X2}'}" TextAlignment="Right" />
+                    <TextBox IsReadOnly="True" Text="{Binding VideoCard.GraphicsBitMask, StringFormat='BitMask: {0:X2}'}" TextAlignment="Right" />
+                    <TextBox IsReadOnly="True" Text="{Binding VideoCard.GraphicsRotateCount, StringFormat='RotateCount:  {0}'}" TextAlignment="Right" />
+                    <TextBox IsReadOnly="True" Text="{Binding VideoCard.GraphicsFunctionSelect, StringFormat='Function: {0}'}" TextAlignment="Right" />
+                    <TextBox IsReadOnly="True" Text="{Binding VideoCard.GraphicsReadMode, StringFormat='ReadMode: {0}'}" TextAlignment="Right" />
+                    <TextBox IsReadOnly="True" Text="{Binding VideoCard.GraphicsWriteMode, StringFormat='WriteMode: {0}'}" TextAlignment="Right" />
+                    <TextBox IsReadOnly="True" Text="{Binding VideoCard.GraphicsOddEven, StringFormat='OddEven: {0}'}" TextAlignment="Right" />
+                    <TextBox IsReadOnly="True" Text="{Binding VideoCard.GraphicsShiftRegisterMode, StringFormat='ShiftRegisterMode: {0}'}" TextAlignment="Right" />
+                    <TextBox IsReadOnly="True" Text="{Binding VideoCard.GraphicsIn256ColorMode, StringFormat='In256ColorMode: {0}'}" TextAlignment="Right" />
+                    <TextBox IsReadOnly="True" Text="{Binding VideoCard.GraphicsGraphicsMode, StringFormat='GraphicsMode: {0}'}" TextAlignment="Right" />
+                    <TextBox IsReadOnly="True" Text="{Binding VideoCard.GraphicsChainOddMapsToEven, StringFormat='ChainOddMapsToEven: {0}'}" TextAlignment="Right" />
                 </WrapPanel>
             </Grid>
             <Grid Margin="5" RowDefinitions="Auto,*">
                 <Label HorizontalAlignment="Center" FontWeight="Bold">Sequencer</Label>
                 <WrapPanel Grid.Row="1" Orientation="Vertical">
-                    <TextBlock Text="{Binding VideoCard.SequencerResetRegister, StringFormat='Reset: {0:X2}'}" TextAlignment="Right" />
-                    <TextBlock Text="{Binding VideoCard.SequencerClockingModeRegister, StringFormat='ClockingMode: {0:X2}'}" TextAlignment="Right" />
-                    <TextBlock Text="{Binding VideoCard.SequencerPlaneMask, StringFormat='PlaneMask: {0:X2}'}" TextAlignment="Right" />
-                    <TextBlock Text="{Binding VideoCard.SequencerCharacterMapSelect, StringFormat='CharacterMapSelect: {0:X2}'}" TextAlignment="Right" />
-                    <TextBlock Text="{Binding VideoCard.SequencerSequencerMemoryMode, StringFormat='SequencerMemoryMode: {0:X2}'}" TextAlignment="Right" />
-                    <TextBlock Text="{Binding VideoCard.SequencerSynchronousReset, StringFormat='SynchronousReset: {0}'}" TextAlignment="Right" />
-                    <TextBlock Text="{Binding VideoCard.SequencerAsynchronousReset, StringFormat='AsynchronousReset: {0}'}" TextAlignment="Right" />
-                    <TextBlock Text="{Binding VideoCard.SequencerDotsPerClock, StringFormat='DotsPerClock: {0}'}" TextAlignment="Right" />
-                    <TextBlock Text="{Binding VideoCard.SequencerShiftLoad, StringFormat='ShiftLoad: {0}'}" TextAlignment="Right" />
-                    <TextBlock Text="{Binding VideoCard.SequencerDotClock, StringFormat='DotClock: {0}'}" TextAlignment="Right" />
-                    <TextBlock Text="{Binding VideoCard.SequencerShift4, StringFormat='Shift4: {0}'}" TextAlignment="Right" />
-                    <TextBlock Text="{Binding VideoCard.SequencerScreenOff, StringFormat='ScreenOff: {0}'}" TextAlignment="Right" />
-                    <TextBlock Text="{Binding VideoCard.SequencerCharacterMapA, StringFormat='CharacterMapA: {0:X4}'}" TextAlignment="Right" />
-                    <TextBlock Text="{Binding VideoCard.SequencerCharacterMapB, StringFormat='CharacterMapB: {0:X4}'}" TextAlignment="Right" />
-                    <TextBlock Text="{Binding VideoCard.SequencerExtendedMemory, StringFormat='ExtendedMemory: {0}'}" TextAlignment="Right" />
-                    <TextBlock Text="{Binding VideoCard.SequencerOddEvenMode, StringFormat='OddEvenMode: {0}'}" TextAlignment="Right" />
-                    <TextBlock Text="{Binding VideoCard.SequencerChain4Mode, StringFormat='Chain4Mode: {0}'}" TextAlignment="Right" />
+                    <TextBox IsReadOnly="True" Text="{Binding VideoCard.SequencerResetRegister, StringFormat='Reset: {0:X2}'}" TextAlignment="Right" />
+                    <TextBox IsReadOnly="True" Text="{Binding VideoCard.SequencerClockingModeRegister, StringFormat='ClockingMode: {0:X2}'}" TextAlignment="Right" />
+                    <TextBox IsReadOnly="True" Text="{Binding VideoCard.SequencerPlaneMask, StringFormat='PlaneMask: {0:X2}'}" TextAlignment="Right" />
+                    <TextBox IsReadOnly="True" Text="{Binding VideoCard.SequencerCharacterMapSelect, StringFormat='CharacterMapSelect: {0:X2}'}" TextAlignment="Right" />
+                    <TextBox IsReadOnly="True" Text="{Binding VideoCard.SequencerSequencerMemoryMode, StringFormat='SequencerMemoryMode: {0:X2}'}" TextAlignment="Right" />
+                    <TextBox IsReadOnly="True" Text="{Binding VideoCard.SequencerSynchronousReset, StringFormat='SynchronousReset: {0}'}" TextAlignment="Right" />
+                    <TextBox IsReadOnly="True" Text="{Binding VideoCard.SequencerAsynchronousReset, StringFormat='AsynchronousReset: {0}'}" TextAlignment="Right" />
+                    <TextBox IsReadOnly="True" Text="{Binding VideoCard.SequencerDotsPerClock, StringFormat='DotsPerClock: {0}'}" TextAlignment="Right" />
+                    <TextBox IsReadOnly="True" Text="{Binding VideoCard.SequencerShiftLoad, StringFormat='ShiftLoad: {0}'}" TextAlignment="Right" />
+                    <TextBox IsReadOnly="True" Text="{Binding VideoCard.SequencerDotClock, StringFormat='DotClock: {0}'}" TextAlignment="Right" />
+                    <TextBox IsReadOnly="True" Text="{Binding VideoCard.SequencerShift4, StringFormat='Shift4: {0}'}" TextAlignment="Right" />
+                    <TextBox IsReadOnly="True" Text="{Binding VideoCard.SequencerScreenOff, StringFormat='ScreenOff: {0}'}" TextAlignment="Right" />
+                    <TextBox IsReadOnly="True" Text="{Binding VideoCard.SequencerCharacterMapA, StringFormat='CharacterMapA: {0:X4}'}" TextAlignment="Right" />
+                    <TextBox IsReadOnly="True" Text="{Binding VideoCard.SequencerCharacterMapB, StringFormat='CharacterMapB: {0:X4}'}" TextAlignment="Right" />
+                    <TextBox IsReadOnly="True" Text="{Binding VideoCard.SequencerExtendedMemory, StringFormat='ExtendedMemory: {0}'}" TextAlignment="Right" />
+                    <TextBox IsReadOnly="True" Text="{Binding VideoCard.SequencerOddEvenMode, StringFormat='OddEvenMode: {0}'}" TextAlignment="Right" />
+                    <TextBox IsReadOnly="True" Text="{Binding VideoCard.SequencerChain4Mode, StringFormat='Chain4Mode: {0}'}" TextAlignment="Right" />
                 </WrapPanel>
             </Grid>
             <Grid Margin="5" RowDefinitions="Auto,*">
                 <Label HorizontalAlignment="Center" FontWeight="Bold">AttributeController</Label>
                 <WrapPanel Grid.Row="1" Orientation="Vertical">
-                    <TextBlock Text="{Binding VideoCard.AttributeControllerColorSelect, StringFormat='ColorSelect: {0:X2}'}" TextAlignment="Right" />
-                    <TextBlock Text="{Binding VideoCard.AttributeControllerOverscanColor, StringFormat='OverscanColor: {0:X2}'}" TextAlignment="Right" />
-                    <TextBlock Text="{Binding VideoCard.AttributeControllerAttributeModeControl, StringFormat='AttributeModeControl: {0:X2}'}" TextAlignment="Right" />
-                    <TextBlock Text="{Binding VideoCard.AttributeControllerColorPlaneEnable, StringFormat='ColorPlaneEnable: {0:X2}'}" TextAlignment="Right" />
-                    <TextBlock Text="{Binding VideoCard.AttributeControllerHorizontalPixelPanning, StringFormat='HorizontalPixelPanning: {0:X2}'}" TextAlignment="Right" />
-                    <TextBlock Text="{Binding VideoCard.AttributeControllerVideoOutput45Select, StringFormat='VideoOutput45Select: {0}'}" TextAlignment="Right" />
-                    <TextBlock Text="{Binding VideoCard.AttributeControllerPixelWidth8, StringFormat='PixelWidth8: {0}'}" TextAlignment="Right" />
-                    <TextBlock Text="{Binding VideoCard.AttributeControllerPixelPanningCompatibility, StringFormat='PixelPanningCompatibility: {0}'}" TextAlignment="Right" />
-                    <TextBlock Text="{Binding VideoCard.AttributeControllerBlinkingEnabled, StringFormat='BlinkingEnabled: {0}'}" TextAlignment="Right" />
-                    <TextBlock Text="{Binding VideoCard.AttributeControllerLineGraphicsEnabled, StringFormat='LineGraphicsEnabled: {0}'}" TextAlignment="Right" />
-                    <TextBlock Text="{Binding VideoCard.AttributeControllerMonochromeEmulation, StringFormat='MonochromeEmulation: {0}'}" TextAlignment="Right" />
-                    <TextBlock Text="{Binding VideoCard.AttributeControllerGraphicsMode, StringFormat='GraphicsMode: {0}'}" TextAlignment="Right" />
+                    <TextBox IsReadOnly="True" Text="{Binding VideoCard.AttributeControllerColorSelect, StringFormat='ColorSelect: {0:X2}'}" TextAlignment="Right" />
+                    <TextBox IsReadOnly="True" Text="{Binding VideoCard.AttributeControllerOverscanColor, StringFormat='OverscanColor: {0:X2}'}" TextAlignment="Right" />
+                    <TextBox IsReadOnly="True" Text="{Binding VideoCard.AttributeControllerAttributeModeControl, StringFormat='AttributeModeControl: {0:X2}'}" TextAlignment="Right" />
+                    <TextBox IsReadOnly="True" Text="{Binding VideoCard.AttributeControllerColorPlaneEnable, StringFormat='ColorPlaneEnable: {0:X2}'}" TextAlignment="Right" />
+                    <TextBox IsReadOnly="True" Text="{Binding VideoCard.AttributeControllerHorizontalPixelPanning, StringFormat='HorizontalPixelPanning: {0:X2}'}" TextAlignment="Right" />
+                    <TextBox IsReadOnly="True" Text="{Binding VideoCard.AttributeControllerVideoOutput45Select, StringFormat='VideoOutput45Select: {0}'}" TextAlignment="Right" />
+                    <TextBox IsReadOnly="True" Text="{Binding VideoCard.AttributeControllerPixelWidth8, StringFormat='PixelWidth8: {0}'}" TextAlignment="Right" />
+                    <TextBox IsReadOnly="True" Text="{Binding VideoCard.AttributeControllerPixelPanningCompatibility, StringFormat='PixelPanningCompatibility: {0}'}" TextAlignment="Right" />
+                    <TextBox IsReadOnly="True" Text="{Binding VideoCard.AttributeControllerBlinkingEnabled, StringFormat='BlinkingEnabled: {0}'}" TextAlignment="Right" />
+                    <TextBox IsReadOnly="True" Text="{Binding VideoCard.AttributeControllerLineGraphicsEnabled, StringFormat='LineGraphicsEnabled: {0}'}" TextAlignment="Right" />
+                    <TextBox IsReadOnly="True" Text="{Binding VideoCard.AttributeControllerMonochromeEmulation, StringFormat='MonochromeEmulation: {0}'}" TextAlignment="Right" />
+                    <TextBox IsReadOnly="True" Text="{Binding VideoCard.AttributeControllerGraphicsMode, StringFormat='GraphicsMode: {0}'}" TextAlignment="Right" />
                 </WrapPanel>
             </Grid>
             <Grid Margin="5" RowDefinitions="Auto,*">
                 <Label HorizontalAlignment="Center" FontWeight="Bold">CRT Controller</Label>
                 <WrapPanel Grid.Row="1" Orientation="Vertical">
-                    <TextBlock Text="{Binding VideoCard.CrtControllerCharacterCellHeightRegister, StringFormat='CharacterCellHeight: {0:X2}'}" TextAlignment="Right" />
-                    <TextBlock Text="{Binding VideoCard.CrtControllerCrtModeControl, StringFormat='CrtModeControl: {0:X2}'}" TextAlignment="Right" />
-                    <TextBlock Text="{Binding VideoCard.CrtControllerCursorEnd, StringFormat='CursorEnd: {0:X2}'}" TextAlignment="Right" />
-                    <TextBlock Text="{Binding VideoCard.CrtControllerCursorLocationHigh, StringFormat='CursorLocationHigh: {0:X2}'}" TextAlignment="Right" />
-                    <TextBlock Text="{Binding VideoCard.CrtControllerCursorLocationLow, StringFormat='CursorLocationLow: {0:X2}'}" TextAlignment="Right" />
-                    <TextBlock Text="{Binding VideoCard.CrtControllerCursorStart, StringFormat='CursorStart: {0:X2}'}" TextAlignment="Right" />
-                    <TextBlock Text="{Binding VideoCard.CrtControllerEndHorizontalBlanking, StringFormat='EndHorizontalBlanking: {0:X2}'}" TextAlignment="Right" />
-                    <TextBlock Text="{Binding VideoCard.CrtControllerEndHorizontalDisplay, StringFormat='EndHorizontalDisplay: {0:X2}'}" TextAlignment="Right" />
-                    <TextBlock Text="{Binding VideoCard.CrtControllerEndHorizontalRetrace, StringFormat='EndHorizontalRetrace: {0:X2}'}" TextAlignment="Right" />
-                    <TextBlock Text="{Binding VideoCard.CrtControllerEndVerticalBlanking, StringFormat='EndVerticalBlanking: {0:X2}'}" TextAlignment="Right" />
-                    <TextBlock Text="{Binding VideoCard.CrtControllerHorizontalTotal, StringFormat='HorizontalTotal: {0:X2}'}" TextAlignment="Right" />
-                    <TextBlock Text="{Binding VideoCard.CrtControllerLineCompareRegister, StringFormat='LineCompare: {0:X2}'}" TextAlignment="Right" />
-                    <TextBlock Text="{Binding VideoCard.CrtControllerOffset, StringFormat='Offset: {0:X2}'}" TextAlignment="Right" />
-                    <TextBlock Text="{Binding VideoCard.CrtControllerOverflow, StringFormat='Overflow: {0:X2}'}" TextAlignment="Right" />
-                    <TextBlock Text="{Binding VideoCard.CrtControllerPresetRowScanRegister, StringFormat='PresetRowScan: {0:X2}'}" TextAlignment="Right" />
-                    <TextBlock Text="{Binding VideoCard.CrtControllerStartAddressHigh, StringFormat='StartHigh: {0:X2}'}" TextAlignment="Right" />
-                    <TextBlock Text="{Binding VideoCard.CrtControllerStartAddressLow, StringFormat='StartLow: {0:X2}'}" TextAlignment="Right" />
-                    <TextBlock Text="{Binding VideoCard.CrtControllerStartHorizontalBlanking, StringFormat='StartHorizontalBlanking: {0:X2}'}" TextAlignment="Right" />
-                    <TextBlock Text="{Binding VideoCard.CrtControllerStartHorizontalRetrace, StringFormat='StartHorizontalRetrace: {0:X2}'}" TextAlignment="Right" />
-                    <TextBlock Text="{Binding VideoCard.CrtControllerStartVerticalBlanking, StringFormat='StartVerticalBlanking: {0:X2}'}" TextAlignment="Right" />
-                    <TextBlock Text="{Binding VideoCard.CrtControllerUnderlineLocation, StringFormat='UnderlineLocation: {0:X2}'}" TextAlignment="Right" />
-                    <TextBlock Text="{Binding VideoCard.CrtControllerVerticalDisplayEndRegister, StringFormat='VerticalDisplayEnd: {0:X2}'}" TextAlignment="Right" />
-                    <TextBlock Text="{Binding VideoCard.CrtControllerVerticalRetraceEnd, StringFormat='VerticalRetraceEnd: {0:X2}'}" TextAlignment="Right" />
-                    <TextBlock Text="{Binding VideoCard.CrtControllerVerticalRetraceStart, StringFormat='VerticalRetraceStart: {0:X2}'}" TextAlignment="Right" />
-                    <TextBlock Text="{Binding VideoCard.CrtControllerVerticalTotalRegister, StringFormat='VerticalTotalReg: {0:X2}'}" TextAlignment="Right" />
-                    <TextBlock Text="{Binding VideoCard.CrtControllerAddressWrap, StringFormat='AddressWrap: {0}'}" TextAlignment="Right" />
-                    <TextBlock Text="{Binding VideoCard.CrtControllerBytePanning, StringFormat='BytePanning: {0}'}" TextAlignment="Right" />
-                    <TextBlock Text="{Binding VideoCard.CrtControllerByteWordMode, StringFormat='ByteWordMode: {0}'}" TextAlignment="Right" />
-                    <TextBlock Text="{Binding VideoCard.CrtControllerCharacterCellHeight, StringFormat='CharacterCellHeight: {0}'}" TextAlignment="Right" />
-                    <TextBlock Text="{Binding VideoCard.CrtControllerClearVerticalInterrupt, StringFormat='ClearVerticalInterrupt: {0}'}" TextAlignment="Right" />
-                    <TextBlock Text="{Binding VideoCard.CrtControllerCompatibilityModeSupport, StringFormat='CompatibilityModeSupport: {0}'}" TextAlignment="Right" />
-                    <TextBlock Text="{Binding VideoCard.CrtControllerCompatibleRead, StringFormat='CompatibleRead: {0}'}" TextAlignment="Right" />
-                    <TextBlock Text="{Binding VideoCard.CrtControllerCountByFour, StringFormat='CountByFour: {0}'}" TextAlignment="Right" />
-                    <TextBlock Text="{Binding VideoCard.CrtControllerCountByTwo, StringFormat='CountByTwo: {0}'}" TextAlignment="Right" />
-                    <TextBlock Text="{Binding VideoCard.CrtControllerCrtcScanDouble, StringFormat='CrtcScanDouble: {0}'}" TextAlignment="Right" />
-                    <TextBlock Text="{Binding VideoCard.CrtControllerDisableTextCursor, StringFormat='DisableTextCursor: {0}'}" TextAlignment="Right" />
-                    <TextBlock Text="{Binding VideoCard.CrtControllerDisableVerticalInterrupt, StringFormat='DisableVerticalInterrupt: {0}'}" TextAlignment="Right" />
-                    <TextBlock Text="{Binding VideoCard.CrtControllerDisplayEnableSkew, StringFormat='DisplayEnableSkew: {0}'}" TextAlignment="Right" />
-                    <TextBlock Text="{Binding VideoCard.CrtControllerDoubleWordMode, StringFormat='DoubleWordMode: {0}'}" TextAlignment="Right" />
-                    <TextBlock Text="{Binding VideoCard.CrtControllerHorizontalBlankingEnd, StringFormat='HorizontalBlankingEnd: {0}'}" TextAlignment="Right" />
-                    <TextBlock Text="{Binding VideoCard.CrtControllerHorizontalSyncDelay, StringFormat='HorizontalSyncDelay: {0}'}" TextAlignment="Right" />
-                    <TextBlock Text="{Binding VideoCard.CrtControllerHorizontalSyncEnd, StringFormat='HorizontalSyncEnd: {0}'}" TextAlignment="Right" />
-                    <TextBlock Text="{Binding VideoCard.CrtControllerLineCompare, StringFormat='LineCompareLine: {0}'}" TextAlignment="Right" />
-                    <TextBlock Text="{Binding VideoCard.CrtControllerPresetRowScan, StringFormat='PresetRowScan: {0}'}" TextAlignment="Right" />
-                    <TextBlock Text="{Binding VideoCard.CrtControllerRefreshCyclesPerScanline, StringFormat='RefreshCyclesPerScanline: {0}'}" TextAlignment="Right" />
-                    <TextBlock Text="{Binding VideoCard.CrtControllerSelectRowScanCounter, StringFormat='SelectRowScanCounter: {0}'}" TextAlignment="Right" />
-                    <TextBlock Text="{Binding VideoCard.CrtControllerTextCursorEnd, StringFormat='TextCursorEnd: {0}'}" TextAlignment="Right" />
-                    <TextBlock Text="{Binding VideoCard.CrtControllerTextCursorLocation, StringFormat='TextCursorLocation: {0}'}" TextAlignment="Right" />
-                    <TextBlock Text="{Binding VideoCard.CrtControllerTextCursorSkew, StringFormat='TextCursorSkew: {0}'}" TextAlignment="Right" />
-                    <TextBlock Text="{Binding VideoCard.CrtControllerTextCursorStart, StringFormat='TextCursorStart: {0}'}" TextAlignment="Right" />
-                    <TextBlock Text="{Binding VideoCard.CrtControllerTimingEnable, StringFormat='TimingEnable: {0}'}" TextAlignment="Right" />
-                    <TextBlock Text="{Binding VideoCard.CrtControllerUnderlineScanline, StringFormat='UnderlineScanline: {0}'}" TextAlignment="Right" />
-                    <TextBlock Text="{Binding VideoCard.CrtControllerVerticalTimingHalved, StringFormat='VerticalTimingHalved: {0}'}" TextAlignment="Right" />
-                    <TextBlock Text="{Binding VideoCard.CrtControllerWriteProtect, StringFormat='WriteProtect: {0}'}" TextAlignment="Right" />
-                    <TextBlock Text="{Binding VideoCard.CrtControllerStartAddress, StringFormat='StartAddress: {0:X6}'}" TextAlignment="Right" />
-                    <TextBlock Text="{Binding VideoCard.CrtControllerEndHorizontalDisplay, StringFormat='HorizontalDisplayEnd: {0}'}" TextAlignment="Right" />
-                    <TextBlock Text="{Binding VideoCard.CrtControllerStartHorizontalBlanking, StringFormat='HorizontalBlankingStart: {0}'}" TextAlignment="Right" />
-                    <TextBlock Text="{Binding VideoCard.CrtControllerStartHorizontalRetrace, StringFormat='HorizontalSyncStart: {0}'}" TextAlignment="Right" />
-                    <TextBlock Text="{Binding VideoCard.CrtControllerHorizontalTotal, StringFormat='HorizontalTotal: {0}'}" TextAlignment="Right" />
-                    <TextBlock Text="{Binding VideoCard.CrtControllerVerticalDisplayEnd, StringFormat='VerticalDisplayEnd: {0}'}" TextAlignment="Right" />
-                    <TextBlock Text="{Binding VideoCard.CrtControllerVerticalBlankingStart, StringFormat='VerticalBlankingStart: {0}'}" TextAlignment="Right" />
-                    <TextBlock Text="{Binding VideoCard.CrtControllerVerticalSyncStart, StringFormat='VerticalSyncStart: {0}'}" TextAlignment="Right" />
-                    <TextBlock Text="{Binding VideoCard.CrtControllerVerticalTotal, StringFormat='VerticalTotal: {0}'}" TextAlignment="Right" />
+                    <TextBox IsReadOnly="True" Text="{Binding VideoCard.CrtControllerCharacterCellHeightRegister, StringFormat='CharacterCellHeight: {0:X2}'}" TextAlignment="Right" />
+                    <TextBox IsReadOnly="True" Text="{Binding VideoCard.CrtControllerCrtModeControl, StringFormat='CrtModeControl: {0:X2}'}" TextAlignment="Right" />
+                    <TextBox IsReadOnly="True" Text="{Binding VideoCard.CrtControllerCursorEnd, StringFormat='CursorEnd: {0:X2}'}" TextAlignment="Right" />
+                    <TextBox IsReadOnly="True" Text="{Binding VideoCard.CrtControllerCursorLocationHigh, StringFormat='CursorLocationHigh: {0:X2}'}" TextAlignment="Right" />
+                    <TextBox IsReadOnly="True" Text="{Binding VideoCard.CrtControllerCursorLocationLow, StringFormat='CursorLocationLow: {0:X2}'}" TextAlignment="Right" />
+                    <TextBox IsReadOnly="True" Text="{Binding VideoCard.CrtControllerCursorStart, StringFormat='CursorStart: {0:X2}'}" TextAlignment="Right" />
+                    <TextBox IsReadOnly="True" Text="{Binding VideoCard.CrtControllerEndHorizontalBlanking, StringFormat='EndHorizontalBlanking: {0:X2}'}" TextAlignment="Right" />
+                    <TextBox IsReadOnly="True" Text="{Binding VideoCard.CrtControllerEndHorizontalDisplay, StringFormat='EndHorizontalDisplay: {0:X2}'}" TextAlignment="Right" />
+                    <TextBox IsReadOnly="True" Text="{Binding VideoCard.CrtControllerEndHorizontalRetrace, StringFormat='EndHorizontalRetrace: {0:X2}'}" TextAlignment="Right" />
+                    <TextBox IsReadOnly="True" Text="{Binding VideoCard.CrtControllerEndVerticalBlanking, StringFormat='EndVerticalBlanking: {0:X2}'}" TextAlignment="Right" />
+                    <TextBox IsReadOnly="True" Text="{Binding VideoCard.CrtControllerHorizontalTotal, StringFormat='HorizontalTotal: {0:X2}'}" TextAlignment="Right" />
+                    <TextBox IsReadOnly="True" Text="{Binding VideoCard.CrtControllerLineCompareRegister, StringFormat='LineCompare: {0:X2}'}" TextAlignment="Right" />
+                    <TextBox IsReadOnly="True" Text="{Binding VideoCard.CrtControllerOffset, StringFormat='Offset: {0:X2}'}" TextAlignment="Right" />
+                    <TextBox IsReadOnly="True" Text="{Binding VideoCard.CrtControllerOverflow, StringFormat='Overflow: {0:X2}'}" TextAlignment="Right" />
+                    <TextBox IsReadOnly="True" Text="{Binding VideoCard.CrtControllerPresetRowScanRegister, StringFormat='PresetRowScan: {0:X2}'}" TextAlignment="Right" />
+                    <TextBox IsReadOnly="True" Text="{Binding VideoCard.CrtControllerStartAddressHigh, StringFormat='StartHigh: {0:X2}'}" TextAlignment="Right" />
+                    <TextBox IsReadOnly="True" Text="{Binding VideoCard.CrtControllerStartAddressLow, StringFormat='StartLow: {0:X2}'}" TextAlignment="Right" />
+                    <TextBox IsReadOnly="True" Text="{Binding VideoCard.CrtControllerStartHorizontalBlanking, StringFormat='StartHorizontalBlanking: {0:X2}'}" TextAlignment="Right" />
+                    <TextBox IsReadOnly="True" Text="{Binding VideoCard.CrtControllerStartHorizontalRetrace, StringFormat='StartHorizontalRetrace: {0:X2}'}" TextAlignment="Right" />
+                    <TextBox IsReadOnly="True" Text="{Binding VideoCard.CrtControllerStartVerticalBlanking, StringFormat='StartVerticalBlanking: {0:X2}'}" TextAlignment="Right" />
+                    <TextBox IsReadOnly="True" Text="{Binding VideoCard.CrtControllerUnderlineLocation, StringFormat='UnderlineLocation: {0:X2}'}" TextAlignment="Right" />
+                    <TextBox IsReadOnly="True" Text="{Binding VideoCard.CrtControllerVerticalDisplayEndRegister, StringFormat='VerticalDisplayEnd: {0:X2}'}" TextAlignment="Right" />
+                    <TextBox IsReadOnly="True" Text="{Binding VideoCard.CrtControllerVerticalRetraceEnd, StringFormat='VerticalRetraceEnd: {0:X2}'}" TextAlignment="Right" />
+                    <TextBox IsReadOnly="True" Text="{Binding VideoCard.CrtControllerVerticalRetraceStart, StringFormat='VerticalRetraceStart: {0:X2}'}" TextAlignment="Right" />
+                    <TextBox IsReadOnly="True" Text="{Binding VideoCard.CrtControllerVerticalTotalRegister, StringFormat='VerticalTotalReg: {0:X2}'}" TextAlignment="Right" />
+                    <TextBox IsReadOnly="True" Text="{Binding VideoCard.CrtControllerAddressWrap, StringFormat='AddressWrap: {0}'}" TextAlignment="Right" />
+                    <TextBox IsReadOnly="True" Text="{Binding VideoCard.CrtControllerBytePanning, StringFormat='BytePanning: {0}'}" TextAlignment="Right" />
+                    <TextBox IsReadOnly="True" Text="{Binding VideoCard.CrtControllerByteWordMode, StringFormat='ByteWordMode: {0}'}" TextAlignment="Right" />
+                    <TextBox IsReadOnly="True" Text="{Binding VideoCard.CrtControllerCharacterCellHeight, StringFormat='CharacterCellHeight: {0}'}" TextAlignment="Right" />
+                    <TextBox IsReadOnly="True" Text="{Binding VideoCard.CrtControllerClearVerticalInterrupt, StringFormat='ClearVerticalInterrupt: {0}'}" TextAlignment="Right" />
+                    <TextBox IsReadOnly="True" Text="{Binding VideoCard.CrtControllerCompatibilityModeSupport, StringFormat='CompatibilityModeSupport: {0}'}" TextAlignment="Right" />
+                    <TextBox IsReadOnly="True" Text="{Binding VideoCard.CrtControllerCompatibleRead, StringFormat='CompatibleRead: {0}'}" TextAlignment="Right" />
+                    <TextBox IsReadOnly="True" Text="{Binding VideoCard.CrtControllerCountByFour, StringFormat='CountByFour: {0}'}" TextAlignment="Right" />
+                    <TextBox IsReadOnly="True" Text="{Binding VideoCard.CrtControllerCountByTwo, StringFormat='CountByTwo: {0}'}" TextAlignment="Right" />
+                    <TextBox IsReadOnly="True" Text="{Binding VideoCard.CrtControllerCrtcScanDouble, StringFormat='CrtcScanDouble: {0}'}" TextAlignment="Right" />
+                    <TextBox IsReadOnly="True" Text="{Binding VideoCard.CrtControllerDisableTextCursor, StringFormat='DisableTextCursor: {0}'}" TextAlignment="Right" />
+                    <TextBox IsReadOnly="True" Text="{Binding VideoCard.CrtControllerDisableVerticalInterrupt, StringFormat='DisableVerticalInterrupt: {0}'}" TextAlignment="Right" />
+                    <TextBox IsReadOnly="True" Text="{Binding VideoCard.CrtControllerDisplayEnableSkew, StringFormat='DisplayEnableSkew: {0}'}" TextAlignment="Right" />
+                    <TextBox IsReadOnly="True" Text="{Binding VideoCard.CrtControllerDoubleWordMode, StringFormat='DoubleWordMode: {0}'}" TextAlignment="Right" />
+                    <TextBox IsReadOnly="True" Text="{Binding VideoCard.CrtControllerHorizontalBlankingEnd, StringFormat='HorizontalBlankingEnd: {0}'}" TextAlignment="Right" />
+                    <TextBox IsReadOnly="True" Text="{Binding VideoCard.CrtControllerHorizontalSyncDelay, StringFormat='HorizontalSyncDelay: {0}'}" TextAlignment="Right" />
+                    <TextBox IsReadOnly="True" Text="{Binding VideoCard.CrtControllerHorizontalSyncEnd, StringFormat='HorizontalSyncEnd: {0}'}" TextAlignment="Right" />
+                    <TextBox IsReadOnly="True" Text="{Binding VideoCard.CrtControllerLineCompare, StringFormat='LineCompareLine: {0}'}" TextAlignment="Right" />
+                    <TextBox IsReadOnly="True" Text="{Binding VideoCard.CrtControllerPresetRowScan, StringFormat='PresetRowScan: {0}'}" TextAlignment="Right" />
+                    <TextBox IsReadOnly="True" Text="{Binding VideoCard.CrtControllerRefreshCyclesPerScanline, StringFormat='RefreshCyclesPerScanline: {0}'}" TextAlignment="Right" />
+                    <TextBox IsReadOnly="True" Text="{Binding VideoCard.CrtControllerSelectRowScanCounter, StringFormat='SelectRowScanCounter: {0}'}" TextAlignment="Right" />
+                    <TextBox IsReadOnly="True" Text="{Binding VideoCard.CrtControllerTextCursorEnd, StringFormat='TextCursorEnd: {0}'}" TextAlignment="Right" />
+                    <TextBox IsReadOnly="True" Text="{Binding VideoCard.CrtControllerTextCursorLocation, StringFormat='TextCursorLocation: {0}'}" TextAlignment="Right" />
+                    <TextBox IsReadOnly="True" Text="{Binding VideoCard.CrtControllerTextCursorSkew, StringFormat='TextCursorSkew: {0}'}" TextAlignment="Right" />
+                    <TextBox IsReadOnly="True" Text="{Binding VideoCard.CrtControllerTextCursorStart, StringFormat='TextCursorStart: {0}'}" TextAlignment="Right" />
+                    <TextBox IsReadOnly="True" Text="{Binding VideoCard.CrtControllerTimingEnable, StringFormat='TimingEnable: {0}'}" TextAlignment="Right" />
+                    <TextBox IsReadOnly="True" Text="{Binding VideoCard.CrtControllerUnderlineScanline, StringFormat='UnderlineScanline: {0}'}" TextAlignment="Right" />
+                    <TextBox IsReadOnly="True" Text="{Binding VideoCard.CrtControllerVerticalTimingHalved, StringFormat='VerticalTimingHalved: {0}'}" TextAlignment="Right" />
+                    <TextBox IsReadOnly="True" Text="{Binding VideoCard.CrtControllerWriteProtect, StringFormat='WriteProtect: {0}'}" TextAlignment="Right" />
+                    <TextBox IsReadOnly="True" Text="{Binding VideoCard.CrtControllerStartAddress, StringFormat='StartAddress: {0:X6}'}" TextAlignment="Right" />
+                    <TextBox IsReadOnly="True" Text="{Binding VideoCard.CrtControllerEndHorizontalDisplay, StringFormat='HorizontalDisplayEnd: {0}'}" TextAlignment="Right" />
+                    <TextBox IsReadOnly="True" Text="{Binding VideoCard.CrtControllerStartHorizontalBlanking, StringFormat='HorizontalBlankingStart: {0}'}" TextAlignment="Right" />
+                    <TextBox IsReadOnly="True" Text="{Binding VideoCard.CrtControllerStartHorizontalRetrace, StringFormat='HorizontalSyncStart: {0}'}" TextAlignment="Right" />
+                    <TextBox IsReadOnly="True" Text="{Binding VideoCard.CrtControllerHorizontalTotal, StringFormat='HorizontalTotal: {0}'}" TextAlignment="Right" />
+                    <TextBox IsReadOnly="True" Text="{Binding VideoCard.CrtControllerVerticalDisplayEnd, StringFormat='VerticalDisplayEnd: {0}'}" TextAlignment="Right" />
+                    <TextBox IsReadOnly="True" Text="{Binding VideoCard.CrtControllerVerticalBlankingStart, StringFormat='VerticalBlankingStart: {0}'}" TextAlignment="Right" />
+                    <TextBox IsReadOnly="True" Text="{Binding VideoCard.CrtControllerVerticalSyncStart, StringFormat='VerticalSyncStart: {0}'}" TextAlignment="Right" />
+                    <TextBox IsReadOnly="True" Text="{Binding VideoCard.CrtControllerVerticalTotal, StringFormat='VerticalTotal: {0}'}" TextAlignment="Right" />
                 </WrapPanel>
             </Grid>
             <Grid Margin="5" RowDefinitions="Auto,*">
                 <Label HorizontalAlignment="Center" FontWeight="Bold">Renderer</Label>
                 <WrapPanel Grid.Row="1" Orientation="Vertical">
-                    <TextBlock Text="{Binding VideoCard.RendererWidth, StringFormat='Width: {0}'}" TextAlignment="Right" />
-                    <TextBlock Text="{Binding VideoCard.RendererHeight, StringFormat='Height: {0}'}" TextAlignment="Right" />
-                    <TextBlock Text="{Binding VideoCard.RendererBufferSize, StringFormat='BufferSize: {0}'}" TextAlignment="Right" />
-                    <TextBlock Text="{Binding VideoCard.LastFrameRenderTime, StringFormat='FrameRenderTime: {0}'}" TextAlignment="Right" />
+                    <TextBox IsReadOnly="True" Text="{Binding VideoCard.RendererWidth, StringFormat='Width: {0}'}" TextAlignment="Right" />
+                    <TextBox IsReadOnly="True" Text="{Binding VideoCard.RendererHeight, StringFormat='Height: {0}'}" TextAlignment="Right" />
+                    <TextBox IsReadOnly="True" Text="{Binding VideoCard.RendererBufferSize, StringFormat='BufferSize: {0}'}" TextAlignment="Right" />
+                    <TextBox IsReadOnly="True" Text="{Binding VideoCard.LastFrameRenderTime, StringFormat='FrameRenderTime: {0}'}" TextAlignment="Right" />
                 </WrapPanel>
             </Grid>
         </WrapPanel>

--- a/src/Spice86/Views/VideoCardView.axaml
+++ b/src/Spice86/Views/VideoCardView.axaml
@@ -14,6 +14,11 @@
             <OnPlatform Default="{StaticResource RobotoMonoFont}" />
         </TextElement.FontFamily>
         <WrapPanel>
+            <WrapPanel.ContextMenu>
+                <ContextMenu>
+                    <MenuItem Header="Save Video Card Info..." Command="{Binding SaveVideoCardInfo}" HotKey="Ctrl+S" ToolTip.Tip="Ctrl+S" />
+                </ContextMenu>
+            </WrapPanel.ContextMenu>
             <Grid Margin="5" RowDefinitions="Auto,*">
                 <Label HorizontalAlignment="Center" FontWeight="Bold">General registers</Label>
                 <WrapPanel Grid.Row="1" Orientation="Vertical">


### PR DESCRIPTION
The Spice86 builtin debugger is able to display a lot of information about the video card state, which is very useful for tracking down video-related issues. However prior to this PR, it wasn't possible to easily copy it and compare snapshots of the video card state at different points in time without manually copying each field or transcribing it in some other way, which was painful and time-consuming.

Therefore this PR adds a new context menu to the video debugger view that allows the user to save the whole video card state to disk as a JSON file. That makes it possible to run through a JSON formatting tool like `jq` and `diff` it much more easily.

Thanks to @maximilien-noal for getting me started by making the properties on the video card view read-only for me!

**Video Card Info debugger screen *before*:**
<img width="1920" height="1057" alt="2025-09-17_17-43" src="https://github.com/user-attachments/assets/7af6ca5b-085e-4700-a25f-9d7719977324" />

**Video Card Info debugger screen *after*:**
<img width="1920" height="1056" alt="2025-09-17_17-54" src="https://github.com/user-attachments/assets/c92bb2b2-8666-4658-9500-b19323b67e42" />

**New *Save Video Card Info* context menu:**
<img width="1920" height="1056" alt="2025-09-17_17-43-2" src="https://github.com/user-attachments/assets/76b5b349-e2cf-4e36-8b24-8940af4b3381" />

**New *Save Video Card Info* save file dialog:**
<img width="1920" height="1056" alt="2025-09-17_17-40" src="https://github.com/user-attachments/assets/46ebb115-7d02-42d6-a36e-cad01c5de22b" />

**Example video card info output file:**
```
$ cat VideoCardInfo.json | jq .
{
  "GeneralMiscellaneousOutputRegister": 99,
  "GeneralClockSelect": 0,
  "GeneralEnableRam": true,
  "GeneralVerticalSize": 400,
  "GeneralHorizontalSyncPolarity": 0,
  "GeneralVerticalSyncPolarity": 1,
  "GeneralIoAddressSelect": 1,
  "GeneralOddPageSelect": true,
  "GeneralInputStatusRegister0": 0,
  "GeneralCrtInterrupt": false,
  "GeneralSwitchSense": false,
  "GeneralInputStatusRegister1": 9,
  "GeneralDisplayDisabled": true,
  "GeneralVerticalRetrace": true,
  "DacReadIndex": 0,
  "DacWriteIndex": 0,
  "DacPixelMask": 255,
  "DacData": 0,
  "GraphicsDataRotate": 0,
  "GraphicsRotateCount": 0,
  "GraphicsFunctionSelect": 0,
  "GraphicsBitMask": 255,
  "GraphicsColorCompare": 0,
  "GraphicsReadMode": 0,
  "GraphicsWriteMode": 0,
  "GraphicsOddEven": false,
  "GraphicsShiftRegisterMode": 1,
  "GraphicsIn256ColorMode": false,
  "GraphicsMiscellaneousGraphics": 5,
  "GraphicsModeRegister": 0,
  "GraphicsGraphicsMode": true,
  "GraphicsChainOddMapsToEven": false,
  "GraphicsMemoryMap": 1,
  "GraphicsSetReset": 0,
  "GraphicsColorDontCare": 15,
  "GraphicsEnableSetReset": 0,
  "GraphicsReadMapSelect": 0,
  "SequencerResetRegister": 3,
  "SequencerSynchronousReset": true,
  "SequencerAsynchronousReset": true,
  "SequencerClockingModeRegister": 9,
  "SequencerDotsPerClock": 8,
  "SequencerShiftLoad": false,
  "SequencerDotClock": true,
  "SequencerShift4": false,
  "SequencerScreenOff": false,
  "SequencerPlaneMask": 15,
  "SequencerCharacterMapSelect": 0,
  "SequencerCharacterMapA": 0,
  "SequencerCharacterMapB": 0,
  "SequencerSequencerMemoryMode": 6,
  "SequencerExtendedMemory": true,
  "SequencerOddEvenMode": false,
  "SequencerChain4Mode": false,
  "AttributeControllerColorSelect": 0,
  "AttributeControllerOverscanColor": 0,
  "AttributeControllerAttributeModeControl": 1,
  "AttributeControllerVideoOutput45Select": false,
  "AttributeControllerPixelWidth8": false,
  "AttributeControllerPixelPanningCompatibility": false,
  "AttributeControllerBlinkingEnabled": false,
  "AttributeControllerLineGraphicsEnabled": false,
  "AttributeControllerMonochromeEmulation": false,
  "AttributeControllerGraphicsMode": true,
  "AttributeControllerColorPlaneEnable": 15,
  "AttributeControllerHorizontalPixelPanning": 0,
  "CrtControllerAddressWrap": true,
  "CrtControllerClearVerticalInterrupt": false,
  "CrtControllerCompatibilityModeSupport": true,
  "CrtControllerCompatibleRead": true,
  "CrtControllerCountByFour": false,
  "CrtControllerCountByTwo": false,
  "CrtControllerCrtcScanDouble": true,
  "CrtControllerDisableTextCursor": false,
  "CrtControllerDisableVerticalInterrupt": false,
  "CrtControllerDoubleWordMode": false,
  "CrtControllerSelectRowScanCounter": true,
  "CrtControllerTimingEnable": true,
  "CrtControllerVerticalTimingHalved": false,
  "CrtControllerWriteProtect": true,
  "CrtControllerCrtModeControl": 227,
  "CrtControllerCursorEnd": 0,
  "CrtControllerCursorLocationHigh": 0,
  "CrtControllerCursorLocationLow": 0,
  "CrtControllerCursorStart": 0,
  "CrtControllerEndHorizontalBlanking": 144,
  "CrtControllerEndHorizontalDisplay": 39,
  "CrtControllerEndHorizontalRetrace": 128,
  "CrtControllerEndVerticalBlanking": 185,
  "CrtControllerHorizontalTotal": 45,
  "CrtControllerLineCompareRegister": 255,
  "CrtControllerCharacterCellHeightRegister": 192,
  "CrtControllerOffset": 20,
  "CrtControllerOverflow": 31,
  "CrtControllerPresetRowScanRegister": 0,
  "CrtControllerStartAddressHigh": 32,
  "CrtControllerStartAddressLow": 0,
  "CrtControllerStartHorizontalBlanking": 40,
  "CrtControllerStartHorizontalRetrace": 43,
  "CrtControllerStartVerticalBlanking": 40,
  "CrtControllerUnderlineLocation": 0,
  "CrtControllerVerticalDisplayEndRegister": 143,
  "CrtControllerVerticalRetraceEnd": 142,
  "CrtControllerVerticalRetraceStart": 156,
  "CrtControllerVerticalTotalRegister": 191,
  "CrtControllerByteWordMode": 1,
  "CrtControllerBytePanning": 0,
  "CrtControllerCharacterCellHeight": 0,
  "CrtControllerDisplayEnableSkew": 0,
  "CrtControllerHorizontalBlankingEnd": 48,
  "CrtControllerHorizontalSyncDelay": 0,
  "CrtControllerHorizontalSyncEnd": 0,
  "CrtControllerLineCompare": 1023,
  "CrtControllerPresetRowScan": 0,
  "CrtControllerRefreshCyclesPerScanline": 3,
  "CrtControllerStartAddress": 8192,
  "CrtControllerTextCursorEnd": 0,
  "CrtControllerTextCursorLocation": 0,
  "CrtControllerTextCursorSkew": 0,
  "CrtControllerTextCursorStart": 0,
  "CrtControllerUnderlineScanline": 0,
  "CrtControllerVerticalBlankingStart": 406,
  "CrtControllerVerticalDisplayEnd": 399,
  "CrtControllerVerticalSyncStart": 412,
  "CrtControllerVerticalTotal": 447,
  "RendererWidth": 320,
  "RendererHeight": 200,
  "RendererBufferSize": 64000,
  "LastFrameRenderTime": "00:00:00.0325581"
}
```