### PR TITLE
Fix warning NU1504

### DIFF
--- a/tests/Spice86.Tests/Spice86.Tests.csproj
+++ b/tests/Spice86.Tests/Spice86.Tests.csproj
@@ -54,35 +54,30 @@
     </None>
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="SingleStepTests.Intel8086.00-FF" Version="2025.6.8" />
     <EmbeddedResource Include="$(NuGetPackageRoot)singlesteptests.intel8086.00-ff/2025.6.8/content/tests/8086.00-FF.zip">
       <Link>8086.00-FF.zip</Link>
       <LogicalName>8086.00-FF.zip</LogicalName>
     </EmbeddedResource>
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="SingleStepTests.Intel80286.00-3F" Version="2025.10.8" />
     <EmbeddedResource Include="$(NuGetPackageRoot)singlesteptests.intel80286.00-3f/2025.10.8/content/tests/80286.00-3F.zip">
       <Link>80286.00-3F.zip</Link>
       <LogicalName>80286.00-3F.zip</LogicalName>
     </EmbeddedResource>
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="SingleStepTests.Intel80286.40-7F" Version="2025.10.8" />
     <EmbeddedResource Include="$(NuGetPackageRoot)singlesteptests.intel80286.40-7f/2025.10.8/content/tests/80286.40-7F.zip">
       <Link>80286.40-7F.zip</Link>
       <LogicalName>80286.40-7F.zip</LogicalName>
     </EmbeddedResource>
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="SingleStepTests.Intel80286.80-BF" Version="2025.10.8" />
     <EmbeddedResource Include="$(NuGetPackageRoot)singlesteptests.intel80286.80-bf/2025.10.8/content/tests/80286.80-BF.zip">
       <Link>80286.80-BF.zip</Link>
       <LogicalName>80286.80-BF.zip</LogicalName>
     </EmbeddedResource>
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="SingleStepTests.Intel80286.C0-FF" Version="2025.10.8" />
     <EmbeddedResource Include="$(NuGetPackageRoot)singlesteptests.intel80286.c0-ff/2025.10.8/content/tests/80286.C0-FF.zip">
       <Link>80286.C0-FF.zip</Link>
       <LogicalName>80286.C0-FF.zip</LogicalName>


### PR DESCRIPTION
Fixes warning for dotnet build:
```
warning NU1504: Duplicate 'PackageReference' items found. Remove the duplicate items or use the Update functionality to ensure a consistent restore behavior. The duplicate 'PackageReference' items are: SingleStepTests.Intel8086.00-FF , SingleStepTests.Intel8086.00-FF 2025.6.8; SingleStepTests.Intel80286.00-3F , SingleStepTests.Intel80286.00-3F 2025.10.8; SingleStepTests.Intel80286.40-7F , SingleStepTests.Intel80286.40-7F 2025.10.8; SingleStepTests.Intel80286.80-BF , SingleStepTests.Intel80286.80-BF 2025.10.8; SingleStepTests.Intel80286.C0-FF , SingleStepTests.Intel80286.C0-FF 2025.10.8.
```