### PR TITLE
Fix Int21 0x42 to treat CX/DX as a signed integer

### DIFF
--- a/src/Spice86.Core/Emulator/InterruptHandlers/Dos/DosInt21Handler.cs
+++ b/src/Spice86.Core/Emulator/InterruptHandlers/Dos/DosInt21Handler.cs
@@ -5,7 +5,6 @@ using Serilog.Events;
 using Spice86.Core.Emulator.CPU;
 using Spice86.Core.Emulator.Errors;
 using Spice86.Core.Emulator.Function;
-using Spice86.Core.Emulator.InterruptHandlers;
 using Spice86.Core.Emulator.InterruptHandlers.Input.Keyboard;
 using Spice86.Core.Emulator.Memory;
 using Spice86.Core.Emulator.OperatingSystem;
@@ -15,8 +14,6 @@ using Spice86.Core.Emulator.OperatingSystem.Structures;
 using Spice86.Shared.Interfaces;
 using Spice86.Shared.Utils;
 
-using System;
-using System.IO;
 using System.Linq;
 using System.Runtime.CompilerServices;
 using System.Text;
@@ -927,7 +924,7 @@ public class DosInt21Handler : InterruptHandler {
     public void MoveFilePointerUsingHandle(bool calledFromVm) {
         SeekOrigin originOfMove = (SeekOrigin)State.AL;
         ushort fileHandle = State.BX;
-        uint offset = (uint)(State.CX << 16 | State.DX);
+        int offset = (State.CX << 16) | State.DX;
         if (LoggerService.IsEnabled(LogEventLevel.Verbose)) {
             LoggerService.Verbose("MOVE FILE POINTER USING HANDLE. {OriginOfMove}, {FileHandle}, {Offset}", 
                 originOfMove, fileHandle, offset);

--- a/src/Spice86.Core/Emulator/OperatingSystem/DosFileManager.cs
+++ b/src/Spice86.Core/Emulator/OperatingSystem/DosFileManager.cs
@@ -451,7 +451,7 @@ public class DosFileManager {
     /// <param name="fileHandle">The handle to the file.</param>
     /// <param name="offset">Number of bytes to move.</param>
     /// <returns>A <see cref="DosFileOperationResult"/> with details about the result of the operation.</returns>
-    public DosFileOperationResult MoveFilePointerUsingHandle(SeekOrigin originOfMove, ushort fileHandle, uint offset) {
+    public DosFileOperationResult MoveFilePointerUsingHandle(SeekOrigin originOfMove, ushort fileHandle, int offset) {
         if (GetOpenFile(fileHandle) is not VirtualFileBase file) {
             return FileNotOpenedError(fileHandle);
         }

--- a/tests/Spice86.Tests/Dos/DosInt21HandlerTests.cs
+++ b/tests/Spice86.Tests/Dos/DosInt21HandlerTests.cs
@@ -1,0 +1,108 @@
+namespace Spice86.Tests.Dos;
+
+using FluentAssertions;
+
+using NSubstitute;
+
+using Spice86.Core.Emulator.CPU;
+using Spice86.Core.Emulator.Function;
+using Spice86.Core.Emulator.InterruptHandlers.Dos;
+using Spice86.Core.Emulator.Memory;
+using Spice86.Core.Emulator.OperatingSystem;
+using Spice86.Core.Emulator.OperatingSystem.Devices;
+using Spice86.Core.Emulator.OperatingSystem.Structures;
+using Spice86.Shared.Interfaces;
+
+using Xunit;
+
+public class DosInt21HandlerTests {
+    [Fact]
+    public void MoveFilePointerUsingHandle_ShouldTreatCxDxOffsetAsSignedValue() {
+        // Arrange
+        IMemory memory = Substitute.For<IMemory>();
+        var state = new State(CpuModel.INTEL_80286);
+        var stack = new Stack(memory, state);
+        ILoggerService logger = Substitute.For<ILoggerService>();
+        IFunctionHandlerProvider functionHandlerProvider = Substitute.For<IFunctionHandlerProvider>();
+        string cDrivePath = Path.GetTempPath();
+        var driveManager = new DosDriveManager(logger, cDrivePath, null);
+        var stringDecoder = new DosStringDecoder(memory, state);
+        IList<IVirtualDevice> virtualDevices = new List<IVirtualDevice>();
+        var dosFileManager = new DosFileManager(memory, stringDecoder, driveManager, logger, virtualDevices);
+        var recordingFile = new RecordingVirtualFile();
+        const ushort fileHandle = 0x0003;
+        dosFileManager.OpenFiles[fileHandle] = recordingFile;
+        var clock = new Clock(logger);
+
+        var handler = new DosInt21Handler(
+            memory,
+            null!,
+            functionHandlerProvider,
+            stack,
+            state,
+            null!,
+            null!,
+            stringDecoder,
+            null!,
+            dosFileManager,
+            driveManager,
+            clock,
+            logger);
+
+        state.AL = (byte)SeekOrigin.Current;
+        state.BX = fileHandle;
+        state.CX = 0xFFFF;
+        state.DX = 0xFFFF;
+
+        // Act
+        handler.MoveFilePointerUsingHandle(false);
+
+        // Assert
+        recordingFile.LastSeekOffset.Should().Be(-1);
+        recordingFile.LastSeekOrigin.Should().Be(SeekOrigin.Current);
+    }
+
+    private sealed class RecordingVirtualFile : VirtualFileBase {
+        private long _length;
+
+        public long LastSeekOffset { get; private set; }
+
+        public SeekOrigin LastSeekOrigin { get; private set; }
+
+        public override bool CanRead => false;
+
+        public override bool CanSeek => true;
+
+        public override bool CanWrite => false;
+
+        public override long Length => _length;
+
+        public override long Position { get; set; }
+
+        public override void Flush() {
+        }
+
+        public override int Read(byte[] buffer, int offset, int count) {
+            throw new NotSupportedException();
+        }
+
+        public override long Seek(long offset, SeekOrigin origin) {
+            LastSeekOffset = offset;
+            LastSeekOrigin = origin;
+            return origin switch {
+                SeekOrigin.Begin => Position = offset,
+                SeekOrigin.Current => Position += offset,
+                SeekOrigin.End => Position = _length + offset,
+                _ => Position
+            };
+        }
+
+        public override void SetLength(long value) {
+            _length = value;
+        }
+
+        public override void Write(byte[] buffer, int offset, int count) {
+            throw new NotSupportedException();
+        }
+    }
+}


### PR DESCRIPTION
### Description of Changes
CX/DX was casted to uint which does not wrap around as expected, the test shows it.

### Rationale behind Changes
CX/DX can be negative and could lead to undesired behavior.

### Suggested Testing Steps
Run the test
