### PR TITLE
Add trailing slash to nuget path if needed, and use dotnet nuget instead of nuget (more portable)

### DIFF
--- a/.github/workflows/nuget.yml
+++ b/.github/workflows/nuget.yml
@@ -35,24 +35,24 @@ jobs:
     - name: Upload NuGet Bufdio.Spice86
       if: github.ref == 'refs/heads/master'
       working-directory: ./src/Bufdio.Spice86/bin/Release
-      run: nuget push Bufdio.Spice86.10.0.0.nupkg ${{secrets.NUGET_API_KEY}} -Source 'https://api.nuget.org/v3/index.json' -SkipDuplicate
+      run: dotnet nuget push Bufdio.Spice86.10.0.0.nupkg ${{secrets.NUGET_API_KEY}} -Source 'https://api.nuget.org/v3/index.json' -SkipDuplicate
 
     - name: Upload NuGet Spice86.Shared
       if: github.ref == 'refs/heads/master'
       working-directory: ./src/Spice86.Shared/bin/Release
-      run: nuget push Spice86.Shared.10.0.0.nupkg ${{secrets.NUGET_API_KEY}} -Source 'https://api.nuget.org/v3/index.json' -SkipDuplicate
+      run: dotnet nuget push Spice86.Shared.10.0.0.nupkg ${{secrets.NUGET_API_KEY}} -Source 'https://api.nuget.org/v3/index.json' -SkipDuplicate
 
     - name: Upload NuGet Spice86.Logging
       if: github.ref == 'refs/heads/master'
       working-directory: ./src/Spice86.Logging/bin/Release
-      run: nuget push Spice86.Logging.10.0.0.nupkg ${{secrets.NUGET_API_KEY}} -Source 'https://api.nuget.org/v3/index.json' -SkipDuplicate
+      run: dotnet nuget push Spice86.Logging.10.0.0.nupkg ${{secrets.NUGET_API_KEY}} -Source 'https://api.nuget.org/v3/index.json' -SkipDuplicate
 
     - name: Upload NuGet Spice86.Core
       if: github.ref == 'refs/heads/master'
       working-directory: ./src/Spice86.Core/bin/Release
-      run: nuget push Spice86.Core.10.0.0.nupkg ${{secrets.NUGET_API_KEY}} -Source 'https://api.nuget.org/v3/index.json' -SkipDuplicate
+      run: dotnet nuget push Spice86.Core.10.0.0.nupkg ${{secrets.NUGET_API_KEY}} -Source 'https://api.nuget.org/v3/index.json' -SkipDuplicate
 
     - name: Upload NuGet Spice86
       if: github.ref == 'refs/heads/master'
       working-directory: ./src/Spice86/bin/Release
-      run: nuget push Spice86.10.0.0.nupkg ${{secrets.NUGET_API_KEY}} -Source 'https://api.nuget.org/v3/index.json' -SkipDuplicate
+      run: dotnet nuget push Spice86.10.0.0.nupkg ${{secrets.NUGET_API_KEY}} -Source 'https://api.nuget.org/v3/index.json' -SkipDuplicate

--- a/tests/Spice86.Tests/Spice86.Tests.csproj
+++ b/tests/Spice86.Tests/Spice86.Tests.csproj
@@ -54,31 +54,31 @@
     </None>
   </ItemGroup>
   <ItemGroup>
-    <EmbeddedResource Include="$(NuGetPackageRoot)singlesteptests.intel8086.00-ff/2025.6.8/content/tests/8086.00-FF.zip">
+    <EmbeddedResource Include="$([MSBuild]::EnsureTrailingSlash($(NuGetPackageRoot)))singlesteptests.intel8086.00-ff/2025.6.8/content/tests/8086.00-FF.zip">
       <Link>8086.00-FF.zip</Link>
       <LogicalName>8086.00-FF.zip</LogicalName>
     </EmbeddedResource>
   </ItemGroup>
   <ItemGroup>
-    <EmbeddedResource Include="$(NuGetPackageRoot)singlesteptests.intel80286.00-3f/2025.10.8/content/tests/80286.00-3F.zip">
+    <EmbeddedResource Include="$([MSBuild]::EnsureTrailingSlash($(NuGetPackageRoot)))singlesteptests.intel80286.00-3f/2025.10.8/content/tests/80286.00-3F.zip">
       <Link>80286.00-3F.zip</Link>
       <LogicalName>80286.00-3F.zip</LogicalName>
     </EmbeddedResource>
   </ItemGroup>
   <ItemGroup>
-    <EmbeddedResource Include="$(NuGetPackageRoot)singlesteptests.intel80286.40-7f/2025.10.8/content/tests/80286.40-7F.zip">
+    <EmbeddedResource Include="$([MSBuild]::EnsureTrailingSlash($(NuGetPackageRoot)))singlesteptests.intel80286.40-7f/2025.10.8/content/tests/80286.40-7F.zip">
       <Link>80286.40-7F.zip</Link>
       <LogicalName>80286.40-7F.zip</LogicalName>
     </EmbeddedResource>
   </ItemGroup>
   <ItemGroup>
-    <EmbeddedResource Include="$(NuGetPackageRoot)singlesteptests.intel80286.80-bf/2025.10.8/content/tests/80286.80-BF.zip">
+    <EmbeddedResource Include="$([MSBuild]::EnsureTrailingSlash($(NuGetPackageRoot)))singlesteptests.intel80286.80-bf/2025.10.8/content/tests/80286.80-BF.zip">
       <Link>80286.80-BF.zip</Link>
       <LogicalName>80286.80-BF.zip</LogicalName>
     </EmbeddedResource>
   </ItemGroup>
   <ItemGroup>
-    <EmbeddedResource Include="$(NuGetPackageRoot)singlesteptests.intel80286.c0-ff/2025.10.8/content/tests/80286.C0-FF.zip">
+    <EmbeddedResource Include="$([MSBuild]::EnsureTrailingSlash($(NuGetPackageRoot)))singlesteptests.intel80286.c0-ff/2025.10.8/content/tests/80286.C0-FF.zip">
       <Link>80286.C0-FF.zip</Link>
       <LogicalName>80286.C0-FF.zip</LogicalName>
     </EmbeddedResource>


### PR DESCRIPTION
If it builds, it works :)