### PR TITLE
fix: typo in CtrControllerRegister

### DIFF
--- a/src/Spice86.Core/Emulator/Devices/Video/Registers/CrtControllerRegisters.cs
+++ b/src/Spice86.Core/Emulator/Devices/Video/Registers/CrtControllerRegisters.cs
@@ -138,7 +138,7 @@ public sealed class CrtControllerRegisters {
     ///     Gets or sets the Text Cursor Location Low register.
     /// </summary>
     public byte TextCursorLocationLow {
-        get => (byte)(_screenStartAddress & 0xFF);
+        get => (byte)(_textCursorLocation & 0xFF);
         set => _textCursorLocation = _textCursorLocation & 0xFF00 | value;
     }
 


### PR DESCRIPTION
### Description of Changes

         ///     Gets or sets the Text Cursor Location Low register.
     /// </summary>
     public byte TextCursorLocationLow {
    -        get => (byte)(_screenStartAddress & 0xFF);
    +        get => (byte)(_textCursorLocation & 0xFF);
         set => _textCursorLocation = _textCursorLocation & 0xFF00 | value;

### Rationale behind Changes

Maybe it will fix up some of the text mode limitations / bugs
