### PR TITLE
improve logging performance

### DIFF
--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -40,6 +40,7 @@
     <PackageVersion Include="Semi.Avalonia.DataGrid" Version="11.3.7" />
     <PackageVersion Include="Semi.Avalonia.TreeDataGrid" Version="11.0.10.4" />
     <PackageVersion Include="Serilog" Version="4.3.0" />
+    <PackageVersion Include="Serilog.Sinks.Async" Version="2.1.0" />
     <PackageVersion Include="Serilog.Sinks.Console" Version="6.0.0" />
     <PackageVersion Include="Serilog.Sinks.Debug" Version="3.0.0" />
     <PackageVersion Include="Serilog.Sinks.File" Version="7.0.0" />

--- a/src/Spice86.Logging/LoggerPropertyBagEnricher.cs
+++ b/src/Spice86.Logging/LoggerPropertyBagEnricher.cs
@@ -1,0 +1,13 @@
+namespace Spice86.Logging;
+
+using Serilog.Core;
+using Serilog.Events;
+
+using Spice86.Shared.Interfaces;
+
+internal sealed class LoggerPropertyBagEnricher(ILoggerPropertyBag propertyBag) : ILogEventEnricher {
+    public void Enrich(LogEvent logEvent, ILogEventPropertyFactory propertyFactory) {
+        logEvent.AddOrUpdateProperty(propertyFactory.CreateProperty("IP", propertyBag.CsIp));
+        logEvent.AddOrUpdateProperty(propertyFactory.CreateProperty("ContextIndex", propertyBag.ContextIndex));
+    }
+}

--- a/src/Spice86.Logging/LoggerService.cs
+++ b/src/Spice86.Logging/LoggerService.cs
@@ -1,4 +1,5 @@
-﻿namespace Spice86.Logging;
+﻿#pragma warning disable CA2254
+namespace Spice86.Logging;
 
 using Serilog;
 using Serilog.Core;
@@ -6,158 +7,454 @@ using Serilog.Events;
 
 using Spice86.Shared.Interfaces;
 
-/// <inheritdoc cref="ILoggerService"/>
+/// <inheritdoc cref="ILoggerService" />
 public class LoggerService : ILoggerService {
-    /// <summary>
-    /// The format for the log message that will be output.
-    /// </summary>
-    private const string LogFormat = "[{Timestamp:yyyy-MM-dd HH:mm:ss.fff zzz}] [{Level:u4}] [{ContextIndex}/{IP:j}] {Message:lj}{NewLine}{Exception}";
+    private const string LogFormat =
+        "[{Timestamp:yyyy-MM-dd HH:mm:ss.fff zzz}] [{Level:u4}] [{ContextIndex}/{IP:j}] {Message:lj}{NewLine}{Exception}";
 
-    /// <inheritdoc/>
-    public LoggingLevelSwitch LogLevelSwitch { get; set; } = new(LogEventLevel.Information);
-
-    /// <inheritdoc/>
-    public bool AreLogsSilenced { get; set; }
-
-    private Serilog.Core.Logger? _logger;
+    private static readonly object?[] EmptyProperties = [];
 
     private readonly LoggerConfiguration _loggerConfiguration;
-
-    /// <inheritdoc/>
-    public ILoggerPropertyBag LoggerPropertyBag { get; }
+    private Logger? _logger;
+    private LoggingLevelSwitch _logLevelSwitch;
 
     /// <summary>
-    /// Initializes a new instance of the <see cref="LoggerService"/> class.
+    ///     Initializes a new instance of the <see cref="LoggerService" /> class.
     /// </summary>
     public LoggerService() {
+        _logLevelSwitch = new LoggingLevelSwitch();
         LoggerPropertyBag = new LoggerPropertyBag();
         _loggerConfiguration = CreateLoggerConfiguration();
-        _loggerConfiguration
-            .MinimumLevel.ControlledBy(LogLevelSwitch);
+        _loggerConfiguration.MinimumLevel.ControlledBy(_logLevelSwitch);
     }
 
-    /// <summary>
-    /// Creates the ILogger at the last possible time, since it can be created only once.
-    /// </summary>
-    /// <returns>The ILogger instance.</returns>
-    private ILogger GetLogger() {
-        _logger ??= _loggerConfiguration.CreateLogger();
-        return AddProperties(_logger);
+    /// <inheritdoc />
+    public LoggingLevelSwitch LogLevelSwitch {
+        get => _logLevelSwitch;
+        set {
+            _logLevelSwitch = value ?? throw new ArgumentNullException(nameof(value));
+            _loggerConfiguration.MinimumLevel.ControlledBy(_logLevelSwitch);
+            ResetLogger();
+        }
     }
 
-    private ILogger AddProperties(Serilog.Core.Logger logger) {
-        return logger.
-            ForContext("IP", LoggerPropertyBag.CsIp, destructureObjects: false).
-            ForContext("ContextIndex", LoggerPropertyBag.ContextIndex, destructureObjects: false);
-    }
+    /// <inheritdoc />
+    public bool AreLogsSilenced { get; set; }
 
-    /// <inheritdoc/>
+    /// <inheritdoc />
+    public ILoggerPropertyBag LoggerPropertyBag { get; }
+
+    /// <inheritdoc />
     public LoggerConfiguration CreateLoggerConfiguration() {
-        return new LoggerConfiguration()
+        LoggerConfiguration configuration = new LoggerConfiguration()
             .Enrich.FromLogContext()
-            .WriteTo.Console(outputTemplate: LogFormat)
-            .WriteTo.Debug(outputTemplate: LogFormat)
-            .WriteTo.File("logs/log-.txt", outputTemplate: LogFormat, rollingInterval: RollingInterval.Day);
+            .Enrich.With(new LoggerPropertyBagEnricher(LoggerPropertyBag))
+            .WriteTo.Async(conf => conf.Console(outputTemplate: LogFormat)
+                .WriteTo.Async(conf2 => conf2.Debug(outputTemplate: LogFormat))
+                .WriteTo.Async(conf3 =>
+                    conf3.File("logs/log-.txt", outputTemplate: LogFormat, rollingInterval: RollingInterval.Day)));
+        return configuration;
     }
 
-    /// <inheritdoc/>
+    /// <inheritdoc />
     public ILoggerService WithLogLevel(LogEventLevel minimumLevel) {
-        var logger = new LoggerService() {LogLevelSwitch = new LoggingLevelSwitch(minimumLevel)};
-        logger._loggerConfiguration.MinimumLevel.ControlledBy(new LoggingLevelSwitch(minimumLevel));
+        var logger = new LoggerService {
+            LogLevelSwitch = {
+                MinimumLevel = minimumLevel
+            }
+        };
         return logger;
     }
 
+    public void Write(LogEventLevel level, string messageTemplate) {
+        GetLoggerForLevel(level)?.Write(level, messageTemplate);
+    }
+
+    public void Write<T>(LogEventLevel level, string messageTemplate, T propertyValue) {
+        GetLoggerForLevel(level)?.Write(level, messageTemplate, propertyValue);
+    }
+
+    public void Write<T0, T1>(LogEventLevel level, string messageTemplate, T0 propertyValue0, T1 propertyValue1) {
+        GetLoggerForLevel(level)?.Write(level, messageTemplate, propertyValue0, propertyValue1);
+    }
+
+    public void Write<T0, T1, T2>(LogEventLevel level, string messageTemplate, T0 propertyValue0, T1 propertyValue1,
+        T2 propertyValue2) {
+        GetLoggerForLevel(level)
+            ?.Write(level, messageTemplate, propertyValue0, propertyValue1, propertyValue2);
+    }
+
+    public void Write(LogEventLevel level, string messageTemplate, params object?[]? propertyValues) {
+        GetLoggerForLevel(level)?.Write(level, messageTemplate, Normalize(propertyValues));
+    }
+
+    public void Write(LogEventLevel level, Exception? exception, string messageTemplate) {
+        GetLoggerForLevel(level)?.Write(level, exception, messageTemplate);
+    }
+
+    public void Write<T>(LogEventLevel level, Exception? exception, string messageTemplate, T propertyValue) {
+        GetLoggerForLevel(level)?.Write(level, exception, messageTemplate, propertyValue);
+    }
+
+    public void Write<T0, T1>(LogEventLevel level, Exception? exception, string messageTemplate, T0 propertyValue0,
+        T1 propertyValue1) {
+        GetLoggerForLevel(level)
+            ?.Write(level, exception, messageTemplate, propertyValue0, propertyValue1);
+    }
+
+    public void Write<T0, T1, T2>(LogEventLevel level, Exception? exception, string messageTemplate, T0 propertyValue0,
+        T1 propertyValue1, T2 propertyValue2) {
+        GetLoggerForLevel(level)
+            ?.Write(level, exception, messageTemplate, propertyValue0, propertyValue1, propertyValue2);
+    }
+
+    public void Write(LogEventLevel level, Exception? exception, string messageTemplate,
+        params object?[]? propertyValues) {
+        GetLoggerForLevel(level)?.Write(level, exception, messageTemplate, Normalize(propertyValues));
+    }
+
+    /// <inheritdoc />
+    public void Write(LogEvent logEvent) {
+        GetLoggerForLevel(logEvent.Level)?.Write(logEvent);
+    }
+
+    /// <inheritdoc />
+    public bool IsEnabled(LogEventLevel level) {
+        return LogLevelSwitch.MinimumLevel <= level;
+    }
+
+    private void ResetLogger() {
+        _logger?.Dispose();
+        _logger = null;
+    }
+
+    private Logger? GetLoggerForLevel(LogEventLevel level) {
+        if (AreLogsSilenced || !IsEnabled(level)) {
+            return null;
+        }
+
+        _logger ??= _loggerConfiguration.CreateLogger();
+        return _logger;
+    }
+
+    private static object?[] Normalize(object?[]? properties) {
+        return properties is { Length: > 0 } ? properties : EmptyProperties;
+    }
+
 #pragma warning disable Serilog004
-
-    /// <inheritdoc/>
-    public void Information(string messageTemplate, params object?[]? properties) {
-        if (AreLogsSilenced) {
-            return;
-        }
-        GetLogger().Information(messageTemplate, properties);
+    public void Verbose(string messageTemplate) {
+        GetLoggerForLevel(LogEventLevel.Information)?.Verbose(messageTemplate);
     }
 
-    /// <inheritdoc/>
-    public void Warning(string message) {
-        if (AreLogsSilenced) {
-            return;
-        }
-        GetLogger().Warning(message);
+    public void Verbose<T>(string messageTemplate, T propertyValue) {
+        GetLoggerForLevel(LogEventLevel.Information)?.Verbose(messageTemplate, propertyValue);
     }
 
-    /// <inheritdoc/>
-    public void Warning(Exception? e, string messageTemplate, params object?[]? properties) {
-        if (AreLogsSilenced) {
-            return;
-        }
-        GetLogger().Warning(e, messageTemplate, properties);
+    public void Verbose<T0, T1>(string messageTemplate, T0 propertyValue0, T1 propertyValue1) {
+        GetLoggerForLevel(LogEventLevel.Information)
+            ?.Verbose(messageTemplate, propertyValue0, propertyValue1);
     }
 
-    /// <inheritdoc/>
-    public void Error(Exception? e, string messageTemplate, params object?[]? properties) {
-        if (AreLogsSilenced) {
-            return;
-        }
-        GetLogger().Error(e, messageTemplate, properties);
+    public void Verbose<T0, T1, T2>(string messageTemplate, T0 propertyValue0, T1 propertyValue1, T2 propertyValue2) {
+        GetLoggerForLevel(LogEventLevel.Information)
+            ?.Verbose(messageTemplate, propertyValue0, propertyValue1, propertyValue2);
     }
 
-    /// <inheritdoc/>
-    public void Fatal(Exception? e, string messageTemplate, params object?[]? properties) {
-        if (AreLogsSilenced) {
-            return;
-        }
-        GetLogger().Fatal(e, messageTemplate, properties);
+    public void Verbose(Exception? exception, string messageTemplate) {
+        GetLoggerForLevel(LogEventLevel.Information)?.Verbose(exception, messageTemplate);
     }
 
-    /// <inheritdoc/>
-    public void Warning(string messageTemplate, params object?[]? properties) {
-        if (AreLogsSilenced) {
-            return;
-        }
-        GetLogger().Warning(messageTemplate, properties);
+    public void Verbose<T>(Exception? exception, string messageTemplate, T propertyValue) {
+        GetLoggerForLevel(LogEventLevel.Information)?.Verbose(exception, messageTemplate, propertyValue);
     }
 
-    /// <inheritdoc/>
-    public void Error(string messageTemplate, params object?[]? properties) {
-        if (AreLogsSilenced) {
-            return;
-        }
-        GetLogger().Error(messageTemplate, properties);
+    public void Verbose<T0, T1>(Exception? exception, string messageTemplate, T0 propertyValue0, T1 propertyValue1) {
+        GetLoggerForLevel(LogEventLevel.Information)
+            ?.Verbose(exception, messageTemplate, propertyValue0, propertyValue1);
     }
 
-    /// <inheritdoc/>
-    public void Fatal(string messageTemplate, params object?[]? properties) {
-        if (AreLogsSilenced) {
-            return;
-        }
-        GetLogger().Fatal(messageTemplate, properties);
+    public void Verbose<T0, T1, T2>(Exception? exception, string messageTemplate, T0 propertyValue0, T1 propertyValue1,
+        T2 propertyValue2) {
+        GetLoggerForLevel(LogEventLevel.Information)
+            ?.Verbose(exception, messageTemplate, propertyValue0, propertyValue1, propertyValue2);
     }
 
-    /// <inheritdoc/>
-    public void Debug(string messageTemplate, params object?[]? properties) {
-        if (AreLogsSilenced) {
-            return;
-        }
-        GetLogger().Debug(messageTemplate, properties);
+    public void Verbose(Exception? exception, string messageTemplate, params object?[]? propertyValues) {
+        GetLoggerForLevel(LogEventLevel.Information)
+            ?.Verbose(exception, messageTemplate, Normalize(propertyValues));
     }
 
-    /// <inheritdoc/>
+    /// <inheritdoc />
     public void Verbose(string messageTemplate, params object?[]? properties) {
-        if (AreLogsSilenced) {
+        GetLoggerForLevel(LogEventLevel.Information)?.Verbose(messageTemplate, Normalize(properties));
+    }
+
+    public void Debug(Exception? exception, string messageTemplate, params object?[]? propertyValues) {
+        GetLoggerForLevel(LogEventLevel.Information)
+            ?.Debug(exception, messageTemplate, Normalize(propertyValues));
+    }
+
+    public void Debug(string messageTemplate) {
+        GetLoggerForLevel(LogEventLevel.Information)?.Debug(messageTemplate);
+    }
+
+    public void Debug<T>(string messageTemplate, T propertyValue) {
+        GetLoggerForLevel(LogEventLevel.Information)?.Debug(messageTemplate, propertyValue);
+    }
+
+    public void Debug<T0, T1>(string messageTemplate, T0 propertyValue0, T1 propertyValue1) {
+        GetLoggerForLevel(LogEventLevel.Information)
+            ?.Debug(messageTemplate, propertyValue0, propertyValue1);
+    }
+
+    public void Debug<T0, T1, T2>(string messageTemplate, T0 propertyValue0, T1 propertyValue1, T2 propertyValue2) {
+        GetLoggerForLevel(LogEventLevel.Information)
+            ?.Debug(messageTemplate, propertyValue0, propertyValue1, propertyValue2);
+    }
+
+    public void Debug(Exception? exception, string messageTemplate) {
+        GetLoggerForLevel(LogEventLevel.Information)?.Debug(exception, messageTemplate);
+    }
+
+    public void Debug<T>(Exception? exception, string messageTemplate, T propertyValue) {
+        GetLoggerForLevel(LogEventLevel.Information)?.Debug(exception, messageTemplate, propertyValue);
+    }
+
+    public void Debug<T0, T1>(Exception? exception, string messageTemplate, T0 propertyValue0, T1 propertyValue1) {
+        GetLoggerForLevel(LogEventLevel.Information)
+            ?.Debug(exception, messageTemplate, propertyValue0, propertyValue1);
+    }
+
+    public void Debug<T0, T1, T2>(Exception? exception, string messageTemplate, T0 propertyValue0, T1 propertyValue1,
+        T2 propertyValue2) {
+        GetLoggerForLevel(LogEventLevel.Information)
+            ?.Debug(exception, messageTemplate, propertyValue0, propertyValue1, propertyValue2);
+    }
+
+    /// <inheritdoc />
+    public void Debug(string messageTemplate, params object?[]? properties) {
+        GetLoggerForLevel(LogEventLevel.Information)?.Debug(messageTemplate, Normalize(properties));
+    }
+
+    public void Information(Exception? exception, string messageTemplate) {
+        GetLoggerForLevel(LogEventLevel.Information)?.Information(exception, messageTemplate);
+    }
+
+    public void Information<T>(Exception? exception, string messageTemplate, T propertyValue) {
+        GetLoggerForLevel(LogEventLevel.Information)?.Information(exception, messageTemplate, propertyValue);
+    }
+
+    public void Information<T0, T1>(Exception? exception, string messageTemplate, T0 propertyValue0,
+        T1 propertyValue1) {
+        GetLoggerForLevel(LogEventLevel.Information)
+            ?.Information(exception, messageTemplate, propertyValue0, propertyValue1);
+    }
+
+    public void Information<T0, T1, T2>(Exception? exception, string messageTemplate, T0 propertyValue0,
+        T1 propertyValue1,
+        T2 propertyValue2) {
+        GetLoggerForLevel(LogEventLevel.Information)
+            ?.Information(exception, messageTemplate, propertyValue0, propertyValue1, propertyValue2);
+    }
+
+    public void Information(Exception? exception, string messageTemplate, params object?[]? propertyValues) {
+        GetLoggerForLevel(LogEventLevel.Information)
+            ?.Information(exception, messageTemplate, Normalize(propertyValues));
+    }
+
+    public void Information(string messageTemplate) {
+        GetLoggerForLevel(LogEventLevel.Information)?.Information(messageTemplate);
+    }
+
+    public void Information<T>(string messageTemplate, T propertyValue) {
+        GetLoggerForLevel(LogEventLevel.Information)?.Information(messageTemplate, propertyValue);
+    }
+
+    public void Information<T0, T1>(string messageTemplate, T0 propertyValue0, T1 propertyValue1) {
+        GetLoggerForLevel(LogEventLevel.Information)?.Information(messageTemplate, propertyValue0, propertyValue1);
+    }
+
+    public void Information<T0, T1, T2>(string messageTemplate, T0 propertyValue0, T1 propertyValue1,
+        T2 propertyValue2) {
+        GetLoggerForLevel(LogEventLevel.Information)
+            ?.Information(messageTemplate, propertyValue0, propertyValue1, propertyValue2);
+    }
+
+    /// <inheritdoc />
+    public void Information(string messageTemplate, params object?[]? properties) {
+        GetLoggerForLevel(LogEventLevel.Information)?.Information(messageTemplate, Normalize(properties));
+    }
+
+    public void Warning<T>(string messageTemplate, T propertyValue) {
+        GetLoggerForLevel(LogEventLevel.Information)?.Warning(messageTemplate, propertyValue);
+    }
+
+    public void Warning<T0, T1>(string messageTemplate, T0 propertyValue0, T1 propertyValue1) {
+        GetLoggerForLevel(LogEventLevel.Information)
+            ?.Warning(messageTemplate, propertyValue0, propertyValue1);
+    }
+
+    public void Warning<T0, T1, T2>(string messageTemplate, T0 propertyValue0, T1 propertyValue1, T2 propertyValue2) {
+        GetLoggerForLevel(LogEventLevel.Information)
+            ?.Warning(messageTemplate, propertyValue0, propertyValue1, propertyValue2);
+    }
+
+    public void Warning(Exception? exception, string messageTemplate) {
+        GetLoggerForLevel(LogEventLevel.Information)?.Warning(exception, messageTemplate);
+    }
+
+    public void Warning<T>(Exception? exception, string messageTemplate, T propertyValue) {
+        GetLoggerForLevel(LogEventLevel.Information)?.Warning(exception, messageTemplate, propertyValue);
+    }
+
+    public void Warning<T0, T1>(Exception? exception, string messageTemplate, T0 propertyValue0, T1 propertyValue1) {
+        GetLoggerForLevel(LogEventLevel.Information)
+            ?.Warning(exception, messageTemplate, propertyValue0, propertyValue1);
+    }
+
+    public void Warning<T0, T1, T2>(Exception? exception, string messageTemplate, T0 propertyValue0, T1 propertyValue1,
+        T2 propertyValue2) {
+        GetLoggerForLevel(LogEventLevel.Information)
+            ?.Warning(exception, messageTemplate, propertyValue0, propertyValue1, propertyValue2);
+    }
+
+    /// <inheritdoc />
+    public void Warning(string message) {
+        GetLoggerForLevel(LogEventLevel.Information)?.Warning(message);
+    }
+
+    /// <inheritdoc />
+    public void Warning(Exception? e, string messageTemplate, params object?[]? properties) {
+        ILogger? logger = GetLoggerForLevel(LogEventLevel.Warning);
+        if (logger is null) {
             return;
         }
-        GetLogger().Verbose(messageTemplate, properties);
+
+        object?[] propertyValues = Normalize(properties);
+        if (e is null) {
+            logger.Warning(messageTemplate, propertyValues);
+        } else {
+            logger.Warning(e, messageTemplate, propertyValues);
+        }
+    }
+
+    public void Error(string messageTemplate) {
+        GetLoggerForLevel(LogEventLevel.Information)?.Error(messageTemplate);
+    }
+
+    public void Error<T>(string messageTemplate, T propertyValue) {
+        GetLoggerForLevel(LogEventLevel.Information)?.Error(messageTemplate, propertyValue);
+    }
+
+    public void Error<T0, T1>(string messageTemplate, T0 propertyValue0, T1 propertyValue1) {
+        GetLoggerForLevel(LogEventLevel.Information)
+            ?.Error(messageTemplate, propertyValue0, propertyValue1);
+    }
+
+    public void Error<T0, T1, T2>(string messageTemplate, T0 propertyValue0, T1 propertyValue1, T2 propertyValue2) {
+        GetLoggerForLevel(LogEventLevel.Information)
+            ?.Error(messageTemplate, propertyValue0, propertyValue1, propertyValue2);
+    }
+
+    public void Error(Exception? exception, string messageTemplate) {
+        GetLoggerForLevel(LogEventLevel.Information)?.Error(exception, messageTemplate);
+    }
+
+    public void Error<T>(Exception? exception, string messageTemplate, T propertyValue) {
+        GetLoggerForLevel(LogEventLevel.Information)?.Error(exception, messageTemplate, propertyValue);
+    }
+
+    public void Error<T0, T1>(Exception? exception, string messageTemplate, T0 propertyValue0, T1 propertyValue1) {
+        GetLoggerForLevel(LogEventLevel.Information)
+            ?.Error(exception, messageTemplate, propertyValue0, propertyValue1);
+    }
+
+    public void Error<T0, T1, T2>(Exception? exception, string messageTemplate, T0 propertyValue0, T1 propertyValue1,
+        T2 propertyValue2) {
+        GetLoggerForLevel(LogEventLevel.Information)
+            ?.Error(exception, messageTemplate, propertyValue0, propertyValue1, propertyValue2);
+    }
+
+    /// <inheritdoc />
+    public void Error(Exception? e, string messageTemplate, params object?[]? properties) {
+        ILogger? logger = GetLoggerForLevel(LogEventLevel.Error);
+        if (logger is null) {
+            return;
+        }
+
+        object?[] propertyValues = Normalize(properties);
+        if (e is null) {
+            logger.Error(messageTemplate, propertyValues);
+        } else {
+            logger.Error(e, messageTemplate, propertyValues);
+        }
+    }
+
+    public void Fatal(string messageTemplate) {
+        GetLoggerForLevel(LogEventLevel.Information)?.Fatal(messageTemplate);
+    }
+
+    public void Fatal<T>(string messageTemplate, T propertyValue) {
+        GetLoggerForLevel(LogEventLevel.Information)?.Fatal(messageTemplate, propertyValue);
+    }
+
+    public void Fatal<T0, T1>(string messageTemplate, T0 propertyValue0, T1 propertyValue1) {
+        GetLoggerForLevel(LogEventLevel.Information)
+            ?.Fatal(messageTemplate, propertyValue0, propertyValue1);
+    }
+
+    public void Fatal<T0, T1, T2>(string messageTemplate, T0 propertyValue0, T1 propertyValue1, T2 propertyValue2) {
+        GetLoggerForLevel(LogEventLevel.Information)
+            ?.Fatal(messageTemplate, propertyValue0, propertyValue1, propertyValue2);
+    }
+
+    public void Fatal(Exception? exception, string messageTemplate) {
+        GetLoggerForLevel(LogEventLevel.Information)?.Fatal(exception, messageTemplate);
+    }
+
+    public void Fatal<T>(Exception? exception, string messageTemplate, T propertyValue) {
+        GetLoggerForLevel(LogEventLevel.Information)?.Fatal(exception, messageTemplate, propertyValue);
+    }
+
+    public void Fatal<T0, T1>(Exception? exception, string messageTemplate, T0 propertyValue0, T1 propertyValue1) {
+        GetLoggerForLevel(LogEventLevel.Information)
+            ?.Fatal(exception, messageTemplate, propertyValue0, propertyValue1);
+    }
+
+    public void Fatal<T0, T1, T2>(Exception? exception, string messageTemplate, T0 propertyValue0, T1 propertyValue1,
+        T2 propertyValue2) {
+        GetLoggerForLevel(LogEventLevel.Information)
+            ?.Fatal(exception, messageTemplate, propertyValue0, propertyValue1, propertyValue2);
+    }
+
+    /// <inheritdoc />
+    public void Fatal(Exception? e, string messageTemplate, params object?[]? properties) {
+        ILogger? logger = GetLoggerForLevel(LogEventLevel.Fatal);
+        if (logger is null) {
+            return;
+        }
+
+        object?[] propertyValues = Normalize(properties);
+        if (e is null) {
+            logger.Fatal(messageTemplate, propertyValues);
+        } else {
+            logger.Fatal(e, messageTemplate, propertyValues);
+        }
+    }
+
+    /// <inheritdoc />
+    public void Warning(string messageTemplate, params object?[]? properties) {
+        GetLoggerForLevel(LogEventLevel.Information)?.Warning(messageTemplate, Normalize(properties));
+    }
+
+    /// <inheritdoc />
+    public void Error(string messageTemplate, params object?[]? properties) {
+        GetLoggerForLevel(LogEventLevel.Information)?.Error(messageTemplate, Normalize(properties));
+    }
+
+    /// <inheritdoc />
+    public void Fatal(string messageTemplate, params object?[]? properties) {
+        GetLoggerForLevel(LogEventLevel.Information)?.Fatal(messageTemplate, Normalize(properties));
     }
 #pragma warning restore Serilog004
-
-    /// <inheritdoc/>
-    public void Write(LogEvent logEvent) {
-        GetLogger().Write(logEvent);
-    }
-
-    /// <inheritdoc/>
-    public bool IsEnabled(LogEventLevel level) {
-        _logger ??= _loggerConfiguration.CreateLogger();
-        return _logger.IsEnabled(level);
-    }
 }

--- a/src/Spice86.Logging/Spice86.Logging.csproj
+++ b/src/Spice86.Logging/Spice86.Logging.csproj
@@ -8,6 +8,7 @@
     </PropertyGroup>
     <ItemGroup>
         <PackageReference Include="Serilog"/>
+        <PackageReference Include="Serilog.Sinks.Async" />
         <PackageReference Include="Serilog.Sinks.Console"/>
         <PackageReference Include="Serilog.Sinks.Debug"/>
         <PackageReference Include="Serilog.Sinks.File"/>


### PR DESCRIPTION
### Description of Changes
LoggerService now has overloads for up to three message parameters, which makes it obsolete to check for IsEnabled every time. Logging calls where a param is evaluated at runtime still have to be guarded though. The same is true for log calls > 3 parameters.

Also introduces async logging.

### Rationale behind Changes
The codebase is cluttered with IsEnabled guards. This PR addresses this issue. Moreover it also improves the general logging performance by efficiently using a PropertyBagEnricher. Here are some benchmarks:

```
Master
| Method                       | Mean     | Error   | StdDev  | Ratio | Gen0   | Allocated | Alloc Ratio |
|----------------------------- |---------:|--------:|--------:|------:|-------:|----------:|------------:|
| LogInformationBaseline       | 158.5 ns | 1.47 ns | 1.37 ns |  1.00 | 0.0215 |     360 B |        1.00 |
| LogInformationWithScalar     | 161.9 ns | 0.68 ns | 0.53 ns |  1.02 | 0.0234 |     392 B |        1.09 |
| LogInformationWithScalar2    | 159.0 ns | 0.49 ns | 0.46 ns |  1.00 | 0.0234 |     392 B |        1.09 |
| LogInformationWithCond       | 161.1 ns | 0.45 ns | 0.40 ns |  1.02 | 0.0234 |     392 B |        1.09 |
| LogInformationWithManyParams | 174.5 ns | 0.52 ns | 0.49 ns |  1.10 | 0.0305 |     512 B |        1.42 |


Optimized
| Method                       | Mean       | Error     | StdDev    | Ratio | RatioSD | Gen0   | Allocated | Alloc Ratio |
|----------------------------- |-----------:|----------:|----------:|------:|--------:|-------:|----------:|------------:|
| LogInformationBaseline       |  0.7006 ns | 0.0019 ns | 0.0016 ns |  1.00 |    0.00 |      - |         - |          NA |
| LogInformationWithScalar     |  0.5727 ns | 0.0084 ns | 0.0075 ns |  0.82 |    0.01 |      - |         - |          NA |
| LogInformationWithScalar2    |  0.3192 ns | 0.0040 ns | 0.0037 ns |  0.46 |    0.01 |      - |         - |          NA |
| LogInformationWithCond       |  0.6814 ns | 0.0049 ns | 0.0044 ns |  0.97 |    0.01 |      - |         - |          NA |
| LogInformationWithManyParams | 15.3133 ns | 0.1156 ns | 0.0965 ns | 21.86 |    0.14 | 0.0091 |     152 B |          NA |
```

The benchmark:

```
    [Benchmark(Baseline = true)]
    public void LogInformationBaseline() {
        _loggerService.Information(_baselineMessage);
    }

    [Benchmark]
    public void LogInformationWithScalar() {
        _loggerService.Information(_scalarMessage, _a1);
    }

    [Benchmark]
    public void LogInformationWithScalar2() {
        _loggerService.Information("This is a log {msg}", "message");
    }

    [Benchmark]
    public void LogInformationWithCond() {
        _loggerService.Information(_scalarMessage, _a4 > _a3 ? "this is a string" : "this is another string");
    }

    [Benchmark]
    public void LogInformationWithManyParams() {
        _loggerService.Information(_structuredMessage, _a2, _a3, _a4, _a5);
    }
```

### Suggested Testing Steps
<!-- If applicable, including examples you've already tested with / recommendations for how to test further is very helpful! -->
