### PR TITLE
Fix breakpoint double reload from file and memory selection copy to clipboard

### DIFF
--- a/src/Spice86/Spice86DependencyInjection.cs
+++ b/src/Spice86/Spice86DependencyInjection.cs
@@ -319,7 +319,6 @@ public class Spice86DependencyInjection : IDisposable {
 
         SerializableUserBreakpointCollection deserializedUserBreakpoints =
               emulatorStateSerializer.LoadBreakpoints(configuration.RecordedDataDirectory);
-        emulatorBreakpointsManager.RestoreBreakpoints(deserializedUserBreakpoints);
       
         IInstructionExecutor cpuForEmulationLoop = configuration.CfgCpu ? cfgCpu : cpu;
 

--- a/src/Spice86/ViewModels/MemoryViewModel.cs
+++ b/src/Spice86/ViewModels/MemoryViewModel.cs
@@ -287,9 +287,9 @@ public partial class MemoryViewModel : ViewModelWithErrorDialog {
     public async Task CopySelection() {
         if (SelectionRange is not null &&
             TryParseAddressString(StartAddress, _state, out uint? address)) {
-            byte[] memoryBytes = _memory.ReadRam(
-                (uint)(address.Value + SelectionRange.Value.Start.ByteIndex),
-                (uint)SelectionRange.Value.ByteLength);
+            ulong startAddress = address.Value + SelectionRange.Value.Start.ByteIndex;
+            ulong length = SelectionRange.Value.ByteLength;
+            byte[] memoryBytes = _memory.ReadRam((uint)length,(uint)startAddress);
             string hexRepresentation = ConvertUtils.ByteArrayToHexString(memoryBytes);
             await _textClipboard.SetTextAsync($"{hexRepresentation}");
         }


### PR DESCRIPTION
Before, any breakpoint saved to file was loaded twice when emulator started.

Also, copying hex from memory view was not copying at all the correct data