### PR TITLE
Centralize address and hex parsing in a class to get the same behaviour everywhere

### DIFF
--- a/src/Spice86/ViewModels/AddressAndValueParser.cs
+++ b/src/Spice86/ViewModels/AddressAndValueParser.cs
@@ -1,0 +1,154 @@
+namespace Spice86.ViewModels;
+
+using Spice86.Core.Emulator.CPU;
+using Spice86.Shared.Emulator.Memory;
+using Spice86.Shared.Utils;
+
+using System.Diagnostics.CodeAnalysis;
+using System.Globalization;
+using System.Reflection;
+using System.Text.RegularExpressions;
+
+public partial class AddressAndValueParser {
+    
+    [GeneratedRegex(@"^0x[0-9A-Fa-f]+$")]
+    public static partial Regex HexUintRegex();
+    
+    /// <summary>
+    /// A000:0000 is valid
+    /// DS:SI is valid
+    /// </summary>
+    /// <returns></returns>
+    [GeneratedRegex(@"^([0-9A-Fa-f]{1,4}|[a-zA-Z]{2}):([0-9A-Fa-f]{1,4}|[a-zA-Z]{2})$")]
+    public static partial Regex SegmentedAddressRegex();
+
+    /// <summary>
+    /// Tries to parse the address string into a uint address.
+    /// </summary>
+    /// <param name="value">The user input.</param>
+    /// <param name="state">The emulated CPU registers and flags.</param>
+    /// <param name="address">The parsed address. <c>null</c> if we return <c>false</c></param>
+    /// <returns>A boolean value indicating success or error, along with the address out variable.</returns>
+    public static bool TryParseAddressString(string? value, State state, [NotNullWhen(true)] out uint? address) {
+        if (string.IsNullOrWhiteSpace(value)) {
+            address = null;
+            return false;
+        }
+
+        string valueTrimmed = value.Trim();
+        address = ParseSegmentedAddress(valueTrimmed, state)?.Linear;
+        if (address != null) {
+            return true;
+        }
+        
+        address = ParseHex(valueTrimmed);
+        return address != null;
+    }
+
+    public static SegmentedAddress? ParseSegmentedAddress(string value, State? state) {
+        string trimmedValue = value.Trim();
+        Match segmentedMatch = SegmentedAddressRegex()
+            .Match(trimmedValue);
+        if (segmentedMatch.Success) {
+            ushort? segment = TryParseSegmentOrRegister(
+                segmentedMatch.Groups[1].Value,
+                state);
+            ushort? offset = TryParseSegmentOrRegister(
+                segmentedMatch.Groups[2].Value,
+                state);
+            if (segment != null && offset != null) {
+                return new(segment.Value, offset.Value);
+            }
+        }
+
+        return null;
+    }
+    
+    public static ushort? TryParseSegmentOrRegister(string value, State? state) {
+        // Try a property of the CPU state first (there is no collision with hex values)
+        ushort? res = GetUshortStateProperty(value, state);
+        if (res != null) {
+            return res;
+        }
+        // Try to parse hex value
+        if (ushort.TryParse(value, NumberStyles.HexNumber,
+                CultureInfo.InvariantCulture, out ushort result)) {
+            return result;
+        }
+
+        return null;
+    }
+    
+    public static ushort? GetUshortStateProperty(string value, State? state) {
+        if (state is null) {
+            return null;
+        }
+        PropertyInfo? property = state.GetType().GetProperty(value.ToUpperInvariant());
+        if (property != null &&
+            property.PropertyType == typeof(ushort) &&
+            property.GetValue(state) is ushort propertyValue) {
+            return propertyValue;
+        }
+
+        return null;
+    }
+
+    public static bool IsValidHex(string value) {
+       return HexUintRegex().Match(value).Success;
+    }
+
+    public static uint? ParseHex(string value) {
+        if (!IsValidHex(value)) {
+            return null;
+        }
+
+        string hexValue = value;
+        if (hexValue.StartsWith("0x") && hexValue.Length is > 2 and <= 10) {
+            hexValue = hexValue[2..];
+        }
+        if (uint.TryParse(hexValue, NumberStyles.HexNumber,
+                CultureInfo.InvariantCulture, out uint res)) {
+            return res;
+        }
+
+        return null;
+    }
+    
+    public static byte[]? ParseHexAsArray(string? value) {
+        if (value == null) {
+            return null;
+        }
+        string valueTrimmed = value.Trim();
+        if (!IsValidHex(valueTrimmed)) {
+            return null;
+        }
+        
+        if (valueTrimmed.StartsWith("0x")) {
+            valueTrimmed = valueTrimmed[2..];
+        }
+
+        return ConvertUtils.HexToByteArray(valueTrimmed);
+    }
+    
+    
+    public static bool TryValidateAddress(string? value, State state, out string message) {
+        if (string.IsNullOrWhiteSpace(value)) {
+            message = "Address is required";
+            return false;
+        }
+        if (!IsValidHex(value) &&
+            !SegmentedAddressRegex().IsMatch(value) && 
+            GetUshortStateProperty(value, state) == null) {
+            message = "Invalid address format";
+            return false;
+        }
+
+        if (!TryParseAddressString(value, state, out uint? _)) {
+            message = "Invalid address";
+            return false;
+        }
+
+        message = string.Empty;
+        return true;
+    }
+}

--- a/src/Spice86/ViewModels/BreakpointsViewModel.cs
+++ b/src/Spice86/ViewModels/BreakpointsViewModel.cs
@@ -224,7 +224,7 @@ public partial class BreakpointsViewModel : ViewModelBase {
     [RelayCommand(CanExecute = nameof(ConfirmBreakpointCreationCanExecute))]
     private void ConfirmBreakpointCreation() {
         if (IsExecutionBreakpointSelected) {
-            if (!TryParseAddressString(ExecutionAddressValue, _state, out uint? executionAddress)) {
+            if (!AddressAndValueParser.TryParseAddressString(ExecutionAddressValue, _state, out uint? executionAddress)) {
                 return;
             }
             BreakpointViewModel executionVm = AddAddressBreakpoint(
@@ -237,11 +237,11 @@ public partial class BreakpointsViewModel : ViewModelBase {
                 }, null, ExecutionBreakpoint);
             BreakpointCreated?.Invoke(executionVm);
         } else if (IsMemoryBreakpointSelected) {
-            if (TryParseAddressString(MemoryBreakpointStartAddress, _state, out uint? memorystartAddress) &&
-                TryParseAddressString(MemoryBreakpointEndAddress, _state, out uint? memoryEndAddress)) {
+            if (AddressAndValueParser.TryParseAddressString(MemoryBreakpointStartAddress, _state, out uint? memorystartAddress) &&
+                AddressAndValueParser.TryParseAddressString(MemoryBreakpointEndAddress, _state, out uint? memoryEndAddress)) {
                 CreateMemoryBreakpointAtAddress(memorystartAddress.Value,
                     memoryEndAddress.Value, null);
-            } else if (TryParseAddressString(MemoryBreakpointStartAddress, _state,
+            } else if (AddressAndValueParser.TryParseAddressString(MemoryBreakpointStartAddress, _state,
                 out uint? memoryStartAddressAlone)) {
                 CreateMemoryBreakpointAtAddress(
                     memoryStartAddressAlone.Value,
@@ -262,7 +262,7 @@ public partial class BreakpointsViewModel : ViewModelBase {
                 }, null, "Cycles breakpoint");
             BreakpointCreated?.Invoke(cyclesVm);
         } else if (IsInterruptBreakpointSelected) {
-            if (!TryParseAddressString(InterruptNumber, _state, out uint? interruptNumber)) {
+            if (!AddressAndValueParser.TryParseAddressString(InterruptNumber, _state, out uint? interruptNumber)) {
                 return;
             }
             BreakpointViewModel interruptVm = AddAddressBreakpoint(
@@ -274,7 +274,7 @@ public partial class BreakpointsViewModel : ViewModelBase {
                 }, null, "Interrupt breakpoint");
             BreakpointCreated?.Invoke(interruptVm);
         } else if (IsIoPortBreakpointSelected) {
-            if (!TryParseAddressString(IoPortNumber, _state, out uint? ioPortNumber)) {
+            if (!AddressAndValueParser.TryParseAddressString(IoPortNumber, _state, out uint? ioPortNumber)) {
                 return;
             }
             BreakpointViewModel ioPortVm = AddAddressBreakpoint(

--- a/src/Spice86/ViewModels/StructureViewModel.cs
+++ b/src/Spice86/ViewModels/StructureViewModel.cs
@@ -142,7 +142,7 @@ public partial class StructureViewModel : ViewModelBase, IDisposable {
     partial void OnSelectedStructureChanged(StructType? value) {
         if (value is null) {
             StructureMemory = _originalMemory;
-            if (TryParseAddressString(MemoryAddress, _state, out uint? address)) {
+            if (AddressAndValueParser.TryParseAddressString(MemoryAddress, _state, out uint? address)) {
                 RequestScrollToAddress?.Invoke(this, new AddressChangedMessage(address.Value));
             }
         }
@@ -150,7 +150,7 @@ public partial class StructureViewModel : ViewModelBase, IDisposable {
     }
 
     private void OnMemoryAddressChanged(string? value) {
-        if (TryParseAddressString(value, _state, out uint? address)) {
+        if (AddressAndValueParser.TryParseAddressString(value, _state, out uint? address)) {
             RequestScrollToAddress?.Invoke(this, new AddressChangedMessage(address.Value));
         }
         Update();
@@ -175,7 +175,7 @@ public partial class StructureViewModel : ViewModelBase, IDisposable {
         }
 
         // Calculate the offset into the viewed memory.
-        uint offset = IsAddressableMemory && TryParseAddressString(MemoryAddress, _state,
+        uint offset = IsAddressableMemory && AddressAndValueParser.TryParseAddressString(MemoryAddress, _state,
             out uint? address)
             ? address.Value
             : 0;

--- a/src/Spice86/Views/Converters/SegmentedAddressConverter.cs
+++ b/src/Spice86/Views/Converters/SegmentedAddressConverter.cs
@@ -6,12 +6,13 @@ using Avalonia.Data.Converters;
 
 using Spice86.Core.Emulator.CPU;
 using Spice86.Shared.Emulator.Memory;
+using Spice86.ViewModels;
 
 using System.Globalization;
 using System.Reflection;
 using System.Text.RegularExpressions;
 
-public partial class SegmentedAddressConverter : AvaloniaObject, IValueConverter {
+public class SegmentedAddressConverter : AvaloniaObject, IValueConverter {
     public static readonly StyledProperty<State?> StateProperty = AvaloniaProperty.Register<SegmentedAddressConverter, State?>(nameof(State));
 
     public State? State {
@@ -32,13 +33,10 @@ public partial class SegmentedAddressConverter : AvaloniaObject, IValueConverter
             return new SegmentedAddress();
         }
 
-        Match match = SegmentedAddressRegex().Match(inputString);
-        if (match.Success) {
-            ushort? segment = ParseSegmentOrRegister(match.Groups[1].Value, State);
-            ushort? offset = ParseSegmentOrRegister(match.Groups[2].Value, State);
-            if (segment.HasValue && offset.HasValue) {
-                return new SegmentedAddress(segment.Value, offset.Value);
-            }
+        SegmentedAddress? result = AddressAndValueParser.ParseSegmentedAddress(inputString, State);
+
+        if (result != null) {
+            return result;
         }
 
         return new BindingNotification(new InvalidCastException(value.ToString()), BindingErrorType.Error);
@@ -59,7 +57,4 @@ public partial class SegmentedAddressConverter : AvaloniaObject, IValueConverter
 
         return null;
     }
-
-    [GeneratedRegex(@"^([0-9A-Fa-f]{4}|[a-zA-Z]{2}):([0-9A-Fa-f]{4}|[a-zA-Z]{2})$")]
-    private static partial Regex SegmentedAddressRegex();
 }


### PR DESCRIPTION
Makes disassembly view parse the addresses as the other do, accepting segmented addresses like 1:1, ending with spaces, ...