### PR TITLE
fix: don't show cycles UI when using NullCyclesLimiter

### DIFF
--- a/src/Spice86/ViewModels/MainWindowViewModel.cs
+++ b/src/Spice86/ViewModels/MainWindowViewModel.cs
@@ -52,6 +52,9 @@ public sealed partial class MainWindowViewModel : ViewModelWithErrorDialog, IGui
         }
     }
 
+    [ObservableProperty]
+    private bool _showCyclesLimitingUI;
+
     [RelayCommand]
     private void IncreaseTargetCycles() {
         _cyclesLimiter.IncreaseCycles();
@@ -106,6 +109,7 @@ public sealed partial class MainWindowViewModel : ViewModelWithErrorDialog, IGui
         _pauseHandler.Resumed += OnResumed;
         TimeMultiplier = Configuration.TimeMultiplier;
         _targetCyclesPerMs = _cyclesLimiter.TargetCpuCyclesPerMs;
+        ShowCyclesLimitingUI = _cyclesLimiter.TargetCpuCyclesPerMs is not 0;
         DispatcherTimerStarter.StartNewDispatcherTimer(TimeSpan.FromSeconds(1.0 / 30.0),
             DispatcherPriority.Background,
             (_, _) => RefreshMainTitleWithInstructionsPerMs());

--- a/src/Spice86/Views/MainWindow.axaml
+++ b/src/Spice86/Views/MainWindow.axaml
@@ -95,10 +95,10 @@
 			</MenuItem>
 		</Menu>
 		<StackPanel IsEnabled="{Binding IsEmulatorRunning}" Grid.Row="0" Margin="160,0,0,0" HorizontalAlignment="Left" VerticalAlignment="Top" Orientation="Horizontal">
-			<Label Focusable="False" VerticalAlignment="Center" Content="Cycles/ms:" />
-			<Button Margin="10,0,5,0" HotKey="Ctrl+F11" Focusable="False" IsEnabled="{Binding !IsPaused}" Command="{Binding DecreaseTargetCyclesCommand}" Content="-" />
-			<NumericUpDown Focusable="False" FormatString="0" IsReadOnly="True" IsEnabled="{Binding !IsPaused}" Text="{Binding TargetCyclesPerMs, FallbackValue=1}" Minimum="100" Maximum="60000" />
-			<Button Margin="5,0,10,0" HotKey="Ctrl+F12" Focusable="False" IsEnabled="{Binding !IsPaused}" Command="{Binding IncreaseTargetCyclesCommand}" Content="+" />
+			<Label IsVisible="{Binding ShowCyclesLimitingUI}" Focusable="False" VerticalAlignment="Center" Content="Cycles/ms:" />
+			<Button IsVisible="{Binding ShowCyclesLimitingUI}" Margin="10,0,5,0" HotKey="Ctrl+F11" Focusable="False" IsEnabled="{Binding !IsPaused}" Command="{Binding DecreaseTargetCyclesCommand}" Content="-" />
+			<NumericUpDown IsVisible="{Binding ShowCyclesLimitingUI}" Focusable="False" FormatString="0" IsReadOnly="True" IsEnabled="{Binding !IsPaused}" Text="{Binding TargetCyclesPerMs, FallbackValue=1}" Minimum="100" Maximum="60000" />
+			<Button IsVisible="{Binding ShowCyclesLimitingUI}" Margin="5,0,10,0" HotKey="Ctrl+F12" Focusable="False" IsEnabled="{Binding !IsPaused}" Command="{Binding IncreaseTargetCyclesCommand}" Content="+" />
 			<Button Focusable="False" Command="{Binding PauseCommand}" Margin="5,0,5,0" ToolTip.Tip="Pause (Ctrl+Shift+F5)" HotKey="Ctrl+Shift+F5" IsVisible="{Binding !IsPaused}">
 				<fluent:SymbolIcon Symbol="Pause" />
 			</Button>


### PR DESCRIPTION
This small PR doesn't show the cycles limiting UI if we are in the default config, where cycles limiting is not possible anyway.