### PR TITLE
refactor: centralize identical dispatcher timers (performance)

### DIFF
--- a/src/Spice86/ViewModels/Services/DispatcherTimerStarter.cs
+++ b/src/Spice86/ViewModels/Services/DispatcherTimerStarter.cs
@@ -2,16 +2,32 @@ namespace Spice86.ViewModels.Services;
 
 using Avalonia.Threading;
 
+/// <summary>
+/// Centralizes UI callbacks to go read the emulator state. Typically done on pause.
+/// </summary>
 internal static class DispatcherTimerStarter {
+    private static readonly Dictionary<(TimeSpan Interval, DispatcherPriority Priority), DispatcherTimer> _timers = new();
+    private static readonly Dictionary<(TimeSpan Interval, DispatcherPriority Priority), EventHandler> _callbacks = new();
+
     /// <summary>
-    /// Starts a new <see cref="DispatcherTimer"/> with the specified <paramref name="interval"/>, <paramref name="priority"/> and <paramref name="callback"/>.
+    /// Registers a callback to be executed at a specified interval and priority.
+    /// If a timer with the same interval and priority already exists, the callback is added to the existing timer's event handler.
+    /// Otherwise, a new timer is created.
     /// </summary>
-    /// <param name="interval">The time between executions of the callback</param>
-    /// <param name="priority">The priority of execution for the UI Dispatcher</param>
-    /// <param name="callback">The user code to execute</param>
+    /// <param name="interval">The time between executions of the callback.</param>
+    /// <param name="priority">The priority of execution for the UI Dispatcher.</param>
+    /// <param name="callback">The user code to execute.</param>
     public static DispatcherTimer StartNewDispatcherTimer(TimeSpan interval, DispatcherPriority priority, EventHandler callback) {
-        var dispatcherTimer = new DispatcherTimer(interval, priority, callback);
-        dispatcherTimer.Start();
-        return dispatcherTimer;
+        (TimeSpan interval, DispatcherPriority priority) key = (interval, priority);
+        if (_timers.TryGetValue(key, out DispatcherTimer? timer)) {
+            _callbacks[key] += callback;
+            return timer;
+        } else {
+            _callbacks[key] = callback;
+            var newTimer = new DispatcherTimer(interval, priority, (sender, e) => _callbacks[key]?.Invoke(sender, e));
+            _timers[key] = newTimer;
+            newTimer.Start();
+            return newTimer;
+        }
     }
 }


### PR DESCRIPTION
### Description of Changes

This PR reduces the number of UI dispatcher timers used by ViewModel, when they have the same priority and time span.

So performance is improved. Even if slightly.

### Rationale behind Changes

Eventually, I want to have way more things displayed in the debugger, so it's nice to share the same dispatcher timer if possible.

### Suggested Testing Steps

Already tested with Dune, but feedback is welcome.