### PR TITLE
Respect the VGA Vertical Sync End register's Write Protect bit

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,6 +187,7 @@ Also, while in Seer, set Settings/Configuration/Assembly/Disassembly Mode to
 |  | HMA is implemented |
 |  | No paging support |
 | **Graphics** | Text modes, VGA, EGA, and CGA implemented |
+|  | EGA and CGA modes are best effort (you may find bugs) |
 |  | No VESA support |
 | **DOS** | Partial int 21h implementation (DOS 5.0) |
 | **Input** | Keyboard and mouse supported |

--- a/src/Spice86.Core/Emulator/Devices/Video/Registers/CrtController/OverflowRegister.cs
+++ b/src/Spice86.Core/Emulator/Devices/Video/Registers/CrtController/OverflowRegister.cs
@@ -1,7 +1,8 @@
 namespace Spice86.Core.Emulator.Devices.Video.Registers.CrtController;
 
 /// <summary>
-/// Represents the 8 bit Overflow register.
+/// Represents the 8 bit Overflow register, which is used to store additional bits that wouldn't fit
+/// into other CRT Controller registers.
 /// </summary>
 public class OverflowRegister : Register8 {
     public int VerticalTotal89 => (GetBit(0) ? 1 << 8 : 0) | (GetBit(5) ? 1 << 9 : 0);

--- a/src/Spice86.Core/Emulator/Devices/Video/Registers/CrtControllerRegisters.cs
+++ b/src/Spice86.Core/Emulator/Devices/Video/Registers/CrtControllerRegisters.cs
@@ -266,35 +266,51 @@ public sealed class CrtControllerRegisters {
     public void WriteRegister(CrtControllerRegister register, byte value) {
         switch (register) {
             case CrtControllerRegister.HorizontalTotal:
-                HorizontalTotal = value;
+                if (!VerticalSyncEndRegister.WriteProtect) {
+                    HorizontalTotal = value;
+                }
                 break;
 
             case CrtControllerRegister.HorizontalDisplayEnd:
-                HorizontalDisplayEnd = value;
+                if (!VerticalSyncEndRegister.WriteProtect) {
+                    HorizontalDisplayEnd = value;
+                }
                 break;
 
             case CrtControllerRegister.HorizontalBlankingStart:
-                HorizontalBlankingStart = value;
+                if (!VerticalSyncEndRegister.WriteProtect) {
+                    HorizontalBlankingStart = value;
+                }
                 break;
 
             case CrtControllerRegister.HorizontalBlankingEnd:
-                HorizontalBlankingEndRegister.Value = value;
+                if (!VerticalSyncEndRegister.WriteProtect) {
+                    HorizontalBlankingEndRegister.Value = value;
+                }
                 break;
 
             case CrtControllerRegister.HorizontalRetraceStart:
-                HorizontalSyncStart = value;
+                if (!VerticalSyncEndRegister.WriteProtect) {
+                    HorizontalSyncStart = value;
+                }
                 break;
 
             case CrtControllerRegister.HorizontalRetraceEnd:
-                HorizontalSyncEndRegister.Value = value;
+                if (!VerticalSyncEndRegister.WriteProtect) {
+                    HorizontalSyncEndRegister.Value = value;
+                }
                 break;
 
             case CrtControllerRegister.VerticalTotal:
-                VerticalTotal = value;
+                if (!VerticalSyncEndRegister.WriteProtect) {
+                    VerticalTotal = value;
+                }
                 break;
 
             case CrtControllerRegister.Overflow:
-                OverflowRegister.Value = value;
+                if (!VerticalSyncEndRegister.WriteProtect) {
+                    OverflowRegister.Value = value;
+                }
                 break;
 
             case CrtControllerRegister.PresetRowScan:

--- a/src/Spice86.Core/Emulator/Devices/Video/Registers/RegisterExtensions.cs
+++ b/src/Spice86.Core/Emulator/Devices/Video/Registers/RegisterExtensions.cs
@@ -101,7 +101,14 @@ public static class RegisterExtensions {
             case CrtControllerRegister.VerticalTotal:
                 break;
             case CrtControllerRegister.Overflow:
-                break;
+                return string.Format(
+                    "[0,5]Vertical total upper: {0}, [1,6]Vertical display end upper: {1}, [2,7]Vertical sync start upper: {2}, [3]Vertical blanking start upper: {3}, [4]Line compare upper: {4}",
+                    (byte)(((value & 0x01) << 1) | ((value >> 5) & 0x01)),
+                    (byte)((((value >> 1) & 0x01) << 1) | ((value >> 6) & 0x01)),
+                    (byte)((((value >> 2) & 0x01) << 1) | ((value >> 7) & 0x01)),
+                    (byte)((value >> 3) & 0x01),
+                    (byte)((value >> 4) & 0x01)
+                );
             case CrtControllerRegister.PresetRowScan:
                 break;
             case CrtControllerRegister.CharacterCellHeight:
@@ -129,7 +136,14 @@ public static class RegisterExtensions {
             case CrtControllerRegister.VerticalRetraceEnd:
                 break;
             case CrtControllerRegister.VerticalDisplayEnd:
-                break;
+                return string.Format(
+                    "[0-3]Vertical Sync End: {0}, [4]Clear Vertical Interrupt: {1}, [5]Disable Vertical Interrupt: {2}, [6]Refresh Cycle: {3}, [7]Write Protect: {4}",
+                    value & 0x0F,
+                    (value & 0x10) == 0x10 ? "Enabled" : "Disabled",
+                    (value & 0x20) == 0x20 ? "Enabled" : "Disabled",
+                    (value & 0x40) == 0x40 ? "5" : "3",
+                    (value & 0x80) == 0x80 ? "Enabled" : "Disabled"
+                );
             case CrtControllerRegister.Offset:
                 break;
             case CrtControllerRegister.UnderlineLocation:


### PR DESCRIPTION
According to the VGA spec, the Vertical Sync End register in the CRT Controller is supposed to prevent CRT Controller registers 0 - 7 from being written. This bit was unused in the earlier EGA spec. This bit is set by default in DOS INT10 video modes 0x00 - 0x0E that were introduced prior to VGA to enable interoperability of programs that use CGA, EGA, and early text modes to work with VGA video cards, such as the one emulated by Spice86.

Prior to this, we already had the correct definition of the `WriteProtect` bit in the `VerticalSyncEndRegister`, but it wasn't being used anywhere. It was simply ignored. This worked correctly for games that used VGA compatible video modes, and for some games that used earlier EGA compatible video modes but didn't set any of the reserved bits that were later used by VGA, but not for all earlier games.

To fix it, I made the CRT Controller properly respect the Vertical Sync End register's Write Protect bit, which in turn enables compatibility with more games that use EGA (and possibly CGA - although that remains untested). I also added more detail to some of the comments and log messages that I used to debug this problem, which will hopefully help anyone looking at it in the future to pick it up more quickly.

I tested it with Exodus, which now works correctly, and regression tested it with Dune. Everything seems to work correctly.
<img width="1030" height="796" alt="image" src="https://github.com/user-attachments/assets/8228abbc-cd3c-4879-b02d-0dc6ac166fd2" />
<img width="1025" height="795" alt="image" src="https://github.com/user-attachments/assets/adb8a05a-28b5-46c3-9ddf-91f6f45593dc" />

This fixes #1390.