### PR TITLE
Release/v11

### DIFF
--- a/.github/workflows/nuget.yml
+++ b/.github/workflows/nuget.yml
@@ -30,29 +30,29 @@ jobs:
 
     - name: Package NuGet
       working-directory: ./src
-      run: dotnet pack --include-symbols --include-source --configuration Release
+      run: dotnet pack --include-symbols --include-source --configuration Release -p:NoWarn=NU5104
 
     - name: Upload NuGet Bufdio.Spice86
-      if: github.ref == 'refs/heads/master'
+      if: github.ref == 'refs/heads/master' && matrix.os == 'ubuntu-latest'
       working-directory: ./src/Bufdio.Spice86/bin/Release
-      run: dotnet nuget push Bufdio.Spice86.10.0.0.nupkg ${{secrets.NUGET_API_KEY}} -Source 'https://api.nuget.org/v3/index.json' -SkipDuplicate
+      run: dotnet nuget push Bufdio.Spice86.11.0.0.nupkg --api-key "${{ secrets.NUGET_API_KEY }}" --source "https://api.nuget.org/v3/index.json" --skip-duplicate
 
     - name: Upload NuGet Spice86.Shared
-      if: github.ref == 'refs/heads/master'
+      if: github.ref == 'refs/heads/master' && matrix.os == 'ubuntu-latest'
       working-directory: ./src/Spice86.Shared/bin/Release
-      run: dotnet nuget push Spice86.Shared.10.0.0.nupkg ${{secrets.NUGET_API_KEY}} -Source 'https://api.nuget.org/v3/index.json' -SkipDuplicate
+      run: dotnet nuget push Spice86.Shared.11.0.0.nupkg --api-key "${{ secrets.NUGET_API_KEY }}" --source "https://api.nuget.org/v3/index.json" --skip-duplicate
 
     - name: Upload NuGet Spice86.Logging
-      if: github.ref == 'refs/heads/master'
+      if: github.ref == 'refs/heads/master' && matrix.os == 'ubuntu-latest'
       working-directory: ./src/Spice86.Logging/bin/Release
-      run: dotnet nuget push Spice86.Logging.10.0.0.nupkg ${{secrets.NUGET_API_KEY}} -Source 'https://api.nuget.org/v3/index.json' -SkipDuplicate
+      run: dotnet nuget push Spice86.Logging.11.0.0.nupkg --api-key "${{ secrets.NUGET_API_KEY }}" --source "https://api.nuget.org/v3/index.json" --skip-duplicate
 
     - name: Upload NuGet Spice86.Core
-      if: github.ref == 'refs/heads/master'
+      if: github.ref == 'refs/heads/master' && matrix.os == 'ubuntu-latest'
       working-directory: ./src/Spice86.Core/bin/Release
-      run: dotnet nuget push Spice86.Core.10.0.0.nupkg ${{secrets.NUGET_API_KEY}} -Source 'https://api.nuget.org/v3/index.json' -SkipDuplicate
+      run: dotnet nuget push Spice86.Core.11.0.0.nupkg --api-key "${{ secrets.NUGET_API_KEY }}" --source "https://api.nuget.org/v3/index.json" --skip-duplicate
 
     - name: Upload NuGet Spice86
-      if: github.ref == 'refs/heads/master'
+      if: github.ref == 'refs/heads/master' && matrix.os == 'ubuntu-latest'
       working-directory: ./src/Spice86/bin/Release
-      run: dotnet nuget push Spice86.10.0.0.nupkg ${{secrets.NUGET_API_KEY}} -Source 'https://api.nuget.org/v3/index.json' -SkipDuplicate
+      run: dotnet nuget push Spice86.11.0.0.nupkg --api-key "${{ secrets.NUGET_API_KEY }}" --source "https://api.nuget.org/v3/index.json" --skip-duplicate

--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -5,6 +5,10 @@ on:
     branches:
       - "master"
 
+permissions:
+  contents: write
+  packages: write
+
 jobs:
   pre-release:
     name: "Pre Release"
@@ -12,6 +16,11 @@ jobs:
 
     steps:
        - uses: actions/checkout@v1
+
+       - name: Determine prerelease version
+         run: |
+              COMMIT_SHA=$(git rev-parse --short HEAD)
+              echo "PRERELEASE_VERSION=11.0.0-${COMMIT_SHA}" >> $GITHUB_ENV
 
        - name: Setup .NET
          uses: actions/setup-dotnet@v1
@@ -48,6 +57,27 @@ jobs:
        - name: Zip Release output
          run: zip -qq -r ReleaseBuild.zip Release
          working-directory: ./src/Spice86/bin
+
+       - name: Pack prerelease NuGet packages
+         working-directory: ./src
+         run: dotnet pack Spice86.sln --configuration Release --include-symbols --include-source -p:PackageVersion=${PRERELEASE_VERSION} -p:SymbolPackageFormat=snupkg -p:NoWarn=NU5104
+
+       - name: Publish prerelease NuGet packages
+         env:
+           PACKAGE_VERSION: ${{ env.PRERELEASE_VERSION }}
+           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+         run: |
+              set -euo pipefail
+              SOURCE="https://nuget.pkg.github.com/${{ github.repository_owner }}/index.json"
+              for project in Bufdio.Spice86 Spice86.Shared Spice86.Logging Spice86.Core Spice86; do
+                   PACKAGE_PATH="./src/${project}/bin/Release/${project}.${PACKAGE_VERSION}.nupkg"
+                   if [ -f "$PACKAGE_PATH" ]; then
+                        dotnet nuget push "$PACKAGE_PATH" --source "$SOURCE" --api-key "$GITHUB_TOKEN" --skip-duplicate
+                   else
+                        echo "::error::Package not found: $PACKAGE_PATH"
+                        exit 1
+                   fi
+              done
 
        - name: Publish GitHub Release
          uses: "marvinpinto/action-automatic-releases@latest"

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -16,10 +16,10 @@
 	</PropertyGroup>
 	<!-- Nuget package info-->
 	<PropertyGroup>
-		<Version>10.0.0</Version>
+		<Version>11.0.0</Version>
 		<PackageReleaseNotes>
             <![CDATA[
-            # Release Notes - https://github.com/OpenRakis/Spice86/wiki/Spice86-v10-release-notes
+            # Release Notes - https://github.com/OpenRakis/Spice86/wiki/Spice86-v11-release-notes
             ]]>
 		</PackageReleaseNotes>
 		<Authors>Alberto Marnetto, Ales Teska, Artjom Vejsel, Edu Garcia, Ivan Kuzmenko, John Källén, Joris van Eijden, Karl Lenz, Kevin Ferrare, LowLevelMahn, Maximilien Noal, Stefan Hueg</Authors>


### PR DESCRIPTION
https://github.com/OpenRakis/Spice86/wiki/Spice86-v11-release-notes

New release of the nuget packages.

YAML files should not fail now, even with a rc nuget package as a dependancy (MUNT wrapper for MT-32 emulation), and even if the Spice86 package is already published.

Edits to PR.YML amount to: each PR merged into master should create a new Nuget pre-release package.