### PR TITLE
Fix CS1591 warning treated as error in pack prerelease workflow (#1455)

### DIFF
--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -58,6 +58,11 @@ jobs:
          run: zip -qq -r ReleaseBuild.zip Release
          working-directory: ./src/Spice86/bin
 
+       # Suppress the following warnings during NuGet packing:
+       #   1591   - Missing XML documentation
+       #   NU5104 - Package icon issues
+       #   NU1507 - Package validation issues
+       # Semicolons are URL-encoded as %3B for compatibility.
        - name: Pack prerelease NuGet packages
          working-directory: ./src
          run: dotnet pack Spice86.sln --configuration Release --include-symbols --include-source -p:PackageVersion=${PRERELEASE_VERSION} -p:SymbolPackageFormat=snupkg -p:NoWarn=1591%3BNU5104%3BNU1507


### PR DESCRIPTION
* Fix CS1591 warning as error in pack prerelease workflow

Update NoWarn parameter to include 1591, NU5104, and NU1507 using URL-encoded semicolons (%3B). This prevents CS1591 (missing XML documentation) warnings from being treated as errors during pack.

Otherwise dotnet pack always failed, and the pre-release Nuget package could not be published.
