### PR TITLE
refactor: no optional param, no singleton, source is static anyway

### DIFF
--- a/src/Spice86.Core/Emulator/Devices/Timer/IWallClock.cs
+++ b/src/Spice86.Core/Emulator/Devices/Timer/IWallClock.cs
@@ -3,9 +3,9 @@
 namespace Spice86.Core.Emulator.Devices.Timer;
 
 /// <summary>
-///     Provides deterministic access to the current UTC time and delay primitives.
+///     Provides deterministic access to the current UTC time.
 /// </summary>
-public interface ITimeProvider {
+public interface IWallClock {
     /// <summary>
     ///     Gets the current coordinated universal time.
     /// </summary>

--- a/src/Spice86.Core/Emulator/Devices/Timer/WallClock.cs
+++ b/src/Spice86.Core/Emulator/Devices/Timer/WallClock.cs
@@ -5,14 +5,7 @@ namespace Spice86.Core.Emulator.Devices.Timer;
 /// <summary>
 ///     Wall-clock-backed time provider.
 /// </summary>
-public sealed class SystemTimeProvider : ITimeProvider {
-    private SystemTimeProvider() {
-    }
-
-    /// <summary>
-    ///     Gets the singleton <see cref="SystemTimeProvider" /> instance backed by the system clock.
-    /// </summary>
-    public static SystemTimeProvider Instance { get; } = new();
+public sealed class WallClock : IWallClock {
 
     /// <summary>
     ///     Gets the current UTC timestamp as reported by <see cref="DateTime.UtcNow" />.


### PR DESCRIPTION
A small refactoring that renames the ITimeProvider/TimeProvider, removes the singleton, and makes the class not optional.

Even the interface could be removed now.

I found the singleton, interface, and optional parameter quite confusing to follow. And wondered why all that for what is only System.DateTime.Now in the end ?

Why both inject it and have a singleton ?

I think less code = less maintenance burden.

Furthermore, in the codebase, if only one class uses another class, it creates it directly.

This approach tries to avoid helpess classes (classes that can't initialize themselves without help), large constructors (there is already too much of those), and only shares what should be shared (like, for example, for PauseHandler - all classes share the same instance for the pause/unpause feature to work).