### PR TITLE
Converts CfgCpu AST to Expression trees.

### DIFF
--- a/src/Spice86.Core/Emulator/CPU/CfgCpu/Ast/Builder/AstBuilder.cs
+++ b/src/Spice86.Core/Emulator/CPU/CfgCpu/Ast/Builder/AstBuilder.cs
@@ -1,14 +1,8 @@
 ﻿namespace Spice86.Core.Emulator.CPU.CfgCpu.Ast.Builder;
 
 using Spice86.Core.Emulator.CPU.CfgCpu.Ast.Instruction;
-using Spice86.Core.Emulator.CPU.CfgCpu.Ast.Operations;
-using Spice86.Core.Emulator.CPU.CfgCpu.Ast.Value;
-using Spice86.Core.Emulator.CPU.CfgCpu.Ast.Value.Constant;
 using Spice86.Core.Emulator.CPU.CfgCpu.ParsedInstruction;
 using Spice86.Core.Emulator.CPU.CfgCpu.ParsedInstruction.Instructions.Interfaces;
-using Spice86.Core.Emulator.CPU.CfgCpu.ParsedInstruction.ModRm;
-using Spice86.Core.Emulator.CPU.Registers;
-using Spice86.Shared.Emulator.Memory;
 
 public class AstBuilder {
     public AstBuilder() {

--- a/src/Spice86.Core/Emulator/CPU/CfgCpu/Ast/Builder/ModRmAstBuilder.cs
+++ b/src/Spice86.Core/Emulator/CPU/CfgCpu/Ast/Builder/ModRmAstBuilder.cs
@@ -48,7 +48,7 @@ public class ModRmAstBuilder(RegisterAstBuilder register, InstructionFieldAstBui
 
         ValueNode? displacement = ModRmDisplacementToNode(modRmContext);
         ValueNode? offset = ModRmOffsetToNode(modRmContext);
-        ValueNode? result = BiOperationWithResultNode(new DataType(modRmContext.AddressSize, false), offset, Operation.PLUS,
+        ValueNode? result = BiOperationWithResultNode(new DataType(modRmContext.AddressSize, false), offset, BinaryOperation.PLUS,
             displacement);
         return result ?? new ConstantNode(new DataType(modRmContext.AddressSize, false), 0);
     }
@@ -97,8 +97,8 @@ public class ModRmAstBuilder(RegisterAstBuilder register, InstructionFieldAstBui
         // base + scale * index
         ValueNode scaleNode = new ConstantNode(DataType.UINT8, sibContext.Scale);
         ValueNode? indexExpression =
-            BiOperationWithResultNode(DataType.UINT32, scaleNode, Operation.MULTIPLY, indexNode);
-        return BiOperationWithResultNode(DataType.UINT32, baseNode, Operation.PLUS, indexExpression);
+            BiOperationWithResultNode(DataType.UINT32, scaleNode, BinaryOperation.MULTIPLY, indexNode);
+        return BiOperationWithResultNode(DataType.UINT32, baseNode, BinaryOperation.PLUS, indexExpression);
     }
 
     private ValueNode? SibBaseToNode(SibContext sibContext) {
@@ -133,16 +133,16 @@ public class ModRmAstBuilder(RegisterAstBuilder register, InstructionFieldAstBui
     }
 
     private ValueNode PlusRegs16(RegisterIndex registerIndex1, RegisterIndex registerIndex2) {
-        return new BinaryOperationNode(DataType.UINT16, Register.Reg16(registerIndex1), Operation.PLUS,
+        return new BinaryOperationNode(DataType.UINT16, Register.Reg16(registerIndex1), BinaryOperation.PLUS,
             Register.Reg16(registerIndex2));
     }
 
     private ValueNode? BiOperationWithResultNode(DataType dataType,
         ValueNode? parameter1,
-        Operation operation,
+        BinaryOperation binaryOperation,
         ValueNode? parameter2) {
         if (parameter1 != null && parameter2 != null) {
-            return new BinaryOperationNode(dataType, parameter1, operation, parameter2);
+            return new BinaryOperationNode(dataType, parameter1, binaryOperation, parameter2);
         }
 
         if (parameter1 == null) {

--- a/src/Spice86.Core/Emulator/CPU/CfgCpu/Ast/Builder/PointerAstBuilder.cs
+++ b/src/Spice86.Core/Emulator/CPU/CfgCpu/Ast/Builder/PointerAstBuilder.cs
@@ -18,6 +18,6 @@ public class PointerAstBuilder {
     }
 
     public ValueNode ToSegmentedPointer(DataType targetDataType, ValueNode segment, ValueNode offset) {
-        return new SegmentedPointer(targetDataType, segment, offset);
+        return new SegmentedPointerNode(targetDataType, segment, offset);
     }
 }

--- a/src/Spice86.Core/Emulator/CPU/CfgCpu/Ast/DataType.cs
+++ b/src/Spice86.Core/Emulator/CPU/CfgCpu/Ast/DataType.cs
@@ -9,6 +9,7 @@ public class DataType(BitWidth bitWidth, bool signed) {
     public static DataType INT16 { get; } = new(BitWidth.WORD_16, true);
     public static DataType UINT32 { get; } = new(BitWidth.DWORD_32, false);
     public static DataType INT32 { get; } = new(BitWidth.DWORD_32, true);
+    public static DataType BOOL { get; } = new(BitWidth.DWORD_32, false);
 
     public BitWidth BitWidth { get; } = bitWidth;
     public bool Signed { get; } = signed;

--- a/src/Spice86.Core/Emulator/CPU/CfgCpu/Ast/IAstVisitor.cs
+++ b/src/Spice86.Core/Emulator/CPU/CfgCpu/Ast/IAstVisitor.cs
@@ -7,11 +7,12 @@ using Spice86.Core.Emulator.CPU.CfgCpu.Ast.Value.Constant;
 
 public interface IAstVisitor<T> {
     public T VisitSegmentRegisterNode(SegmentRegisterNode node);
-    public T VisitSegmentedPointer(SegmentedPointer node);
+    public T VisitSegmentedPointer(SegmentedPointerNode node);
     public T VisitRegisterNode(RegisterNode node);
     public T VisitAbsolutePointerNode(AbsolutePointerNode node);
     public T VisitSegmentedAddressConstantNode(SegmentedAddressConstantNode node);
     public T VisitBinaryOperationNode(BinaryOperationNode node);
+    public T VisitUnaryOperationNode(UnaryOperationNode node);
     public T VisitInstructionNode(InstructionNode node);
     public T VisitConstantNode(ConstantNode node);
 }

--- a/src/Spice86.Core/Emulator/CPU/CfgCpu/Ast/Operations/BinaryOperation.cs
+++ b/src/Spice86.Core/Emulator/CPU/CfgCpu/Ast/Operations/BinaryOperation.cs
@@ -1,0 +1,3 @@
+﻿namespace Spice86.Core.Emulator.CPU.CfgCpu.Ast.Operations;
+
+public enum BinaryOperation { PLUS, MULTIPLY, EQUAL, NOT_EQUAL, ASSIGN }

--- a/src/Spice86.Core/Emulator/CPU/CfgCpu/Ast/Operations/BinaryOperationNode.cs
+++ b/src/Spice86.Core/Emulator/CPU/CfgCpu/Ast/Operations/BinaryOperationNode.cs
@@ -3,9 +3,9 @@
 using Spice86.Core.Emulator.CPU.CfgCpu.Ast;
 using Spice86.Core.Emulator.CPU.CfgCpu.Ast.Value;
 
-public class BinaryOperationNode(DataType dataType, ValueNode left, Operation operation, ValueNode right) : ValueNode(dataType) {
+public class BinaryOperationNode(DataType dataType, ValueNode left, BinaryOperation binaryOperation, ValueNode right) : ValueNode(dataType) {
     public ValueNode Left { get; } = left;
-    public Operation Operation { get; } = operation;
+    public BinaryOperation BinaryOperation { get; } = binaryOperation;
     public ValueNode Right { get; } = right;
     
     public override T Accept<T>(IAstVisitor<T> astVisitor) {

--- a/src/Spice86.Core/Emulator/CPU/CfgCpu/Ast/Operations/UnaryOperation.cs
+++ b/src/Spice86.Core/Emulator/CPU/CfgCpu/Ast/Operations/UnaryOperation.cs
@@ -1,3 +1,5 @@
 ﻿namespace Spice86.Core.Emulator.CPU.CfgCpu.Ast.Operations;
 
-public enum Operation { PLUS, MULTIPLY }
+public enum UnaryOperation {
+    NOT
+}

--- a/src/Spice86.Core/Emulator/CPU/CfgCpu/Ast/Operations/UnaryOperationNode.cs
+++ b/src/Spice86.Core/Emulator/CPU/CfgCpu/Ast/Operations/UnaryOperationNode.cs
@@ -1,0 +1,13 @@
+﻿namespace Spice86.Core.Emulator.CPU.CfgCpu.Ast.Operations;
+
+using Spice86.Core.Emulator.CPU.CfgCpu.Ast;
+using Spice86.Core.Emulator.CPU.CfgCpu.Ast.Value;
+
+public class UnaryOperationNode(DataType dataType, UnaryOperation unaryOperation, ValueNode value) : ValueNode(dataType) {
+    public UnaryOperation UnaryOperation { get; } = unaryOperation;
+    public ValueNode Value { get; } = value;
+    
+    public override T Accept<T>(IAstVisitor<T> astVisitor) {
+        return astVisitor.VisitUnaryOperationNode(this);
+    }
+}

--- a/src/Spice86.Core/Emulator/CPU/CfgCpu/Ast/Value/SegmentedPointerNode.cs
+++ b/src/Spice86.Core/Emulator/CPU/CfgCpu/Ast/Value/SegmentedPointerNode.cs
@@ -2,7 +2,7 @@
 
 using Spice86.Core.Emulator.CPU.CfgCpu.Ast;
 
-public class SegmentedPointer(DataType dataType, ValueNode segment, ValueNode offset) : ValueNode(dataType) {
+public class SegmentedPointerNode(DataType dataType, ValueNode segment, ValueNode offset) : ValueNode(dataType) {
     public ValueNode Segment { get; } = segment;
     public ValueNode Offset { get; } = offset;
     

--- a/src/Spice86.Core/Emulator/CPU/CfgCpu/InstructionExecutor/Expressions/AstExpressionBuilder.cs
+++ b/src/Spice86.Core/Emulator/CPU/CfgCpu/InstructionExecutor/Expressions/AstExpressionBuilder.cs
@@ -1,0 +1,203 @@
+﻿namespace Spice86.Core.Emulator.CPU.CfgCpu.InstructionExecutor.Expressions;
+
+using Spice86.Core.Emulator.CPU.CfgCpu.Ast;
+using Spice86.Core.Emulator.CPU.CfgCpu.Ast.Instruction;
+using Spice86.Core.Emulator.CPU.CfgCpu.Ast.Operations;
+using Spice86.Core.Emulator.CPU.CfgCpu.Ast.Value;
+using Spice86.Core.Emulator.CPU.CfgCpu.Ast.Value.Constant;
+using Spice86.Core.Emulator.CPU.CfgCpu.InstructionRenderer;
+using Spice86.Core.Emulator.Errors;
+using Spice86.Core.Emulator.Memory;
+using Spice86.Core.Emulator.Memory.Indexer;
+using Spice86.Shared.Emulator.Memory;
+
+using System.Linq.Expressions;
+using System.Reflection;
+
+public class AstExpressionBuilder : IAstVisitor<Expression> {
+    private readonly ParameterExpression _memoryParameter = Expression.Parameter(typeof(Memory), "memory");
+    private readonly ParameterExpression _stateParameter = Expression.Parameter(typeof(State), "cpuState");
+
+    private readonly ParameterExpression[] _allParameters;
+
+    private readonly RegisterRenderer _registerRenderer = new();
+
+    public AstExpressionBuilder() {
+        _allParameters = [_stateParameter, _memoryParameter];
+    }
+
+    private Type FromDataType(DataType dataType) {
+        if (dataType == DataType.BOOL) {
+            return typeof(bool);
+        }
+        return dataType.BitWidth switch {
+            BitWidth.BYTE_8 => dataType.Signed ? typeof(sbyte) : typeof(byte),
+            BitWidth.WORD_16 => dataType.Signed ? typeof(short) : typeof(ushort),
+            BitWidth.DWORD_32 => dataType.Signed ? typeof(int) : typeof(uint),
+            _ => throw new UnsupportedBitWidthException(dataType.BitWidth)
+        };
+    }
+
+    private BinaryExpression ToExpression(BinaryOperation binaryOperation, Expression left, Expression right) {
+        return binaryOperation switch {
+            BinaryOperation.PLUS => Expression.Add(left, right),
+            BinaryOperation.MULTIPLY => Expression.Multiply(left, right),
+            BinaryOperation.EQUAL => Expression.Equal(left, right),
+            BinaryOperation.NOT_EQUAL => Expression.NotEqual(left, right),
+            BinaryOperation.ASSIGN => Expression.Assign(left, right),
+            _ => throw new InvalidOperationException($"Unhandled Operation: {binaryOperation}")
+        };
+    }
+    
+    private UnaryExpression ToExpression(UnaryOperation unaryOperation, Expression value) {
+        return unaryOperation switch {
+            UnaryOperation.NOT => Expression.Not(value),
+            _ => throw new InvalidOperationException($"Unhandled Operation: {unaryOperation}")
+        };
+    }
+    
+    private T EnsureNonNull<T>(T? argument) {
+        ArgumentNullException.ThrowIfNull(argument);
+        return argument;
+    }
+
+    private string ToMemoryPropertyName(DataType dataType) {
+        return dataType.BitWidth switch {
+            BitWidth.BYTE_8 => dataType.Signed ? nameof(Memory.Int8) : nameof(Memory.UInt8),
+            BitWidth.WORD_16 => dataType.Signed ? nameof(Memory.Int16) : nameof(Memory.UInt16),
+            BitWidth.DWORD_32 => dataType.Signed ? nameof(Memory.Int32) : nameof(Memory.UInt32),
+            _ => throw new UnsupportedBitWidthException(dataType.BitWidth)
+        };
+    }
+
+    private Type ToMemoryIndexerType(DataType dataType) {
+        return dataType.BitWidth switch {
+            BitWidth.BYTE_8 => dataType.Signed ? typeof(Int8Indexer) : typeof(UInt8Indexer),
+            BitWidth.WORD_16 => dataType.Signed ? typeof(Int16Indexer) : typeof(UInt16Indexer),
+            BitWidth.DWORD_32 => dataType.Signed ? typeof(Int32Indexer) : typeof(UInt32Indexer),
+            _ => throw new UnsupportedBitWidthException(dataType.BitWidth)
+        };
+    }
+
+    private PropertyInfo FindSingleParameterIndexer(Type type) {
+        PropertyInfo[] propertyInfos = type.GetProperties();
+        foreach (PropertyInfo propertyInfo in propertyInfos) {
+            ParameterInfo[] indexParameters = propertyInfo.GetIndexParameters();
+            if (indexParameters.Length == 1 && indexParameters[0].ParameterType == typeof(uint)) {
+                return propertyInfo;
+            }
+        }
+        throw new ArgumentException($"Couldn't find a property named Item with 1 parameter for type {type}");
+    }
+    
+    private PropertyInfo FindDualParameterIndexer(Type type) {
+        PropertyInfo[] propertyInfos = type.GetProperties();
+        foreach (PropertyInfo propertyInfo in propertyInfos) {
+            ParameterInfo[] indexParameters = propertyInfo.GetIndexParameters();
+            if (indexParameters.Length == 2 && indexParameters[0].ParameterType == typeof(ushort) && indexParameters[1].ParameterType == typeof(ushort)) {
+                return propertyInfo;
+            }
+        }
+        throw new ArgumentException($"Couldn't find a property named Item with 2 parameters for type {type}");
+    }
+
+    private MemberExpression ToMemoryIndexerProperty(DataType dataType) {
+        string propertyName = ToMemoryPropertyName(dataType);
+        PropertyInfo memoryIndexerProperty = EnsureNonNull(typeof(Memory).GetProperty(propertyName));
+        return Expression.Property(_memoryParameter, memoryIndexerProperty);
+    }
+
+    private IndexExpression ToMemoryIndexer(DataType dataType, Expression indexExpression) {
+        MemberExpression indexerProperty = ToMemoryIndexerProperty(dataType);
+        PropertyInfo indexer = FindSingleParameterIndexer(ToMemoryIndexerType(dataType));
+        return Expression.Property(indexerProperty, indexer, indexExpression);
+    }
+    
+    private IndexExpression ToMemoryIndexer(DataType dataType, Expression segmentExpression, Expression offsetExpression ) {
+        MemberExpression indexerProperty = ToMemoryIndexerProperty(dataType);
+        PropertyInfo indexer = FindDualParameterIndexer(ToMemoryIndexerType(dataType));
+        return Expression.Property(indexerProperty, indexer, segmentExpression, offsetExpression);
+    }
+    
+    private Expression ToRegisterProperty(int registerIndex, DataType dataType, bool isSegmentRegister) {
+        string name = isSegmentRegister ? _registerRenderer.ToStringSegmentRegister(registerIndex) : _registerRenderer.ToStringRegister(dataType.BitWidth, registerIndex);
+        PropertyInfo stateRegisterProperty = EnsureNonNull(typeof(State).GetProperty(name));
+        return Expression.Property(_stateParameter, stateRegisterProperty);
+    }
+
+    public Expression VisitSegmentRegisterNode(SegmentRegisterNode node) {
+       return ToRegisterProperty(node.RegisterIndex, node.DataType, true);
+    }
+
+    public Expression VisitSegmentedPointer(SegmentedPointerNode node) {
+        Expression segmentExpression = node.Segment.Accept(this);
+        Expression offsetExpression = node.Offset.Accept(this);
+        return ToMemoryIndexer(node.DataType, segmentExpression, offsetExpression);
+    }
+
+    public Expression VisitRegisterNode(RegisterNode node) {
+        return ToRegisterProperty(node.RegisterIndex, node.DataType, false);
+    }
+
+    public Expression VisitAbsolutePointerNode(AbsolutePointerNode node) {
+        Expression index = node.AbsoluteAddress.Accept(this);
+        return ToMemoryIndexer(node.DataType, index);
+    }
+    
+    public Expression VisitSegmentedAddressConstantNode(SegmentedAddressConstantNode node) {
+        throw new NotImplementedException();
+    }
+    
+    public Expression VisitBinaryOperationNode(BinaryOperationNode node) {
+        Expression left = node.Left.Accept(this);
+        Expression right = node.Right.Accept(this);
+        return ToExpression(node.BinaryOperation, left, right);
+    }
+    
+    public Expression VisitUnaryOperationNode(UnaryOperationNode node) {
+        Expression value = node.Value.Accept(this);
+        return ToExpression(node.UnaryOperation, value);
+    }
+    
+    public Expression VisitInstructionNode(InstructionNode node) {
+        throw new NotImplementedException();
+    }
+
+    public Expression VisitConstantNode(ConstantNode node) {
+        Type type = FromDataType(node.DataType);
+        object castValue = Convert.ChangeType(node.Value, type);
+        return Expression.Constant(castValue, type);
+    }
+
+    public Expression<Action<State, Memory>> ToAction(Expression expression) {
+        return Expression.Lambda<Action<State, Memory>>(expression, _allParameters);
+    }
+    
+    public Expression<Func<State, Memory, byte>> ToFuncUInt8(Expression expression) {
+        return Expression.Lambda<Func<State, Memory, byte>>(expression, _allParameters);
+    }
+    
+    public Expression<Func<State, Memory, sbyte>> ToFuncInt8(Expression expression) {
+        return Expression.Lambda<Func<State, Memory, sbyte>>(expression, _allParameters);
+    }
+    
+    public Expression<Func<State, Memory, ushort>> ToFuncUInt16(Expression expression) {
+        return Expression.Lambda<Func<State, Memory, ushort>>(expression, _allParameters);
+    }
+    
+    public Expression<Func<State, Memory, short>> ToFuncInt16(Expression expression) {
+        return Expression.Lambda<Func<State, Memory, short>>(expression, _allParameters);
+    }
+
+    public Expression<Func<State, Memory, uint>> ToFuncUInt32(Expression expression) {
+        return Expression.Lambda<Func<State, Memory, uint>>(expression, _allParameters);
+    }
+    
+    public Expression<Func<State, Memory, int>> ToFuncInt32(Expression expression) {
+        return Expression.Lambda<Func<State, Memory, int>>(expression, _allParameters);
+    }
+    
+    public Expression<Func<State, Memory, bool>> ToFuncBool(Expression expression) {
+        return Expression.Lambda<Func<State, Memory, bool>>(expression, _allParameters);
+    }
+}

--- a/src/Spice86.Core/Emulator/CPU/CfgCpu/InstructionRenderer/AstInstructionRenderer.cs
+++ b/src/Spice86.Core/Emulator/CPU/CfgCpu/InstructionRenderer/AstInstructionRenderer.cs
@@ -17,7 +17,7 @@ public class AstInstructionRenderer : IAstVisitor<string> {
         return _registerRenderer.ToStringSegmentRegister(node.RegisterIndex);
     }
 
-    public string VisitSegmentedPointer(SegmentedPointer node) {
+    public string VisitSegmentedPointer(SegmentedPointerNode node) {
         string offset = node.Offset.Accept(this);
         string segment = node.Segment.Accept(this);
 
@@ -77,14 +77,19 @@ public class AstInstructionRenderer : IAstVisitor<string> {
 
     public string VisitBinaryOperationNode(BinaryOperationNode node) {
         string left = node.Left.Accept(this);
-        if (IsZero(node.Right) && node.Operation == Operation.PLUS) {
+        if (IsZero(node.Right) && node.BinaryOperation == BinaryOperation.PLUS) {
             return left;
         }
         string right = node.Right.Accept(this);
-        if (IsNegative(node.Right) && node.Operation == Operation.PLUS) {
+        if (IsNegative(node.Right) && node.BinaryOperation == BinaryOperation.PLUS) {
             return left + right;
         }
-        return left + OperationToString(node.Operation) + right;
+        return left + OperationToString(node.BinaryOperation) + right;
+    }
+    
+    public string VisitUnaryOperationNode(UnaryOperationNode node) {
+        string value = node.Value.Accept(this);
+        return OperationToString(node.UnaryOperation) + value;
     }
 
     private bool IsZero(ValueNode valueNode) {
@@ -109,11 +114,21 @@ public class AstInstructionRenderer : IAstVisitor<string> {
         return mnemonic + " " + string.Join(",", node.Parameters.Select(param => param.Accept(this)));
     }
 
-    private string OperationToString(Operation operation) {
-        return operation switch {
-            Operation.PLUS => "+",
-            Operation.MULTIPLY => "*",
-            _ => throw new InvalidOperationException($"Unsupported AST operation {operation}")
+    private string OperationToString(BinaryOperation binaryOperation) {
+        return binaryOperation switch {
+            BinaryOperation.PLUS => "+",
+            BinaryOperation.MULTIPLY => "*",
+            BinaryOperation.EQUAL => "==",
+            BinaryOperation.NOT_EQUAL => "!=",
+            BinaryOperation.ASSIGN => "=",
+            _ => throw new InvalidOperationException($"Unsupported AST operation {binaryOperation}")
+        };
+    }
+    
+    private string OperationToString(UnaryOperation unaryOperation) {
+        return unaryOperation switch {
+            UnaryOperation.NOT => "!",
+            _ => throw new InvalidOperationException($"Unsupported AST operation {unaryOperation}")
         };
     }
 

--- a/src/Spice86.Core/Emulator/CPU/CfgCpu/InstructionRenderer/RegisterRenderer.cs
+++ b/src/Spice86.Core/Emulator/CPU/CfgCpu/InstructionRenderer/RegisterRenderer.cs
@@ -40,7 +40,6 @@ public class RegisterRenderer {
     private string Reg32Name(int regIndex) {
         return "E" + Reg16Name(regIndex);
     }
-
     public string ToStringRegister(BitWidth bitWidth, int registerIndex) {
         return bitWidth switch {
             BitWidth.BYTE_8=> Reg8Name(registerIndex),
@@ -49,6 +48,7 @@ public class RegisterRenderer {
             _ => throw new ArgumentOutOfRangeException(nameof(bitWidth), bitWidth, null)
         };
     }
+
 
     public string ToStringSegmentRegister(int registerIndex) {
         return _segmentRegistersNames[registerIndex];

--- a/src/Spice86.Core/Emulator/CPU/CfgCpu/ParsedInstruction/Instructions/Mixins/Xlat.mixin
+++ b/src/Spice86.Core/Emulator/CPU/CfgCpu/ParsedInstruction/Instructions/Mixins/Xlat.mixin
@@ -33,7 +33,7 @@ public partial class {{ moxy.Class.Name }} : InstructionWithSegmentRegisterIndex
                 SegmentRegisterIndex,
                 new BinaryOperationNode(builder.AddressType(this),
                     builder.Register.Reg(builder.AddressType(this), RegisterIndex.BxIndex),
-                    Operation.PLUS,
+                    BinaryOperation.PLUS,
                     builder.Register.Accumulator(DataType.UINT8)
                 )
             )

--- a/src/Spice86.Core/Emulator/CPU/CfgCpu/Parser/BaseInstructionParser.cs
+++ b/src/Spice86.Core/Emulator/CPU/CfgCpu/Parser/BaseInstructionParser.cs
@@ -2,7 +2,9 @@ namespace Spice86.Core.Emulator.CPU.CfgCpu.Parser;
 
 using Spice86.Core.Emulator.CPU.CfgCpu.ParsedInstruction;
 using Spice86.Core.Emulator.CPU.CfgCpu.Parser.FieldReader;
+using Spice86.Core.Emulator.CPU.Exceptions;
 using Spice86.Core.Emulator.CPU.Registers;
+using Spice86.Core.Emulator.Errors;
 using Spice86.Shared.Emulator.Memory;
 
 public class BaseInstructionParser {
@@ -58,7 +60,7 @@ public class BaseInstructionParser {
         return ((value >> bitIndex) & 1) == 1;
     }
 
-    protected static InvalidOperationException CreateUnsupportedBitWidthException(BitWidth bitWidth) {
-        return new InvalidOperationException($"Unsupported bit width {bitWidth}");
+    protected static UnsupportedBitWidthException CreateUnsupportedBitWidthException(BitWidth bitWidth) {
+        return new UnsupportedBitWidthException(bitWidth);
     }
 }

--- a/src/Spice86.Core/Emulator/Errors/UnsupportedBitWidthException.cs
+++ b/src/Spice86.Core/Emulator/Errors/UnsupportedBitWidthException.cs
@@ -1,0 +1,5 @@
+﻿namespace Spice86.Core.Emulator.Errors;
+
+using Spice86.Shared.Emulator.Memory;
+
+public class UnsupportedBitWidthException(BitWidth bitWidth) : InvalidOperationException($"Unsupported bit width {bitWidth}");

--- a/tests/Spice86.Tests/Emulator/CPU/CfgCpu/InstructionExecutor/Expressions/AstExpressionBuilderTest.cs
+++ b/tests/Spice86.Tests/Emulator/CPU/CfgCpu/InstructionExecutor/Expressions/AstExpressionBuilderTest.cs
@@ -1,0 +1,176 @@
+﻿using Spice86.Core.Emulator.CPU.CfgCpu.InstructionExecutor.Expressions;
+
+namespace Spice86.Tests.Emulator.CPU.CfgCpu.InstructionExecutor.Expressions;
+
+using Spice86.Core.Emulator.CPU;
+using Spice86.Core.Emulator.CPU.CfgCpu.Ast;
+using Spice86.Core.Emulator.CPU.CfgCpu.Ast.Operations;
+using Spice86.Core.Emulator.CPU.CfgCpu.Ast.Value;
+using Spice86.Core.Emulator.CPU.CfgCpu.Ast.Value.Constant;
+using Spice86.Core.Emulator.CPU.Registers;
+using Spice86.Core.Emulator.Memory;
+
+using System.Linq.Expressions;
+
+using Xunit;
+
+public class AstExpressionBuilderTest {
+    private readonly Memory _memory = new(new(), new Ram(64), new());
+    private readonly State _state = new(CpuModel.INTEL_80286);
+    private readonly AstExpressionBuilder _astExpressionBuilder = new();
+
+    [Fact]
+    public void TestMemoryAddressAbsolute() {
+        // Arrange
+        ConstantNode one = new ConstantNode(DataType.UINT32, 1);
+        AbsolutePointerNode pointerNode = new AbsolutePointerNode(DataType.UINT8, one);
+
+        // Act
+        ExecuteAssignment(pointerNode, 0xF8);
+
+        // Assert
+        Assert.Equal(0xF8, _memory[1]);
+    }
+
+    [Fact]
+    public void TestMemoryAddressSegmented() {
+        // Arrange
+        ConstantNode one = new ConstantNode(DataType.UINT16, 1);
+        ConstantNode two = new ConstantNode(DataType.UINT16, 2);
+        SegmentedPointerNode pointerNode = new SegmentedPointerNode(DataType.UINT8, one, two);
+
+        // Act
+        ExecuteAssignment(pointerNode, 0xF8);
+
+        // Assert
+        Assert.Equal(0xF8, _memory.UInt8[1, 2]);
+    }
+
+    [Fact]
+    public void TestRegister() {
+        // Arrange
+        RegisterNode register = new RegisterNode(DataType.UINT8, (int)RegisterIndex.AxIndex);
+
+        // Act
+        ExecuteAssignment(register, 0xF8);
+
+        // Assert
+        Assert.Equal(0xF8, _state.AL);
+    }
+
+    [Fact]
+    public void TestSegmentRegister() {
+        // Arrange
+        SegmentRegisterNode segmentRegister = new SegmentRegisterNode((int)SegmentRegisterIndex.EsIndex);
+
+        // Act
+        ExecuteAssignment(segmentRegister, 0xF8);
+
+        // Assert
+        Assert.Equal(0xF8, _state.ES);
+    }
+
+    [Fact]
+    public void TestMemoryAddressSegmentedFromRegs() {
+        // Arrange
+        _state.ES = 1;
+        _state.DI = 2;
+        RegisterNode offset = new RegisterNode(DataType.UINT16, (int)RegisterIndex.DiIndex);
+        SegmentRegisterNode segmentRegister = new SegmentRegisterNode((int)SegmentRegisterIndex.EsIndex);
+        SegmentedPointerNode pointerNode = new SegmentedPointerNode(DataType.UINT8, segmentRegister, offset);
+
+        // Act
+        ExecuteAssignment(pointerNode, 0xF8);
+
+        // Assert
+        Assert.Equal(0xF8, _memory.UInt8[1, 2]);
+    }
+
+    [Fact]
+    public void TestAdd() {
+        // Arrange
+        _state.AX = 1;
+        _state.BX = 2;
+        RegisterNode operand1 = new RegisterNode(DataType.UINT16, (int)RegisterIndex.AxIndex);
+        RegisterNode operand2 = new RegisterNode(DataType.UINT16, (int)RegisterIndex.BxIndex);
+        BinaryOperationNode operationNode = new BinaryOperationNode(DataType.UINT16, operand1, BinaryOperation.PLUS, operand2);
+
+        // Act
+        ushort res = ToUint16(operationNode);
+
+        // Assert
+        Assert.Equal(3, res);
+    }
+
+    [Fact]
+    public void TestEquals() {
+        // Arrange
+        _state.AX = 1;
+        RegisterNode operand1 = new RegisterNode(DataType.UINT16, (int)RegisterIndex.AxIndex);
+        ConstantNode operand2 = new ConstantNode(DataType.UINT16, 1);
+        BinaryOperationNode operationNode = new BinaryOperationNode(DataType.BOOL, operand1, BinaryOperation.EQUAL, operand2);
+
+        // Act
+        bool res = ToBool(operationNode);
+
+        // Assert
+        Assert.True(res);
+    }
+
+    [Fact]
+    public void TestNotEquals() {
+        // Arrange
+        _state.AX = 1;
+        RegisterNode operand1 = new RegisterNode(DataType.UINT16, (int)RegisterIndex.AxIndex);
+        ConstantNode operand2 = new ConstantNode(DataType.UINT16, 1);
+        BinaryOperationNode operationNode = new BinaryOperationNode(DataType.BOOL, operand1, BinaryOperation.NOT_EQUAL, operand2);
+
+        // Act
+        bool res = ToBool(operationNode);
+
+        // Assert
+        Assert.False(res);
+    }
+
+    [Fact]
+    public void TestNot() {
+        // Arrange
+        _state.AX = 1;
+        RegisterNode operand1 = new RegisterNode(DataType.UINT16, (int)RegisterIndex.AxIndex);
+        ConstantNode operand2 = new ConstantNode(DataType.UINT16, 1);
+        BinaryOperationNode operationNode = new BinaryOperationNode(DataType.BOOL, operand1, BinaryOperation.EQUAL, operand2);
+        UnaryOperationNode unaryOperationNode = new UnaryOperationNode(DataType.BOOL, UnaryOperation.NOT, operationNode);
+
+        // Act
+        bool res = ToBool(unaryOperationNode);
+
+        // Assert
+        Assert.False(res);
+    }
+
+    private bool ToBool(IVisitableAstNode node) {
+        Expression expression = node.Accept(_astExpressionBuilder);
+        Func<State, Memory, bool> func = _astExpressionBuilder.ToFuncBool(expression).Compile();
+        return func(_state, _memory);
+    }
+
+    private ushort ToUint16(IVisitableAstNode node) {
+        Expression expression = node.Accept(_astExpressionBuilder);
+        Func<State, Memory, ushort> func = _astExpressionBuilder.ToFuncUInt16(expression).Compile();
+        return func(_state, _memory);
+    }
+
+    private void Execute(IVisitableAstNode node) {
+        Expression expression = node.Accept(_astExpressionBuilder);
+        Action<State, Memory> func = _astExpressionBuilder.ToAction(expression).Compile();
+        func(_state, _memory);
+    }
+
+    private void ExecuteAssignment(ValueNode destination, byte value) {
+        ConstantNode valueNode = new(destination.DataType, value);
+        BinaryOperationNode operation = new(destination.DataType, destination, BinaryOperation.ASSIGN, valueNode);
+        
+        // Act
+        Execute(operation);
+    }
+}


### PR DESCRIPTION
### Description of Changes
Currently AST is only used for rendering. This allows AST to be converted to expression tree and executed.

### Rationale behind Changes
This is a building block for conditional breakpoints and more
See https://github.com/OpenRakis/Spice86/pull/1484