### PR TITLE
Fix: return non-dummy values for GetFunctionalityInfo, fix logging

### DIFF
--- a/src/Spice86.Core/Emulator/Devices/Video/IVgaFunctionality.cs
+++ b/src/Spice86.Core/Emulator/Devices/Video/IVgaFunctionality.cs
@@ -311,6 +311,12 @@ public interface IVgaFunctionality {
     void SetFontBlockSpecifier(byte fontBlock);
 
     /// <summary>
+    ///     Read the current value of the VGA character map select register (sequencer index 0x03).
+    /// </summary>
+    /// <returns>The raw register value describing which font blocks are active.</returns>
+    byte GetCharacterMapSelectRegister();
+
+    /// <summary>
     ///     Set the amount of scan lines to use per row.
     /// </summary>
     void SetScanLines(byte lines);

--- a/src/Spice86.Core/Emulator/Devices/Video/VideoFunctionalityInfo.cs
+++ b/src/Spice86.Core/Emulator/Devices/Video/VideoFunctionalityInfo.cs
@@ -153,4 +153,39 @@ public class VideoFunctionalityInfo : MemoryBasedDataStructure {
         UInt8[0x0B + offset] = x;
         UInt8[0x0C + offset] = y;
     }
+
+    public object CreateFunctionalityInfoLogSnapshot() {
+        object[] cursorPositions = new object[8];
+        for (int page = 0; page < cursorPositions.Length; page++) {
+            (byte x, byte y) = GetCursorPosition(page);
+            cursorPositions[page] = new { Page = page, X = x, Y = y };
+        }
+
+        return new {
+            SftAddress,
+            VideoMode,
+            ScreenColumns,
+            VideoBufferLength,
+            VideoBufferAddress,
+            CursorEndLine,
+            CursorStartLine,
+            ActiveDisplayPage,
+            CrtControllerBaseAddress,
+            CurrentRegister3X8Value,
+            CurrentRegister3X9Value,
+            ScreenRows,
+            CharacterMatrixHeight,
+            ActiveDisplayCombinationCode,
+            AlternateDisplayCombinationCode,
+            NumberOfColorsSupported,
+            NumberOfPages,
+            NumberOfActiveScanLines,
+            TextCharacterTableUsed,
+            TextCharacterTableUsed2,
+            OtherStateInformation,
+            VideoRamAvailable,
+            SaveAreaStatus,
+            CursorPositions = cursorPositions
+        };
+    }
 }

--- a/src/Spice86.Core/Emulator/InterruptHandlers/VGA/VgaFunctionality.cs
+++ b/src/Spice86.Core/Emulator/InterruptHandlers/VGA/VgaFunctionality.cs
@@ -579,6 +579,11 @@ public class VgaFunctionality : IVgaFunctionality {
     }
 
     /// <inheritdoc />
+    public byte GetCharacterMapSelectRegister() {
+        return ReadSequencer(0x03);
+    }
+
+    /// <inheritdoc />
     public void EnableVideoAddressing(bool state) {
         byte value = (byte)(state ? 0x02 : 0x00);
         WriteMaskedToMiscellaneousRegister(0x02, value);
@@ -1222,6 +1227,11 @@ public class VgaFunctionality : IVgaFunctionality {
 
     private void WriteToSequencer(byte index, byte value) {
         WriteWordToIoPort((ushort)(value << 8 | index), VgaPort.SequencerAddress);
+    }
+
+    private byte ReadSequencer(byte index) {
+        WriteByteToIoPort(index, VgaPort.SequencerAddress);
+        return _ioPortDispatcher.ReadByte((ushort)VgaPort.SequencerAddress + 1);
     }
 
     private void WriteWordToIoPort(ushort value, VgaPort port) {


### PR DESCRIPTION
The warning that is logged accidentally printed the whole memory.

### Description of Changes
Implement ToDos using real / calculated values, fix logging

### Rationale behind Changes
The returned info aligns with DosBox, avoid logging the whole memory.

### Suggested Testing Steps
I noticed it in Dunkle Schatten, which uses this function at start.
