### PR TITLE
Perf: improve performance of breakpoint checks

### DIFF
--- a/src/Spice86.Core/Emulator/VM/Breakpoint/BreakPointHolder.cs
+++ b/src/Spice86.Core/Emulator/VM/Breakpoint/BreakPointHolder.cs
@@ -9,11 +9,12 @@ public class BreakPointHolder {
     private readonly Dictionary<long, List<BreakPoint>> _addressBreakPoints = new(1000);
 
     private readonly List<BreakPoint> _unconditionalBreakPoints = new(1000);
+    private int _activeBreakpoints;
 
     /// <summary>
-    /// Gets a value indicating whether this BreakPointHolder is empty.
+    /// Gets the number of currently active breakpoints.
     /// </summary>
-    public bool IsEmpty => _addressBreakPoints.Count == 0 && _unconditionalBreakPoints.Count == 0;
+    public bool HasActiveBreakpoints => _activeBreakpoints > 0;
 
     private IEnumerable<BreakPoint> GetAllBreakpoints() {
         return _addressBreakPoints.Values
@@ -37,6 +38,12 @@ public class BreakPointHolder {
                 ToggleAddressBreakPoint(addressBreakPoint, on);
                 break;
         }
+
+        UpdateActiveBreakPoints();
+    }
+
+    private void UpdateActiveBreakPoints() {
+        _activeBreakpoints = GetAllBreakpoints().Count(x => x.IsEnabled);
     }
 
     private void ToggleAddressBreakPoint(AddressBreakPoint breakPoint, bool on) {

--- a/src/Spice86.Core/Emulator/VM/Breakpoint/EmulatorBreakpointsManager.cs
+++ b/src/Spice86.Core/Emulator/VM/Breakpoint/EmulatorBreakpointsManager.cs
@@ -5,7 +5,6 @@ using Spice86.Shared.Emulator.VM.Breakpoint;
 using Spice86.Shared.Emulator.VM.Breakpoint.Serializable;
 using Spice86.Shared.Interfaces;
 
-using System.Collections.Generic;
 using System.Linq;
 
 /// <summary>
@@ -105,11 +104,14 @@ public sealed class EmulatorBreakpointsManager : ISerializableBreakpointsSource 
         }
     }
 
+    public bool HasActiveBreakpoints =>
+        _executionBreakPoints.HasActiveBreakpoints || _cycleBreakPoints.HasActiveBreakpoints;
+
     /// <summary>
     /// Checks the current breakpoints and triggers them if necessary.
     /// </summary>
-    public void CheckExecutionBreakPoints() {
-        if (!_executionBreakPoints.IsEmpty) {
+    public void TriggerBreakpoints() {
+        if (_executionBreakPoints.HasActiveBreakpoints) {
             uint address;
             // We do a loop here because if breakpoint action modifies the IP address we may miss other breakpoints.
             bool triggered;
@@ -119,7 +121,7 @@ public sealed class EmulatorBreakpointsManager : ISerializableBreakpointsSource 
             } while (triggered && address != _state.IpPhysicalAddress);
         }
 
-        if (!_cycleBreakPoints.IsEmpty) {
+        if (_cycleBreakPoints.HasActiveBreakpoints) {
             long cycles = _state.Cycles;
             _cycleBreakPoints.TriggerMatchingBreakPoints(cycles);
         }


### PR DESCRIPTION
The cost of breakpoint checks account for approx. 4% of the total runtime cost in sampling. This change optimizes the runtime cost when no breakpoints are active.