### PR TITLE
Fix: fix the performance regression in breakpoint handling

### DIFF
--- a/src/Spice86.Core/Emulator/VM/Breakpoint/BreakPoint.cs
+++ b/src/Spice86.Core/Emulator/VM/Breakpoint/BreakPoint.cs
@@ -2,7 +2,6 @@
 
 using Spice86.Shared.Emulator.VM.Breakpoint;
 
-
 /// <summary>
 /// Base class for all breakpoints.
 /// </summary>
@@ -19,10 +18,28 @@ public abstract class BreakPoint {
         IsRemovedOnTrigger = isRemovedOnTrigger;
     }
 
+    private bool _isEnabled = true;
+
     /// <summary>
     /// Gets or sets a value indicating whether this breakpoint can be matched and triggered.
+    /// Setting this property raises <see cref="IsEnabledChanged"/> when the value changes.
     /// </summary>
-    public bool IsEnabled { get; set; } = true;
+    public bool IsEnabled {
+        get => _isEnabled;
+        set {
+            if (_isEnabled == value) {
+                return;
+            }
+
+            _isEnabled = value;
+            IsEnabledChanged?.Invoke(this, value);
+        }
+    }
+
+    /// <summary>
+    /// Occurs when <see cref="IsEnabled"/> changes.
+    /// </summary>
+    internal event Action<BreakPoint, bool>? IsEnabledChanged;
 
     /// <summary>
     /// The action to take when the breakpoint is reached.

--- a/src/Spice86.Core/Emulator/VM/Breakpoint/BreakPointHolder.cs
+++ b/src/Spice86.Core/Emulator/VM/Breakpoint/BreakPointHolder.cs
@@ -7,12 +7,12 @@ using System.Linq;
 /// </summary>
 public class BreakPointHolder {
     private readonly Dictionary<long, List<BreakPoint>> _addressBreakPoints = new(1000);
-
     private readonly List<BreakPoint> _unconditionalBreakPoints = new(1000);
+    private readonly HashSet<BreakPoint> _registeredBreakPoints = [];
     private int _activeBreakpoints;
 
     /// <summary>
-    /// Gets the number of currently active breakpoints.
+    /// Gets a value indicating whether at least one breakpoint is currently enabled.
     /// </summary>
     public bool HasActiveBreakpoints => _activeBreakpoints > 0;
 
@@ -38,12 +38,6 @@ public class BreakPointHolder {
                 ToggleAddressBreakPoint(addressBreakPoint, on);
                 break;
         }
-
-        UpdateActiveBreakPoints();
-    }
-
-    private void UpdateActiveBreakPoints() {
-        _activeBreakpoints = GetAllBreakpoints().Count(x => x.IsEnabled);
     }
 
     private void ToggleAddressBreakPoint(AddressBreakPoint breakPoint, bool on) {
@@ -51,23 +45,36 @@ public class BreakPointHolder {
         _addressBreakPoints.TryGetValue(address, out List<BreakPoint>? breakPointList);
         if (on) {
             if (breakPointList == null) {
-                _addressBreakPoints.Add(address, new List<BreakPoint>() { breakPoint });
-            } else {
-                breakPointList.Add(breakPoint);
+                _addressBreakPoints.Add(address, [breakPoint]);
+                RegisterBreakPoint(breakPoint);
+                return;
             }
-        } else if (breakPointList != null) {
-            breakPointList.Remove(breakPoint);
+
+            if (breakPointList.Contains(breakPoint)) {
+                return;
+            }
+
+            breakPointList.Add(breakPoint);
+            RegisterBreakPoint(breakPoint);
+        } else if (breakPointList != null && breakPointList.Remove(breakPoint)) {
             if (breakPointList.Count == 0) {
                 _addressBreakPoints.Remove(address);
             }
+
+            UnregisterBreakPoint(breakPoint);
         }
     }
 
     private void ToggleUnconditionalBreakPoint(BreakPoint breakPoint, bool on) {
         if (on) {
+            if (_unconditionalBreakPoints.Contains(breakPoint)) {
+                return;
+            }
+
             _unconditionalBreakPoints.Add(breakPoint);
-        } else {
-            _unconditionalBreakPoints.Remove(breakPoint);
+            RegisterBreakPoint(breakPoint);
+        } else if (_unconditionalBreakPoints.Remove(breakPoint)) {
+            UnregisterBreakPoint(breakPoint);
         }
     }
 
@@ -94,20 +101,54 @@ public class BreakPointHolder {
         return triggered;
     }
 
-    private static bool TriggerBreakPointsFromList(List<BreakPoint> breakPointList, long address) {
+    private bool TriggerBreakPointsFromList(List<BreakPoint> breakPointList, long address) {
         bool triggered = false;
         for (int i = 0; i < breakPointList.Count; i++) {
             BreakPoint breakPoint = breakPointList[i];
-            if (breakPoint.Matches(address)) {
-                breakPoint.Trigger();
-                if (breakPoint.IsRemovedOnTrigger) {
-                    breakPointList.Remove(breakPoint);
-                }
+            if (!breakPoint.Matches(address)) {
+                continue;
+            }
 
-                triggered = true;
+            breakPoint.Trigger();
+            triggered = true;
+
+            if (breakPoint.IsRemovedOnTrigger) {
+                breakPointList.RemoveAt(i);
+                UnregisterBreakPoint(breakPoint);
+                i--;
             }
         }
 
         return triggered;
+    }
+
+    private void RegisterBreakPoint(BreakPoint breakPoint) {
+        if (!_registeredBreakPoints.Add(breakPoint)) {
+            return;
+        }
+
+        breakPoint.IsEnabledChanged += OnBreakPointIsEnabledChanged;
+        if (breakPoint.IsEnabled) {
+            _activeBreakpoints++;
+        }
+    }
+
+    private void UnregisterBreakPoint(BreakPoint breakPoint) {
+        if (!_registeredBreakPoints.Remove(breakPoint)) {
+            return;
+        }
+
+        breakPoint.IsEnabledChanged -= OnBreakPointIsEnabledChanged;
+        if (breakPoint.IsEnabled && _activeBreakpoints > 0) {
+            _activeBreakpoints--;
+        }
+    }
+
+    private void OnBreakPointIsEnabledChanged(BreakPoint breakPoint, bool isEnabled) {
+        if (isEnabled) {
+            _activeBreakpoints++;
+        } else if (_activeBreakpoints > 0) {
+            _activeBreakpoints--;
+        }
     }
 }

--- a/tests/Spice86.Tests/BreakPointHolderTests.cs
+++ b/tests/Spice86.Tests/BreakPointHolderTests.cs
@@ -1,0 +1,87 @@
+namespace Spice86.Tests;
+
+using Spice86.Core.Emulator.VM.Breakpoint;
+using Spice86.Shared.Emulator.VM.Breakpoint;
+
+using Xunit;
+
+public class BreakPointHolderTests {
+    [Fact]
+    public void HasActiveBreakpointsTracksEnabledState() {
+        BreakPointHolder holder = new();
+        var breakPoint = new AddressBreakPoint(
+            BreakPointType.CPU_EXECUTION_ADDRESS,
+            0x10,
+            _ => { },
+            false);
+
+        Assert.False(holder.HasActiveBreakpoints);
+
+        holder.ToggleBreakPoint(breakPoint, true);
+        Assert.True(holder.HasActiveBreakpoints);
+
+        breakPoint.IsEnabled = false;
+        Assert.False(holder.HasActiveBreakpoints);
+
+        breakPoint.IsEnabled = true;
+        Assert.True(holder.HasActiveBreakpoints);
+
+        holder.ToggleBreakPoint(breakPoint, false);
+        Assert.False(holder.HasActiveBreakpoints);
+    }
+
+    [Fact]
+    public void RemovalOnTriggerUpdatesActiveBreakpoints() {
+        bool triggered = false;
+        BreakPointHolder holder = new();
+        var breakPoint = new AddressBreakPoint(
+            BreakPointType.CPU_EXECUTION_ADDRESS,
+            0x20,
+            _ => triggered = true,
+            true);
+
+        holder.ToggleBreakPoint(breakPoint, true);
+        Assert.True(holder.HasActiveBreakpoints);
+
+        holder.TriggerMatchingBreakPoints(0x20);
+
+        Assert.True(triggered);
+        Assert.False(holder.HasActiveBreakpoints);
+    }
+
+    [Fact]
+    public void DoubleToggleUnconditionalBreakPointDoesNotLeakActiveCount() {
+        BreakPointHolder holder = new();
+        var breakPoint = new UnconditionalBreakPoint(
+            BreakPointType.CPU_EXECUTION_ADDRESS,
+            _ => { },
+            false);
+
+        holder.ToggleBreakPoint(breakPoint, true);
+        holder.ToggleBreakPoint(breakPoint, true);
+        Assert.True(holder.HasActiveBreakpoints);
+
+        holder.ToggleBreakPoint(breakPoint, false);
+        Assert.False(holder.HasActiveBreakpoints);
+    }
+
+    [Fact]
+    public void AddressBreakPointIsOnlyRegisteredOnce() {
+        int triggerCount = 0;
+        BreakPointHolder holder = new();
+        var breakPoint = new AddressBreakPoint(
+            BreakPointType.CPU_EXECUTION_ADDRESS,
+            0x30,
+            _ => triggerCount++,
+            false);
+
+        holder.ToggleBreakPoint(breakPoint, true);
+        holder.ToggleBreakPoint(breakPoint, true);
+
+        holder.TriggerMatchingBreakPoints(0x30);
+        Assert.Equal(1, triggerCount);
+
+        holder.ToggleBreakPoint(breakPoint, false);
+        Assert.False(holder.HasActiveBreakpoints);
+    }
+}


### PR DESCRIPTION
Fixes the performance regression and avoids registering the same breakpoint multiple times.

I could not change the List to a HashSet because breakpoints can remove themselves, which would cause exceptions.