### PR TITLE
Fix: Make performance measurement self-containing

### DIFF
--- a/src/Spice86.Shared/Diagnostics/PerformanceMeasureOptions.cs
+++ b/src/Spice86.Shared/Diagnostics/PerformanceMeasureOptions.cs
@@ -1,0 +1,28 @@
+﻿namespace Spice86.Shared.Diagnostics;
+
+/// <summary>
+///     Configures sampling behavior for <see cref="PerformanceMeasurer" /> instances.
+/// </summary>
+public sealed record PerformanceMeasureOptions {
+    /// <summary>
+    ///     Gets the default set of options (no throttling).
+    /// </summary>
+    public static PerformanceMeasureOptions Default { get; } = new();
+
+    /// <summary>
+    ///     Gets or inits how many <see cref="PerformanceMeasurer.UpdateValue(long)" /> calls should occur before
+    ///     expensive calculations run. A value of 1 disables interval-based throttling.
+    /// </summary>
+    public int CheckInterval { get; init; } = 1;
+
+    /// <summary>
+    ///     Gets or inits the minimum delta between measurements required to trigger a recalculation.
+    /// </summary>
+    public long MinValueDelta { get; init; }
+
+    /// <summary>
+    ///     Gets or inits the maximum amount of time (in milliseconds) allowed between recalculations.
+    ///     A value of 0 disables the time-based guard.
+    /// </summary>
+    public int MaxIntervalMilliseconds { get; init; }
+}

--- a/src/Spice86.Shared/Diagnostics/PerformanceMeasurer.cs
+++ b/src/Spice86.Shared/Diagnostics/PerformanceMeasurer.cs
@@ -4,8 +4,36 @@ using Spice86.Shared.Interfaces;
 
 /// <inheritdoc cref="IPerformanceMeasureReader" />
 public class PerformanceMeasurer : IPerformanceMeasureReader, IPerformanceMeasureWriter {
-    private long _measure;
+    private const int WindowSizeInSeconds = 30;
+    private readonly int _checkInterval;
+    private readonly bool _hasSamplingConstraints;
+    private readonly int _maxIntervalMilliseconds;
+    private readonly long _minValueDelta;
+    private long _firstMeasureTimeInMilliseconds;
     private long _lastTimeInMilliseconds;
+
+    private long _measure;
+    private int _samplingCountdown;
+
+    /// <summary>
+    ///     Initializes a new instance.
+    /// </summary>
+    public PerformanceMeasurer()
+        : this(PerformanceMeasureOptions.Default) {
+    }
+
+    /// <summary>
+    ///     Initializes a new instance with custom sampling options.
+    /// </summary>
+    /// <param name="options">Sampling options that control how frequently expensive calculations run.</param>
+    public PerformanceMeasurer(PerformanceMeasureOptions? options) {
+        PerformanceMeasureOptions sanitized = options ?? PerformanceMeasureOptions.Default;
+        _checkInterval = Math.Max(1, sanitized.CheckInterval);
+        _minValueDelta = Math.Max(0, sanitized.MinValueDelta);
+        _maxIntervalMilliseconds = Math.Max(0, sanitized.MaxIntervalMilliseconds);
+        _hasSamplingConstraints = _checkInterval > 1 || _minValueDelta > 0 || _maxIntervalMilliseconds > 0;
+        _samplingCountdown = _hasSamplingConstraints ? 1 : 0;
+    }
 
     /// <inheritdoc />
     public long ValuePerMillisecond { get; private set; }
@@ -16,31 +44,20 @@ public class PerformanceMeasurer : IPerformanceMeasureReader, IPerformanceMeasur
     /// <inheritdoc />
     public long AverageValuePerSecond { get; private set; }
 
-    /// <summary>
-    /// Initializes a new instance
-    /// </summary>
-    public PerformanceMeasurer() => _lastTimeInMilliseconds = GetCurrentTime();
-
-    private long _firstMeasureTimeInMilliseconds = 0;
-
-    private const int WindowSizeInSeconds = 30;
-
-    private static long GetCurrentTime() {
-        return Environment.TickCount64;
-    }
-
     /// <inheritdoc />
     public void UpdateValue(long newMeasure) {
         long newTimeInMilliseconds = GetCurrentTime();
         if (IsFirstMeasurement()) {
-            _firstMeasureTimeInMilliseconds = newTimeInMilliseconds;
-            _lastTimeInMilliseconds = newTimeInMilliseconds;
-            _measure = newMeasure;
+            InitializeFirstMeasurement(newMeasure, newTimeInMilliseconds);
             return;
         }
 
         if (IsLastMeasurementExpired(newTimeInMilliseconds)) {
             ResetMetrics(newTimeInMilliseconds, newMeasure);
+            return;
+        }
+
+        if (!ShouldProcessSample(newMeasure, newTimeInMilliseconds)) {
             return;
         }
 
@@ -59,8 +76,37 @@ public class PerformanceMeasurer : IPerformanceMeasureReader, IPerformanceMeasur
             : SmoothingAverage(AverageValuePerSecond, valuePerSecond);
     }
 
+    private static long GetCurrentTime() {
+        return Environment.TickCount64;
+    }
+
+    private bool ShouldProcessSample(long newMeasure, long newTimeInMilliseconds) {
+        if (!_hasSamplingConstraints) {
+            return true;
+        }
+
+        if (--_samplingCountdown > 0) {
+            return false;
+        }
+
+        ResetSamplingCountdown();
+
+        long valueDelta = newMeasure - _measure;
+        long timeDelta = newTimeInMilliseconds - _lastTimeInMilliseconds;
+        return valueDelta >= _minValueDelta || (_maxIntervalMilliseconds != 0 && timeDelta >= _maxIntervalMilliseconds);
+    }
+
     private bool IsFirstMeasurement() {
         return _firstMeasureTimeInMilliseconds == 0;
+    }
+
+    private void InitializeFirstMeasurement(long newMeasure, long newTimeInMilliseconds) {
+        _firstMeasureTimeInMilliseconds = newTimeInMilliseconds;
+        _measure = newMeasure;
+        _lastTimeInMilliseconds = newTimeInMilliseconds;
+        ValuePerMillisecond = 0;
+        AverageValuePerSecond = 0;
+        ResetSamplingCountdown();
     }
 
     private void ResetMetrics(long newTimeInMilliseconds, long newMeasure) {
@@ -69,13 +115,21 @@ public class PerformanceMeasurer : IPerformanceMeasureReader, IPerformanceMeasur
         _lastTimeInMilliseconds = newTimeInMilliseconds;
         ValuePerMillisecond = 0;
         AverageValuePerSecond = 0;
+        ResetSamplingCountdown();
     }
 
-    private bool IsLastMeasurementExpired(long newTimeInMilliseconds) =>
-        newTimeInMilliseconds - _firstMeasureTimeInMilliseconds > WindowSizeInSeconds * 1000;
+    private void ResetSamplingCountdown() {
+        if (_hasSamplingConstraints) {
+            _samplingCountdown = _checkInterval;
+        }
+    }
+
+    private bool IsLastMeasurementExpired(long newTimeInMilliseconds) {
+        return newTimeInMilliseconds - _firstMeasureTimeInMilliseconds > WindowSizeInSeconds * 1000;
+    }
 
     private static long SmoothingAverage(long currentAverage, long latestValuePerSecond) {
-        const double alpha = 0.2;
+        const double alpha = 0.2; // Exponential smoothing factor (20% weight for latest value).
         return (long)((currentAverage * (1 - alpha)) + (latestValuePerSecond * alpha));
     }
 }


### PR DESCRIPTION
The measurement-logic is now self-contained, added a comment regarding the alpha.
Thx @kevinferrare for the hint.