### PR TITLE
Feature: mouse capture to main Window

### DIFF
--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -58,6 +58,7 @@
     <PackageVersion Include="Xaml.Behaviors.Avalonia" Version="12.0.0" />
     <PackageVersion Include="Spice86.Audio" Version="11.4.0" />
     <PackageVersion Include="FastExpressionCompiler" Version="5.4.1" />
+    <PackageVersion Include="Silk.NET.SDL" Version="2.23.0" />
     <PackageVersion Include="Tmds.DBus.Protocol" Version="0.92.0" />
   </ItemGroup>
 </Project>

--- a/src/Spice86/App.axaml.cs
+++ b/src/Spice86/App.axaml.cs
@@ -53,11 +53,6 @@ internal partial class App : Application {
                 desktop.Args!)!;
         Spice86DependencyInjection dependencyInjection = new(configuration, mainWindow);
         if (mainWindow.DataContext is MainWindowViewModel mainVm) {
-            mainVm.CloseMainWindow += (_, _) => mainWindow.Close();
-            mainVm.InvalidateBitmap += mainWindow.Image.InvalidateVisual;
-            mainWindow.Image.PointerMoved += (s, e) => mainVm.OnMouseMoved(e, mainWindow.Image);
-            mainWindow.Image.PointerPressed += (s, e) => mainVm.OnMouseButtonDown(e, mainWindow.Image);
-            mainWindow.Image.PointerReleased += (s, e) => mainVm.OnMouseButtonUp(e, mainWindow.Image);
             mainVm.Disposing += dependencyInjection.Dispose;
         }
         desktop.MainWindow = mainWindow;

--- a/src/Spice86/Native/IMouseCaptureBackend.cs
+++ b/src/Spice86/Native/IMouseCaptureBackend.cs
@@ -1,0 +1,47 @@
+namespace Spice86.Native;
+
+using System;
+
+/// <summary>
+/// Abstraction over platform-specific mouse capture strategies.
+/// </summary>
+internal interface IMouseCaptureBackend : IDisposable {
+    /// <summary>
+    /// Gets a value indicating whether mouse capture is currently active.
+    /// </summary>
+    bool IsCaptured { get; }
+
+    /// <summary>
+    /// Gets a value indicating whether this backend hides the cursor and reports only relative
+    /// mouse deltas (e.g. SDL relative mode). When <see langword="false"/>, the cursor remains
+    /// visible and the host Avalonia pointer events continue to carry absolute coordinates.
+    /// </summary>
+    bool UsesRelativeMouseMode { get; }
+
+    /// <summary>
+    /// Performs any one-time platform initialisation required before
+    /// <see cref="EnableCapture"/> or <see cref="DisableCapture"/> may be called.
+    /// </summary>
+    /// <param name="nativeWindowHandle">
+    /// The platform-native window handle (HWND on Windows, X11 Window ID on Linux, NSWindow* on macOS).
+    /// </param>
+    /// <returns><see langword="true"/> if initialisation succeeded; otherwise <see langword="false"/>.</returns>
+    bool TryInitialize(nint nativeWindowHandle);
+
+    /// <summary>Enables mouse capture.</summary>
+    /// <returns><see langword="true"/> if capture was successfully enabled.</returns>
+    bool EnableCapture();
+
+    /// <summary>Disables mouse capture.</summary>
+    /// <returns><see langword="true"/> if capture was successfully disabled.</returns>
+    bool DisableCapture();
+
+    /// <summary>
+    /// Returns the accumulated relative mouse motion since the last call.
+    /// Always returns <c>(0, 0)</c> for backends where <see cref="UsesRelativeMouseMode"/> is
+    /// <see langword="false"/>.
+    /// </summary>
+    /// <param name="dx">Horizontal delta in pixels (positive = right).</param>
+    /// <param name="dy">Vertical delta in pixels (positive = down).</param>
+    void GetRelativeMouseDelta(out int dx, out int dy);
+}

--- a/src/Spice86/Native/SdlMouseCapture.cs
+++ b/src/Spice86/Native/SdlMouseCapture.cs
@@ -1,0 +1,161 @@
+namespace Spice86.Native;
+
+using Silk.NET.SDL;
+
+using System;
+using System.IO;
+
+/// <summary>
+/// SDL2-based mouse capture backend for non-Windows platforms.
+/// Uses <c>SDL_SetRelativeMouseMode</c> to hide the cursor and report relative mouse deltas,
+/// analogous to the approach used in dosbox-staging.
+/// Precompiled SDL2 native libraries are bundled via Silk.NET.SDL (Ultz.Native.SDL),
+/// covering macOS (universal) and Linux (x64/arm64/arm).
+/// </summary>
+internal sealed class SdlMouseCapture : IMouseCaptureBackend {
+    private Sdl? _sdl;
+    private bool _initialized;
+    private bool _isCaptured;
+    private bool _disposed;
+
+    /// <summary>
+    /// Gets a value indicating whether the SDL subsystem was successfully initialized.
+    /// </summary>
+    public bool IsInitialized => _initialized;
+
+    /// <summary>
+    /// Gets a value indicating whether relative mouse capture is currently active.
+    /// </summary>
+    public bool IsCaptured => _isCaptured;
+
+    /// <inheritdoc/>
+    /// <remarks><see langword="true"/>: cursor is hidden and only deltas are reported.</remarks>
+    public bool UsesRelativeMouseMode => true;
+
+    /// <summary>
+    /// Initializes the SDL video subsystem.
+    /// If the SDL2 native library is unavailable, this returns <see langword="false"/> without throwing.
+    /// </summary>
+    /// <param name="nativeWindowHandle">The platform-native window handle (HWND on Windows, X11 Window ID on Linux, NSWindow* on macOS).</param>
+    /// <returns><see langword="true"/> if initialization succeeded; otherwise <see langword="false"/>.</returns>
+    public bool TryInitialize(nint nativeWindowHandle) {
+        if (_initialized) {
+            return true;
+        }
+
+        if (nativeWindowHandle == nint.Zero) {
+            return false;
+        }
+
+        try {
+            _sdl = Sdl.GetApi();
+        } catch (FileNotFoundException) {
+            return false;
+        } catch (DllNotFoundException) {
+            return false;
+        }
+
+        // Suppress SDL's default signal handlers so they don't interfere with the host app.
+        _sdl.SetHint("SDL_NO_SIGNAL_HANDLERS", "1");
+
+        // Initialize only the video subsystem so SDL can manage mouse state.
+        int result = _sdl.Init(Sdl.InitVideo);
+        if (result != 0) {
+            _sdl.Dispose();
+            _sdl = null;
+            return false;
+        }
+
+        _initialized = true;
+        return true;
+    }
+
+    /// <summary>
+    /// Enables SDL relative mouse mode.
+    /// The cursor is hidden and mouse motion is reported as relative deltas only.
+    /// </summary>
+    /// <returns><see langword="true"/> if relative mode was enabled successfully.</returns>
+    public bool EnableCapture() {
+        if (!_initialized || _isCaptured || _sdl is null) {
+            return false;
+        }
+
+        int result = _sdl.SetRelativeMouseMode(SdlBool.True);
+        if (result != 0) {
+            return false;
+        }
+
+        _isCaptured = true;
+        return true;
+    }
+
+    /// <summary>
+    /// Disables SDL relative mouse mode, restoring normal cursor behaviour.
+    /// </summary>
+    /// <returns><see langword="true"/> if relative mode was disabled successfully.</returns>
+    public bool DisableCapture() {
+        if (!_initialized || !_isCaptured || _sdl is null) {
+            return false;
+        }
+
+        int result = _sdl.SetRelativeMouseMode(SdlBool.False);
+        if (result != 0) {
+            return false;
+        }
+
+        _isCaptured = false;
+        return true;
+    }
+
+    /// <summary>
+    /// Retrieves the accumulated relative mouse motion since the last call.
+    /// Analogous to SDL_GetRelativeMouseState used in dosbox-staging.
+    /// </summary>
+    /// <param name="dx">Horizontal delta in screen pixels (positive = right).</param>
+    /// <param name="dy">Vertical delta in screen pixels (positive = down).</param>
+    public void GetRelativeMouseDelta(out int dx, out int dy) {
+        if (!_initialized || _sdl is null) {
+            dx = 0;
+            dy = 0;
+            return;
+        }
+
+        // SDL_PumpEvents processes pending OS events so GetRelativeMouseState is up to date.
+        _sdl.PumpEvents();
+
+        int x = 0;
+        int y = 0;
+        unsafe {
+            _sdl.GetRelativeMouseState(&x, &y);
+        }
+
+        dx = x;
+        dy = y;
+    }
+
+    /// <inheritdoc/>
+    public void Dispose() {
+        if (_disposed) {
+            return;
+        }
+
+        _disposed = true;
+
+        if (_sdl is null) {
+            return;
+        }
+
+        if (_isCaptured) {
+            _sdl.SetRelativeMouseMode(SdlBool.False);
+            _isCaptured = false;
+        }
+
+        if (_initialized) {
+            _sdl.QuitSubSystem(Sdl.InitVideo);
+            _initialized = false;
+        }
+
+        _sdl.Dispose();
+        _sdl = null;
+    }
+}

--- a/src/Spice86/Native/SdlMouseCapture.cs
+++ b/src/Spice86/Native/SdlMouseCapture.cs
@@ -7,8 +7,7 @@ using System.IO;
 
 /// <summary>
 /// SDL2-based mouse capture backend for non-Windows platforms.
-/// Uses <c>SDL_SetRelativeMouseMode</c> to hide the cursor and report relative mouse deltas,
-/// analogous to the approach used in dosbox-staging.
+/// Uses <c>SDL_SetRelativeMouseMode</c> to hide the cursor and report relative mouse deltas.
 /// Precompiled SDL2 native libraries are bundled via Silk.NET.SDL (Ultz.Native.SDL),
 /// covering macOS (universal) and Linux (x64/arm64/arm).
 /// </summary>

--- a/src/Spice86/Native/WindowsMouseCaptureBackend.cs
+++ b/src/Spice86/Native/WindowsMouseCaptureBackend.cs
@@ -1,0 +1,109 @@
+namespace Spice86.Native;
+
+using System;
+
+/// <summary>
+/// Windows-specific mouse capture backend. Uses <c>ClipCursor</c> to confine the cursor
+/// to the emulator window, and <c>SetCapture</c>/<c>ReleaseCapture</c> to ensure mouse
+/// messages continue reaching the window even when the cursor temporarily touches an edge.
+/// Avalonia <c>PointerMoved</c> events still fire with absolute window-relative coordinates
+/// — no delta polling is required.
+/// </summary>
+internal sealed class WindowsMouseCaptureBackend : IMouseCaptureBackend {
+    private nint _windowHandle;
+    private bool _isCaptured;
+    private bool _disposed;
+
+    /// <inheritdoc/>
+    public bool IsCaptured => _isCaptured;
+
+    /// <inheritdoc/>
+    /// <remarks>
+    /// <see langword="false"/>: the cursor remains visible and Avalonia pointer events carry
+    /// absolute coordinates. The host window simply clips the cursor to its bounds.
+    /// </remarks>
+    public bool UsesRelativeMouseMode => false;
+
+    /// <inheritdoc/>
+    public bool TryInitialize(nint nativeWindowHandle) {
+        if (nativeWindowHandle == nint.Zero) {
+            return false;
+        }
+
+        _windowHandle = nativeWindowHandle;
+        return true;
+    }
+
+    /// <inheritdoc/>
+    /// <remarks>
+    /// May be called repeatedly (e.g. on window move/resize) to refresh the clip rectangle.
+    /// </remarks>
+    public bool EnableCapture() {
+        if (_windowHandle == nint.Zero) {
+            return false;
+        }
+
+        bool gotClientRect = WindowsMouseCaptureInterop.GetClientRect(_windowHandle, out WindowsMouseCaptureInterop.ClipRect clientRect);
+        if (!gotClientRect) {
+            return false;
+        }
+
+        WindowsMouseCaptureInterop.WinPoint topLeft = new WindowsMouseCaptureInterop.WinPoint { X = clientRect.Left, Y = clientRect.Top };
+        WindowsMouseCaptureInterop.WinPoint bottomRight = new WindowsMouseCaptureInterop.WinPoint { X = clientRect.Right, Y = clientRect.Bottom };
+
+        bool topLeftConverted = WindowsMouseCaptureInterop.ClientToScreen(_windowHandle, ref topLeft);
+        if (!topLeftConverted) {
+            return false;
+        }
+
+        bool bottomRightConverted = WindowsMouseCaptureInterop.ClientToScreen(_windowHandle, ref bottomRight);
+        if (!bottomRightConverted) {
+            return false;
+        }
+
+        WindowsMouseCaptureInterop.ClipRect screenRect = new WindowsMouseCaptureInterop.ClipRect {
+            Left = topLeft.X,
+            Top = topLeft.Y,
+            Right = bottomRight.X,
+            Bottom = bottomRight.Y
+        };
+
+        WindowsMouseCaptureInterop.SetCapture(_windowHandle);
+        bool clipResult = WindowsMouseCaptureInterop.ClipCursor(ref screenRect);
+        if (clipResult) {
+            _isCaptured = true;
+        }
+
+        return clipResult;
+    }
+
+    /// <inheritdoc/>
+    public bool DisableCapture() {
+        WindowsMouseCaptureInterop.ReleaseCapture();
+        bool clipResult = WindowsMouseCaptureInterop.ClipCursor(IntPtr.Zero);
+        _isCaptured = false;
+        return clipResult;
+    }
+
+    /// <inheritdoc/>
+    /// <remarks>
+    /// Always returns <c>(0, 0)</c>: absolute coordinates come from Avalonia pointer events.
+    /// </remarks>
+    public void GetRelativeMouseDelta(out int dx, out int dy) {
+        dx = 0;
+        dy = 0;
+    }
+
+    /// <inheritdoc/>
+    public void Dispose() {
+        if (_disposed) {
+            return;
+        }
+
+        _disposed = true;
+
+        if (_isCaptured) {
+            DisableCapture();
+        }
+    }
+}

--- a/src/Spice86/Native/WindowsMouseCaptureInterop.cs
+++ b/src/Spice86/Native/WindowsMouseCaptureInterop.cs
@@ -1,0 +1,54 @@
+namespace Spice86.Native;
+
+using System;
+using System.Runtime.InteropServices;
+
+/// <summary>
+/// Windows user32.dll P/Invoke declarations used by <see cref="WindowsMouseCaptureBackend"/>.
+/// </summary>
+internal static partial class WindowsMouseCaptureInterop {
+    /// <summary>Screen-coordinate rectangle used by <see cref="ClipCursor(ref ClipRect)"/>.</summary>
+    [StructLayout(LayoutKind.Sequential)]
+    internal struct ClipRect {
+        public int Left;
+        public int Top;
+        public int Right;
+        public int Bottom;
+    }
+
+    /// <summary>Point structure used by <see cref="ClientToScreen"/>.</summary>
+    [StructLayout(LayoutKind.Sequential)]
+    internal struct WinPoint {
+        public int X;
+        public int Y;
+    }
+
+    /// <summary>Confines the cursor to the supplied rectangle (screen coordinates).</summary>
+    [LibraryImport("user32.dll", SetLastError = true, EntryPoint = "ClipCursor")]
+    [return: MarshalAs(UnmanagedType.Bool)]
+    internal static partial bool ClipCursor(ref ClipRect rect);
+
+    /// <summary>Removes the cursor clipping rectangle.</summary>
+    [LibraryImport("user32.dll", SetLastError = true, EntryPoint = "ClipCursor")]
+    [return: MarshalAs(UnmanagedType.Bool)]
+    internal static partial bool ClipCursor(IntPtr rect);
+
+    /// <summary>Retrieves the client-area bounding rectangle of the specified window.</summary>
+    [LibraryImport("user32.dll", SetLastError = true)]
+    [return: MarshalAs(UnmanagedType.Bool)]
+    internal static partial bool GetClientRect(IntPtr hWnd, out ClipRect lpRect);
+
+    /// <summary>Converts a client-area coordinate to screen coordinates.</summary>
+    [LibraryImport("user32.dll", SetLastError = true)]
+    [return: MarshalAs(UnmanagedType.Bool)]
+    internal static partial bool ClientToScreen(IntPtr hWnd, ref WinPoint lpPoint);
+
+    /// <summary>Sets the mouse capture to the specified window.</summary>
+    [LibraryImport("user32.dll", SetLastError = true)]
+    internal static partial IntPtr SetCapture(IntPtr hWnd);
+
+    /// <summary>Releases mouse capture from a window.</summary>
+    [LibraryImport("user32.dll", SetLastError = true)]
+    [return: MarshalAs(UnmanagedType.Bool)]
+    internal static partial bool ReleaseCapture();
+}

--- a/src/Spice86/Spice86.csproj
+++ b/src/Spice86/Spice86.csproj
@@ -40,6 +40,7 @@
         <PackageReference Include="JvE.Structurizer" />
         <PackageReference Include="Semi.Avalonia" />
         <PackageReference Include="Semi.Avalonia.Dock" />
+        <PackageReference Include="Silk.NET.SDL" />
         <PackageReference Include="Spice86.DataGrid" />
         <PackageReference Include="Xaml.Behaviors.Avalonia" />
     </ItemGroup>
@@ -54,6 +55,9 @@
     <ItemGroup>
         <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleTo">
             <_Parameter1>Spice86.Tests</_Parameter1>
+        </AssemblyAttribute>
+        <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleTo">
+            <_Parameter1>Spice86.Tests.UI</_Parameter1>
         </AssemblyAttribute>
     </ItemGroup>
 </Project>

--- a/src/Spice86/ViewModels/MainWindowViewModel.cs
+++ b/src/Spice86/ViewModels/MainWindowViewModel.cs
@@ -199,16 +199,6 @@ public sealed partial class MainWindowViewModel : ViewModelWithErrorDialog, IGui
         }
     }
 
-    private double? _scale = 1;
-
-    public double? Scale {
-        get => _scale;
-        set {
-            ValidateRequiredPropertyIsNotNull(value);
-            SetProperty(ref _scale, Math.Max(value ?? 0, 1));
-        }
-    }
-
     /// <summary>
     /// The aspect ratio correction factor for the current video mode.
     /// Controls vertical scaling: 1.0 = square pixels, 1.2 = DOS VGA correction.
@@ -284,10 +274,24 @@ public sealed partial class MainWindowViewModel : ViewModelWithErrorDialog, IGui
         UpdateShownEmulatorMouseCursorPosition();
     }
 
+    /// <summary>
+    /// Called by the SDL capture backend when in relative mouse mode.
+    /// Accepts pre-normalised coordinates (0..1 range) instead of Avalonia pointer event data.
+    /// </summary>
+    internal void OnMouseMovedNormalized(double x, double y) {
+        if (_pauseHandler.IsPaused) {
+            return;
+        }
+
+        MouseX = x;
+        MouseY = y;
+        MouseMoved?.Invoke(this, new MouseMoveEventArgs(x, y));
+        UpdateShownEmulatorMouseCursorPosition();
+    }
+
     public void SetResolution(int width, int height) {
         _uiDispatcher.Post(() => {
             _isSettingResolution = true;
-            Scale = 1;
             if (Width != width || Height != height) {
                 Width = width;
                 Height = height;
@@ -345,13 +349,27 @@ public sealed partial class MainWindowViewModel : ViewModelWithErrorDialog, IGui
     private void SetMainTitle(double instructionsPerMillisecond) {
         string currentProgramName = _currentProcessNameProvider.CurrentProgramName;
         if (string.IsNullOrEmpty(currentProgramName)) {
-            MainTitle = $"{nameof(Spice86)} {Configuration.Exe} - cycles/ms: {instructionsPerMillisecond,7:N0}";
+            MainTitle = $"{nameof(Spice86)} {Configuration.Exe} - cycles/ms: {instructionsPerMillisecond,7:N0}{MouseCaptureHint}";
         } else {
-            MainTitle = $"{nameof(Spice86)} {Configuration.Exe} - {currentProgramName} - cycles/ms: {instructionsPerMillisecond,7:N0}";
+            MainTitle = $"{nameof(Spice86)} {Configuration.Exe} - {currentProgramName} - cycles/ms: {instructionsPerMillisecond,7:N0}{MouseCaptureHint}";
         }
     }
 
     [ObservableProperty] private string? _mainTitle;
+
+    [ObservableProperty] private bool _isMouseCaptured;
+
+    [ObservableProperty] private string _mouseCaptureHint = string.Empty;
+
+    internal void UpdateMouseCaptureHint(bool isCaptured) {
+        IsMouseCaptured = isCaptured;
+        if (isCaptured) {
+            MouseCaptureHint = " | Mouse captured (middle click to release)";
+        } else {
+            MouseCaptureHint = " | Mouse free (middle click to capture)";
+        }
+        RefreshMainTitleWithInstructionsPerMs();
+    }
 
     private double? _timeMultiplier = 1;
 

--- a/src/Spice86/Views/DebugWindow.axaml
+++ b/src/Spice86/Views/DebugWindow.axaml
@@ -70,7 +70,7 @@
 			</dock:DockControl.Factory>
 			<dockModel:RootDock IsCollapsable="False">
 				<dockModel:DocumentDock CanCreateDocument="False">
-					<dockModel:Document Id="Disassembly" Title="Disassembly (Alt-F1)" HotKeyManager.HotKey="Alt+F1">
+					<dockModel:Document Id="Disassembly" Title="Disassembly" HotKeyManager.HotKey="Alt+F1">
 						<TabControl ItemsSource="{Binding $parent[Window].DataContext.DisassemblyViewModels}">
 							<TabControl.ItemTemplate>
 								<DataTemplate DataType="{x:Type vm:DisassemblyViewModel}">
@@ -86,18 +86,18 @@
 					</dockModel:Document>
 					<dockModel:Document
 					Id="CodeFlow"
-					Title="Code Flow (Alt-F2)"
+					Title="Code Flow"
 					HotKeyManager.HotKey="Alt+F2">
 						<ContentPresenter
 						Content="{Binding $parent[Window].DataContext.CfgCpuViewModel}" />
 					</dockModel:Document>
 					<dockModel:Document
 					Id="Cpu"
-					Title="CPU (Alt-F3)"
+					Title="CPU"
 					HotKeyManager.HotKey="Alt+F3">
 						<ContentPresenter Content="{Binding $parent[Window].DataContext.CpuViewModel}" />
 					</dockModel:Document>
-					<dockModel:Document Id="Memory" Title="Memory (Alt-F4)" HotKeyManager.HotKey="Alt+F4">
+					<dockModel:Document Id="Memory" Title="Memory" HotKeyManager.HotKey="Alt+F4">
 						<TabControl ItemsSource="{Binding $parent[Window].DataContext.MemoryViewModels}">
 							<TabControl.ItemTemplate>
 								<DataTemplate DataType="{x:Type vm:MemoryViewModel}">
@@ -106,17 +106,17 @@
 							</TabControl.ItemTemplate>
 						</TabControl>
 					</dockModel:Document>
-					<dockModel:Document Id="Devices" Title="Devices (Alt-F5)" HotKeyManager.HotKey="Alt+F5">
+					<dockModel:Document Id="Devices" Title="Devices" HotKeyManager.HotKey="Alt+F5">
 						<TabControl DataContext="{Binding $parent[Window].DataContext}">
-							<controls:HotKeyTabItem HotKeyManager.HotKey="Alt+F7" Header="Video Card" ToolTip.Tip="Alt-F7" Content="{Binding VideoCardViewModel}" />
-							<controls:HotKeyTabItem HotKeyManager.HotKey="Alt+F8" Header="Color Palette" ToolTip.Tip="Alt-F8" Content="{Binding PaletteViewModel}" />
-							<controls:HotKeyTabItem HotKeyManager.HotKey="Alt+F9" Header="General MIDI / MT-32" ToolTip.Tip="Alt-F9" Content="{Binding MidiViewModel}" />
+							<controls:HotKeyTabItem HotKeyManager.HotKey="Alt+F7" Header="Video Card" Content="{Binding VideoCardViewModel}" />
+							<controls:HotKeyTabItem HotKeyManager.HotKey="Alt+F8" Header="Color Palette" Content="{Binding PaletteViewModel}" />
+							<controls:HotKeyTabItem HotKeyManager.HotKey="Alt+F9" Header="General MIDI / MT-32" Content="{Binding MidiViewModel}" />
 
 						</TabControl>
 					</dockModel:Document>
 					<dockModel:Document
 					Id="Breakpoints"
-					Title="Breakpoints (Alt-F6)"
+					Title="Breakpoints"
 					HotKeyManager.HotKey="Alt+F6">
 						<ContentPresenter Content="{Binding $parent[Window].DataContext.BreakpointsViewModel}" />
 					</dockModel:Document>

--- a/src/Spice86/Views/MainWindow.axaml
+++ b/src/Spice86/Views/MainWindow.axaml
@@ -32,7 +32,7 @@
 		<vm:MainWindowViewModel />
 	</Design.DataContext>
 	<Grid RowDefinitions="Auto,*,Auto">
-		<Grid IsTabStop="False" Focusable="False" Grid.ColumnDefinitions="Auto,Auto" Grid.Row="0">
+		<Grid x:Name="TopBar" IsTabStop="False" Focusable="False" Grid.ColumnDefinitions="Auto,Auto" Grid.Row="0">
 			<Menu Grid.Column="0" Name="Menu" Focusable="False" IsTabStop="False" IsVisible="{Binding !IsDialogVisible}">
 				<MenuItem Header="Debug">
 					<MenuItem HotKey="Ctrl+Alt+F2" ToolTip.Tip="Ctrl+Alt+F2" IsEnabled="{Binding IsEmulatorRunning}">
@@ -95,14 +95,6 @@
 				<MenuItem Header="Video" IsEnabled="{Binding IsEmulatorRunning}">
 					<MenuItem>
 						<MenuItem.Header>
-							<StackPanel Orientation="Horizontal">
-								<Label Content="Scale" VerticalAlignment="Center" HorizontalContentAlignment="Center" />
-								<NumericUpDown Text="{Binding Scale}" FormatString="0" Minimum="0" Margin="5,0,0,0" />
-							</StackPanel>
-						</MenuItem.Header>
-					</MenuItem>
-					<MenuItem>
-						<MenuItem.Header>
 							<CheckBox Content="Show Cursor" IsChecked="{Binding ShowCursor}" />
 						</MenuItem.Header>
 					</MenuItem>
@@ -129,7 +121,7 @@
 			<StackPanel Grid.Column="1" Focusable="False" IsTabStop="False" IsEnabled="{Binding IsEmulatorRunning}" Grid.Row="0" Margin="160,0,0,0" HorizontalAlignment="Left" VerticalAlignment="Top" Orientation="Horizontal">
 				<Label IsVisible="{Binding ShowCyclesLimitingUI}" Focusable="False" IsTabStop="False" VerticalAlignment="Center" Content="Cycles/ms:" />
 				<Button IsVisible="{Binding ShowCyclesLimitingUI}" Margin="10,0,5,0" HotKey="Ctrl+F11" Focusable="False" IsTabStop="False" IsEnabled="{Binding !IsPaused}" Command="{Binding DecreaseTargetCyclesCommand}" Content="-" />
-				<NumericUpDown IsVisible="{Binding ShowCyclesLimitingUI}" Focusable="False" IsTabStop="False" FormatString="0" IsReadOnly="True" IsEnabled="{Binding !IsPaused}" Text="{Binding TargetCyclesPerMs, FallbackValue=1}" Minimum="100" Maximum="60000" />
+				<NumericUpDown x:Name="CyclesLimitingNumericUpDown" IsVisible="{Binding ShowCyclesLimitingUI}" Focusable="False" IsTabStop="False" FormatString="0" IsReadOnly="True" IsEnabled="{Binding !IsPaused}" Text="{Binding TargetCyclesPerMs, FallbackValue=1}" Minimum="100" Maximum="60000" />
 				<Button IsVisible="{Binding ShowCyclesLimitingUI}" Margin="5,0,10,0" HotKey="Ctrl+F12" Focusable="False" IsTabStop="False" IsEnabled="{Binding !IsPaused}" Command="{Binding IncreaseTargetCyclesCommand}" Content="+" />
 				<Button Focusable="False" IsTabStop="False" Command="{Binding PauseCommand}" Margin="5,0,5,0" ToolTip.Tip="Pause (Ctrl+Shift+F5)" HotKey="Ctrl+Shift+F5" IsVisible="{Binding !IsPaused}">
 					<fluent:SymbolIcon Symbol="Pause" />
@@ -138,22 +130,18 @@
 					<fluent:SymbolIcon Symbol="Play" />
 				</Button>
 				<Label Focusable="False" IsTabStop="False" VerticalAlignment="Center" Content="Time Modifier:" />
-				<NumericUpDown FormatString="0" Focusable="False" IsTabStop="False" Margin="5,0,5,0" Value="{Binding TimeMultiplier, FallbackValue=1}" Minimum="1" />
+				<NumericUpDown x:Name="TimeMultiplierNumericUpDown" FormatString="0" Focusable="False" IsTabStop="False" Margin="5,0,5,0" Value="{Binding TimeMultiplier, FallbackValue=1}" Minimum="1" />
 				<Button Focusable="False" IsTabStop="False" Margin="2,0,5,0" HotKey="F4" Command="{Binding ResetTimeMultiplierCommand}">
 					<fluent:SymbolIcon Symbol="ArrowReset" />
 				</Button>
 			</StackPanel>
 		</Grid>
-		<Viewbox Grid.Row="1">
+		<Viewbox Name="ScreenView" Grid.Row="1">
 			<LayoutTransformControl>
 				<LayoutTransformControl.LayoutTransform>
 					<TransformGroup>
 						<!-- Dynamic aspect ratio correction based on current video mode -->
 						<ScaleTransform ScaleX="1" ScaleY="{Binding AspectRatioCorrectionFactor}" />
-						<ScaleTransform
-						ScaleX="{Binding Scale}"
-						ScaleY="{Binding Scale}">
-						</ScaleTransform>
 					</TransformGroup>
 				</LayoutTransformControl.LayoutTransform>
 				<Image x:Name="Image"
@@ -162,7 +150,7 @@
 					   Source="{Binding Bitmap}" />
 			</LayoutTransformControl>
 		</Viewbox>
-		<controls:StatusBar IsTabStop="False" Focusable="False" VerticalAlignment="Bottom" Grid.Row="2">
+		<controls:StatusBar x:Name="BottomBar" IsTabStop="False" Focusable="False" VerticalAlignment="Bottom" Grid.Row="2">
 			<controls:StatusBarItem>
 				<TextBlock Text="{Binding StatusMessage}" />
 			</controls:StatusBarItem>
@@ -183,7 +171,7 @@
 			<Separator />
 			<controls:StatusBarItem>
 				<TextBlock Text="{Binding EmulatorMouseCursorInfo, StringFormat='Mouse: {0}'}" />
-		</controls:StatusBarItem>
+			</controls:StatusBarItem>
 			<Separator />
 			<controls:StatusBarItem>
 				<StackPanel Orientation="Horizontal" Spacing="6">

--- a/src/Spice86/Views/MainWindow.axaml.cs
+++ b/src/Spice86/Views/MainWindow.axaml.cs
@@ -1,15 +1,27 @@
-namespace Spice86.Views;
 
 using Avalonia;
 using Avalonia.Controls;
 using Avalonia.Input;
 using Avalonia.Threading;
 
+using Spice86.Native;
 using Spice86.ViewModels;
 
-using System;
+using System.Runtime.InteropServices;
+
+namespace Spice86.Views;
 
 internal partial class MainWindow : Window {
+    // When SDL relative mode is active, track absolute cursor position (0..1) by accumulating deltas.
+    // This matches the emulator's virtual screen width (640 px) so one pixel equals one virtual pixel.
+    private const double VirtualScreenWidth = 640.0;
+
+    private bool _isCaptured;
+    private IMouseCaptureBackend? _captureBackend;
+    private double _sdlCapturedMouseX = 0.5;
+    private double _sdlCapturedMouseY = 0.5;
+    private DispatcherTimer? _relativePollTimer;
+
     /// <summary>
     /// Initializes a new instance
     /// </summary>
@@ -18,15 +30,73 @@ internal partial class MainWindow : Window {
         this.Menu.KeyDown += OnMenuKeyDown;
         this.Menu.KeyDown += OnMenuKeyUp;
         this.Menu.GotFocus += OnMenuGotFocus;
+        this.CyclesLimitingNumericUpDown.GotFocus += CyclesLimitingNumericUpDown_GotFocus;
+        this.TimeMultiplierNumericUpDown.GotFocus += CyclesLimitingNumericUpDown_GotFocus;
         this.Loaded += MainWindow_Loaded;
+        Deactivated += OnWindowDeactivated;
+    }
+
+    private void CyclesLimitingNumericUpDown_GotFocus(object? sender, FocusChangedEventArgs e) {
+        FocusOnVideoBuffer();
+        e.Handled = true;
     }
 
     private void MainWindow_Loaded(object? sender, Avalonia.Interactivity.RoutedEventArgs e) {
         Dispatcher.UIThread.Post(() => {
-            if (DataContext is MainWindowViewModel viewModel) {
-                viewModel.StartEmulator();
+            if (DataContext is MainWindowViewModel mainVm) {
+                mainVm.CloseMainWindow += (_, _) => Close();
+                mainVm.InvalidateBitmap += Image.InvalidateVisual;
+                Image.PointerMoved += OnMouseMoved;
+                Image.PointerPressed += OnPointerPressed;
+                Image.PointerReleased += OnMouseButtonUp;
+                InitializeMouseCapture();
+                UpdateCaptureUiState();
+                FocusOnVideoBuffer();
+                mainVm.StartEmulator();
             }
         }, DispatcherPriority.Background);
+    }
+
+    private void InitializeMouseCapture() {
+        nint nativeHandle = GetNativeWindowHandle();
+        IMouseCaptureBackend backend = CreateCaptureBackend();
+        bool initialized;
+        try {
+            initialized = backend.TryInitialize(nativeHandle);
+        } catch {
+            backend.Dispose();
+            throw;
+        }
+
+        if (!initialized) {
+            backend.Dispose();
+            return;
+        }
+
+        _captureBackend = backend;
+
+        // On Windows, re-apply the ClipCursor rect whenever the window moves or resizes.
+        if (!backend.UsesRelativeMouseMode) {
+            PositionChanged += OnWindowPositionChanged;
+            SizeChanged += OnWindowSizeChanged;
+        }
+    }
+
+    private static IMouseCaptureBackend CreateCaptureBackend() {
+        if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows)) {
+            return new WindowsMouseCaptureBackend();
+        }
+
+        return new SdlMouseCapture();
+    }
+
+    private nint GetNativeWindowHandle() {
+        Avalonia.Platform.IPlatformHandle? platformHandle = TryGetPlatformHandle();
+        if (platformHandle is null) {
+            return nint.Zero;
+        }
+
+        return platformHandle.Handle;
     }
 
     public static readonly StyledProperty<PerformanceViewModel?> PerformanceViewModelProperty =
@@ -38,6 +108,148 @@ internal partial class MainWindow : Window {
         set => SetValue(PerformanceViewModelProperty, value);
     }
 
+    private void OnMouseMoved(object? sender, PointerEventArgs e) {
+        // When SDL relative mode is active, Avalonia pointer events are not useful;
+        // deltas are fed by the polling timer instead.
+        if (_isCaptured && _captureBackend is { UsesRelativeMouseMode: true }) {
+            return;
+        }
+
+        if (this.DataContext is MainWindowViewModel mainVm) {
+            mainVm.OnMouseMoved(e, Image);
+        }
+    }
+
+    private void OnPointerPressed(object? sender, PointerPressedEventArgs e) {
+        if (this.DataContext is not MainWindowViewModel mainVm) {
+            return;
+        }
+
+        if (e.GetCurrentPoint(Image).Properties.IsMiddleButtonPressed) {
+            // Toggle happens on release; consume the press here.
+            e.Handled = true;
+            return;
+        }
+
+        mainVm.OnMouseButtonDown(e, Image);
+    }
+
+    private void OnMouseButtonUp(object? sender, PointerReleasedEventArgs e) {
+        if (this.DataContext is MainWindowViewModel mainVm) {
+            if (e.InitialPressMouseButton == MouseButton.Middle) {
+                ToggleMouseCapture();
+                e.Handled = true;
+                return;
+            }
+            mainVm.OnMouseButtonUp(e, Image);
+        }
+    }
+
+    private void OnPointerCaptureLost(object? sender, PointerCaptureLostEventArgs e) {
+        ReleaseCapture();
+    }
+
+    private void OnWindowDeactivated(object? sender, EventArgs e) {
+        ReleaseCapture();
+    }
+
+    private void OnWindowPositionChanged(object? sender, PixelPointEventArgs e) {
+        if (_isCaptured && _captureBackend is not null) {
+            _captureBackend.EnableCapture();
+        }
+    }
+
+    private void OnWindowSizeChanged(object? sender, SizeChangedEventArgs e) {
+        if (_isCaptured && _captureBackend is not null) {
+            _captureBackend.EnableCapture();
+        }
+    }
+
+    private void ToggleMouseCapture() {
+        if (_isCaptured) {
+            ReleaseCapture();
+        } else {
+            EnableCapture();
+        }
+    }
+
+    private void EnableCapture() {
+        if (!Image.IsVisible || _captureBackend is null) {
+            return;
+        }
+
+        if (_captureBackend.EnableCapture()) {
+            if (_captureBackend.UsesRelativeMouseMode) {
+                _sdlCapturedMouseX = 0.5;
+                _sdlCapturedMouseY = 0.5;
+                StartRelativePollTimer();
+            }
+
+            _isCaptured = true;
+            UpdateCaptureUiState();
+        }
+    }
+
+    private void ReleaseCapture() {
+        if (_captureBackend is not null) {
+            _captureBackend.DisableCapture();
+        }
+
+        StopRelativePollTimer();
+        _isCaptured = false;
+        UpdateCaptureUiState();
+    }
+
+    private void StartRelativePollTimer() {
+        if (_relativePollTimer is not null) {
+            return;
+        }
+
+        // Poll at ~100 Hz to match the mouse device sample rate.
+        _relativePollTimer = new DispatcherTimer(TimeSpan.FromMilliseconds(10), DispatcherPriority.Input, OnRelativePollTick);
+        _relativePollTimer.Start();
+    }
+
+    private void StopRelativePollTimer() {
+        if (_relativePollTimer is null) {
+            return;
+        }
+
+        _relativePollTimer.Stop();
+        _relativePollTimer = null;
+    }
+
+    private void OnRelativePollTick(object? sender, EventArgs e) {
+        if (_captureBackend is null || !_captureBackend.IsCaptured) {
+            return;
+        }
+
+        if (DataContext is not MainWindowViewModel mainVm) {
+            return;
+        }
+
+        _captureBackend.GetRelativeMouseDelta(out int dx, out int dy);
+        if (dx == 0 && dy == 0) {
+            return;
+        }
+
+        // Convert pixel deltas to normalised coordinates.
+        // VirtualScreenWidth matches the emulator's virtual screen width (640) so one pixel = one virtual pixel.
+        double normalizedDx = dx / VirtualScreenWidth;
+        double normalizedDy = dy / VirtualScreenWidth;
+        _sdlCapturedMouseX = Math.Clamp(_sdlCapturedMouseX + normalizedDx, 0.0, 1.0);
+        _sdlCapturedMouseY = Math.Clamp(_sdlCapturedMouseY + normalizedDy, 0.0, 1.0);
+
+        mainVm.OnMouseMovedNormalized(_sdlCapturedMouseX, _sdlCapturedMouseY);
+    }
+
+    private void UpdateCaptureUiState() {
+        TopBar.IsVisible = !_isCaptured;
+        BottomBar.IsVisible = !_isCaptured;
+        if (DataContext is MainWindowViewModel mainVm) {
+            mainVm.UpdateMouseCaptureHint(_isCaptured);
+        }
+    }
 
     private void OnMenuGotFocus(object? sender, FocusChangedEventArgs e) {
         FocusOnVideoBuffer();
@@ -55,20 +267,12 @@ internal partial class MainWindow : Window {
     }
 
     private void FocusOnVideoBuffer() {
-        Image.Focus();
-    }
-
-    protected override void OnOpened(EventArgs e) {
-        base.OnOpened(e);
-        if (DataContext is not MainWindowViewModel mainVm) {
-            return;
-        }
-        mainVm.CloseMainWindow += (_, _) => Close();
+        Image?.Focus();
     }
 
     protected override void OnKeyUp(KeyEventArgs e) {
         FocusOnVideoBuffer();
-        var mainWindowViewModel = (DataContext as MainWindowViewModel);
+        MainWindowViewModel? mainWindowViewModel = DataContext as MainWindowViewModel;
         mainWindowViewModel?.OnKeyUp(e);
         e.Handled = true;
     }
@@ -80,11 +284,20 @@ internal partial class MainWindow : Window {
     }
 
     protected override void OnClosing(WindowClosingEventArgs e) {
+        ReleaseCapture();
         (DataContext as MainWindowViewModel)?.OnMainWindowClosing();
         base.OnClosing(e);
     }
 
     protected override void OnClosed(EventArgs e) {
+        Deactivated -= OnWindowDeactivated;
+        if (_captureBackend is { UsesRelativeMouseMode: false }) {
+            PositionChanged -= OnWindowPositionChanged;
+            SizeChanged -= OnWindowSizeChanged;
+        }
+
+        _captureBackend?.Dispose();
+        _captureBackend = null;
         (DataContext as IDisposable)?.Dispose();
         base.OnClosed(e);
     }

--- a/tests/Spice86.Tests/UI/MouseCaptureTests.cs
+++ b/tests/Spice86.Tests/UI/MouseCaptureTests.cs
@@ -1,0 +1,215 @@
+namespace Spice86.Tests.UI;
+
+using Avalonia.Headless.XUnit;
+
+using FluentAssertions;
+
+using Spice86.Native;
+
+using Xunit;
+
+/// <summary>
+/// Integration tests for mouse capture backends (<see cref="IMouseCaptureBackend"/>).
+/// </summary>
+public class MouseCaptureTests {
+    // ── SdlMouseCapture ────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// <see cref="SdlMouseCapture.TryInitialize"/> returns false when given a zero native handle,
+    /// so the class never calls into SDL for an invalid window.
+    /// </summary>
+    [AvaloniaFact]
+    public void SdlMouseCapture_TryInitialize_ReturnsFalse_WhenHandleIsZero() {
+        // Arrange
+        using SdlMouseCapture capture = new();
+
+        // Act
+        bool result = capture.TryInitialize(nint.Zero);
+
+        // Assert
+        result.Should().BeFalse();
+        capture.IsInitialized.Should().BeFalse();
+    }
+
+    /// <summary>
+    /// <see cref="SdlMouseCapture.EnableCapture"/> returns false and does not set IsCaptured
+    /// when SDL has not been initialized (e.g. headless environment or invalid handle).
+    /// </summary>
+    [AvaloniaFact]
+    public void SdlMouseCapture_EnableCapture_ReturnsFalse_WhenNotInitialized() {
+        // Arrange
+        using SdlMouseCapture capture = new();
+
+        // Act
+        bool result = capture.EnableCapture();
+
+        // Assert
+        result.Should().BeFalse();
+        capture.IsCaptured.Should().BeFalse();
+    }
+
+    /// <summary>
+    /// <see cref="SdlMouseCapture.DisableCapture"/> returns false when SDL is not initialized.
+    /// </summary>
+    [AvaloniaFact]
+    public void SdlMouseCapture_DisableCapture_ReturnsFalse_WhenNotInitialized() {
+        // Arrange
+        using SdlMouseCapture capture = new();
+
+        // Act
+        bool result = capture.DisableCapture();
+
+        // Assert
+        result.Should().BeFalse();
+    }
+
+    /// <summary>
+    /// <see cref="SdlMouseCapture.GetRelativeMouseDelta"/> returns zero deltas when not initialized,
+    /// so callers receive a neutral value and do not accumulate phantom motion.
+    /// </summary>
+    [AvaloniaFact]
+    public void SdlMouseCapture_GetRelativeMouseDelta_ReturnsZero_WhenNotInitialized() {
+        // Arrange
+        using SdlMouseCapture capture = new();
+
+        // Act
+        capture.GetRelativeMouseDelta(out int dx, out int dy);
+
+        // Assert
+        dx.Should().Be(0);
+        dy.Should().Be(0);
+    }
+
+    /// <summary>
+    /// <see cref="SdlMouseCapture"/> can be disposed multiple times without throwing an exception
+    /// (idempotent Dispose pattern).
+    /// </summary>
+    [AvaloniaFact]
+    public void SdlMouseCapture_Dispose_IsIdempotent() {
+        // Arrange
+        SdlMouseCapture capture = new();
+
+        // Act
+        Action doubleDispose = () => {
+            capture.Dispose();
+            capture.Dispose();
+        };
+
+        // Assert
+        doubleDispose.Should().NotThrow();
+    }
+
+    /// <summary>
+    /// <see cref="SdlMouseCapture"/> uses relative mouse mode.
+    /// </summary>
+    [AvaloniaFact]
+    public void SdlMouseCapture_UsesRelativeMouseMode_IsTrue() {
+        // Arrange
+        using SdlMouseCapture capture = new();
+
+        // Assert
+        capture.UsesRelativeMouseMode.Should().BeTrue();
+    }
+
+    // ── WindowsMouseCaptureBackend ─────────────────────────────────────────────
+
+    /// <summary>
+    /// <see cref="WindowsMouseCaptureBackend.TryInitialize"/> returns false when given a zero native
+    /// handle, so no Win32 calls are attempted.
+    /// </summary>
+    [AvaloniaFact]
+    public void WindowsMouseCaptureBackend_TryInitialize_ReturnsFalse_WhenHandleIsZero() {
+        // Arrange
+        using WindowsMouseCaptureBackend backend = new();
+
+        // Act
+        bool result = backend.TryInitialize(nint.Zero);
+
+        // Assert
+        result.Should().BeFalse();
+    }
+
+    /// <summary>
+    /// <see cref="WindowsMouseCaptureBackend.EnableCapture"/> returns false when not initialized.
+    /// </summary>
+    [AvaloniaFact]
+    public void WindowsMouseCaptureBackend_EnableCapture_ReturnsFalse_WhenNotInitialized() {
+        // Arrange
+        using WindowsMouseCaptureBackend backend = new();
+
+        // Act
+        bool result = backend.EnableCapture();
+
+        // Assert
+        result.Should().BeFalse();
+        backend.IsCaptured.Should().BeFalse();
+    }
+
+    /// <summary>
+    /// <see cref="WindowsMouseCaptureBackend.GetRelativeMouseDelta"/> always returns zero
+    /// because the Windows backend uses absolute cursor clipping, not relative deltas.
+    /// </summary>
+    [AvaloniaFact]
+    public void WindowsMouseCaptureBackend_GetRelativeMouseDelta_AlwaysReturnsZero() {
+        // Arrange
+        using WindowsMouseCaptureBackend backend = new();
+
+        // Act
+        backend.GetRelativeMouseDelta(out int dx, out int dy);
+
+        // Assert
+        dx.Should().Be(0);
+        dy.Should().Be(0);
+    }
+
+    /// <summary>
+    /// <see cref="WindowsMouseCaptureBackend"/> does not use relative mouse mode;
+    /// Avalonia pointer events carry absolute coordinates and no delta polling is needed.
+    /// </summary>
+    [AvaloniaFact]
+    public void WindowsMouseCaptureBackend_UsesRelativeMouseMode_IsFalse() {
+        // Arrange
+        using WindowsMouseCaptureBackend backend = new();
+
+        // Assert
+        backend.UsesRelativeMouseMode.Should().BeFalse();
+    }
+
+    /// <summary>
+    /// <see cref="WindowsMouseCaptureBackend"/> can be disposed multiple times without throwing.
+    /// </summary>
+    [AvaloniaFact]
+    public void WindowsMouseCaptureBackend_Dispose_IsIdempotent() {
+        // Arrange
+        WindowsMouseCaptureBackend backend = new();
+
+        // Act
+        Action doubleDispose = () => {
+            backend.Dispose();
+            backend.Dispose();
+        };
+
+        // Assert
+        doubleDispose.Should().NotThrow();
+    }
+
+    // ── IMouseCaptureBackend contract ──────────────────────────────────────────
+
+    /// <summary>
+    /// After a failed <see cref="IMouseCaptureBackend.TryInitialize"/>, IsCaptured must be false.
+    /// </summary>
+    [AvaloniaFact]
+    public void SdlMouseCapture_StateIsConsistent_AfterFailedInitialize() {
+        // Arrange
+        using SdlMouseCapture capture = new();
+
+        // Act
+        capture.TryInitialize(nint.Zero);
+
+        // Assert
+        capture.IsInitialized.Should().BeFalse();
+        capture.IsCaptured.Should().BeFalse();
+    }
+}
+
+


### PR DESCRIPTION
### Description of Changes

Enables mouse capture to the mainWindow edges.

### Rationale behind Changes

A lot of games use edge scrolling (Dune 2, Transarctica)

Dune has controls on the edges of the screen that are easier to target with this feature.

### Suggested Testing Steps

Tested on Windows succesfully.
Other platforms are fully implemented, but if it doesn't work there is no issue (no exceptions) anyway.