### PR TITLE
feat: Make VGA rendering happen on event base. This makes the VGA registers deterministic.

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -114,6 +114,7 @@ Variants: `MemoryBasedDataStructureWithCsBaseAddress`, `MemoryBasedDataStructure
 - **No optional parameters** - avoid nullable or optional parameters in new code
 - **Minimal comments** - write self-documenting code with clear names; avoid obvious comments
 - **Test before submit** - always run tests after code changes to verify functionality
+- **Rebuild and verify** - For any task that changes code or tests, rebuild the project and run the full test suite; do not stop until all tests are green.
 - **Concise documentation** - XML docs should be precise and complete but not verbose; avoid excessive remarks
 - **Ignore Machine class** - this is a legacy aggregator class; work directly with specific components (`CfgCpu`, `Memory`, `Stack`, etc.) instead
 
@@ -171,6 +172,7 @@ Variants: `MemoryBasedDataStructureWithCsBaseAddress`, `MemoryBasedDataStructure
   ```
   - Properly handle null cases with null checks, null-coalescing, or null-conditional operators
   - Don't ignore nullable warnings - fix the underlying issue
+  - **Avoid non-ASCII Unicode characters**: Prefer plain ASCII in source code and documentation; only use Unicode when necessary for languages that require characters outside the ASCII range (for example, Chinese). Some editors or tools may not assume UTF-8 and can render or save these characters incorrectly.
 - **Do not use `#region`**: Avoid `#region`/`#endregion` blocks; keep code organized via clear structure and namespaces
 - **Do not suppress warnings with pragmas**: Never disable warnings using preprocessor directives (e.g., `#pragma warning disable`). Fix the underlying issue instead.
 - **Async usage restrictions**:

--- a/.github/prompts/code-review-commit.prompt.md
+++ b/.github/prompts/code-review-commit.prompt.md
@@ -1,0 +1,6 @@
+---
+name: code-review-commit
+description: Conduct a code review on the last commit's changes and identify potential issues and edge cases.
+---
+Do a git diff of the last commit and pretend you're a senior dev doing a code review and you HATE this implementation. What would you criticize? What edge cases am I missing?
+Write all those findings in a markdown file at the root of the repository called CODE_REVIEW.md. Make sure to include code snippets and references to specific lines in the code.

--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -39,7 +39,6 @@
     <PackageVersion Include="NSubstitute" Version="5.3.0" />
     <PackageVersion Include="NSubstitute.Analyzers.CSharp" Version="1.0.17" />
     <PackageVersion Include="NukedOPL3Sharp" Version="1.1.0" />
-    <PackageVersion Include="OptimizedPriorityQueue" Version="5.1.0" />
     <PackageVersion Include="PanAndZoom" Version="11.3.9.1" />
     <PackageVersion Include="Roslynator.Analyzers" Version="4.15.0" />
     <PackageVersion Include="Roslynator.CodeAnalysis.Analyzers" Version="4.15.0" />

--- a/src/Spice86.Core/CLI/Configuration.cs
+++ b/src/Spice86.Core/CLI/Configuration.cs
@@ -279,4 +279,13 @@ public sealed class Configuration : CommandSettings {
     [CommandOption("--McpHttpPort <MCPHTTPPORT>")]
     [DefaultValue(8081)]
     public int McpHttpPort { get; init; }
+
+    /// <summary>
+    /// Selects the VGA rendering mode. Sync fires VGA events on the emulation thread for determinism;
+    /// Async fires them on the UI thread for better performance.
+    /// </summary>
+    [CommandOption("--RenderingMode <RENDERINGMODE>")]
+    [DefaultValue(RenderingMode.Async)]
+    public RenderingMode RenderingMode { get; init; }
+
 }

--- a/src/Spice86.Core/CLI/RenderingMode.cs
+++ b/src/Spice86.Core/CLI/RenderingMode.cs
@@ -1,0 +1,18 @@
+namespace Spice86.Core.CLI;
+
+/// <summary>
+/// Selects the VGA rendering mode.
+/// </summary>
+public enum RenderingMode {
+    /// <summary>
+    /// VGA timing events fire on the emulation thread, driven by the emulated clock.
+    /// Deterministic but has higher per-instruction overhead.
+    /// </summary>
+    Sync,
+
+    /// <summary>
+    /// VGA timing events fire on the UI thread, driven by the UI timer.
+    /// Non-deterministic but better emulation throughput.
+    /// </summary>
+    Async
+}

--- a/src/Spice86.Core/Emulator/Devices/Cmos/RealTimeClock.cs
+++ b/src/Spice86.Core/Emulator/Devices/Cmos/RealTimeClock.cs
@@ -8,7 +8,7 @@ using Spice86.Core.Emulator.Devices.Timer;
 using Spice86.Core.Emulator.IOPorts;
 using Spice86.Core.Emulator.VM;
 using Spice86.Core.Emulator.VM.Clock;
-using Spice86.Core.Emulator.VM.EmulationLoopScheduler;
+using Spice86.Core.Emulator.VM.DeviceScheduler;
 using Spice86.Shared.Interfaces;
 using Spice86.Shared.Utils;
 
@@ -31,7 +31,7 @@ using System;
 public sealed class RealTimeClock : DefaultIOPortHandler, IDisposable {
     private readonly DualPic _dualPic;
     private readonly CmosRegisters _cmosRegisters = new();
-    private readonly EmulationLoopScheduler _scheduler;
+    private readonly DeviceScheduler _scheduler;
     private readonly IEmulatedClock _clock;
 
     private bool _disposed;
@@ -45,7 +45,7 @@ public sealed class RealTimeClock : DefaultIOPortHandler, IDisposable {
     /// Initializes the RTC/CMOS device with default register values.
     /// </summary>
     public RealTimeClock(State state, IOPortDispatcher ioPortDispatcher, DualPic dualPic,
-        EmulationLoopScheduler scheduler, IEmulatedClock clock, bool failOnUnhandledPort, ILoggerService loggerService)
+        DeviceScheduler scheduler, IEmulatedClock clock, bool failOnUnhandledPort, ILoggerService loggerService)
         : base(state, failOnUnhandledPort, loggerService) {
         _dualPic = dualPic;
         _scheduler = scheduler;
@@ -334,7 +334,7 @@ public sealed class RealTimeClock : DefaultIOPortHandler, IDisposable {
     }
 
     /// <summary>
-    /// Schedules the next periodic interrupt event using EmulationLoopScheduler.
+    /// Schedules the next periodic interrupt event using DeviceScheduler.
     /// </summary>
     private void ScheduleNextPeriodicInterrupt() {
         if (_cmosRegisters.Timer.Delay <= 0) {
@@ -357,7 +357,7 @@ public sealed class RealTimeClock : DefaultIOPortHandler, IDisposable {
     }
     
     /// <summary>
-    /// Callback invoked by EmulationLoopScheduler when periodic interrupt should fire.
+    /// Callback invoked by DeviceScheduler when periodic interrupt should fire.
     /// Triggers the interrupt and schedules the next one.
     /// </summary>
     /// <param name="value">Controller-supplied value (unused for RTC).</param>

--- a/src/Spice86.Core/Emulator/Devices/Input/Keyboard/Intel8042Controller.cs
+++ b/src/Spice86.Core/Emulator/Devices/Input/Keyboard/Intel8042Controller.cs
@@ -6,7 +6,7 @@ using Spice86.Core.Emulator.CPU;
 using Spice86.Core.Emulator.Devices.ExternalInput;
 using Spice86.Core.Emulator.IOPorts;
 using Spice86.Core.Emulator.Memory;
-using Spice86.Core.Emulator.VM.EmulationLoopScheduler;
+using Spice86.Core.Emulator.VM.DeviceScheduler;
 using Spice86.Shared.Interfaces;
 
 /// <summary>
@@ -32,7 +32,7 @@ public partial class Intel8042Controller : DefaultIOPortHandler {
     private int _waitingBytesFromKbd = 0;
 
     /// <summary>
-    /// Sub-ms delay state driven by EmulationLoopScheduler event system
+    /// Sub-ms delay state driven by DeviceScheduler event system
     /// </summary>
     private bool _isDelayRunning = false;
 
@@ -78,7 +78,7 @@ public partial class Intel8042Controller : DefaultIOPortHandler {
 
     // Handler reference for delay timer
     private readonly EventHandler _delayHandler;
-    private readonly EmulationLoopScheduler _scheduler;
+    private readonly DeviceScheduler _scheduler;
 
     public PS2Keyboard KeyboardDevice { get; }
 
@@ -86,7 +86,7 @@ public partial class Intel8042Controller : DefaultIOPortHandler {
     /// Initializes a new instance of the <see cref="Intel8042Controller"/> class.
     /// </summary>
     public Intel8042Controller(State state, IOPortDispatcher ioPortDispatcher,
-        A20Gate a20Gate, DualPic dualPic, EmulationLoopScheduler scheduler, bool failOnUnhandledPort,
+        A20Gate a20Gate, DualPic dualPic, DeviceScheduler scheduler, bool failOnUnhandledPort,
         ILoggerService loggerService,
         IGuiKeyboardEvents? gui = null)
         : base(state, failOnUnhandledPort, loggerService) {

--- a/src/Spice86.Core/Emulator/Devices/Input/Keyboard/PS2Keyboard.cs
+++ b/src/Spice86.Core/Emulator/Devices/Input/Keyboard/PS2Keyboard.cs
@@ -2,7 +2,7 @@ namespace Spice86.Core.Emulator.Devices.Input.Keyboard;
 
 using Serilog.Events;
 
-using Spice86.Core.Emulator.VM.EmulationLoopScheduler;
+using Spice86.Core.Emulator.VM.DeviceScheduler;
 using Spice86.Shared.Emulator.Keyboard;
 using Spice86.Shared.Interfaces;
 
@@ -18,7 +18,7 @@ public partial class PS2Keyboard {
     private readonly Intel8042Controller _controller;
     private readonly ILoggerService _loggerService;
     private readonly KeyboardScancodeConverter _scancodeConverter = new();
-    private readonly EmulationLoopScheduler _scheduler;
+    private readonly DeviceScheduler _scheduler;
     private readonly IGuiKeyboardEvents? _gui;
     private readonly EventHandler _typematicTickHandler;
     private readonly EventHandler _ledsAllOnExpireHandler;
@@ -64,7 +64,7 @@ public partial class PS2Keyboard {
     /// <param name="loggerService">The logger service implementation.</param>
     /// <param name="gui">Optional GUI interface for keyboard events.</param>
     public PS2Keyboard(Intel8042Controller controller,
-        EmulationLoopScheduler scheduler, ILoggerService loggerService,
+        DeviceScheduler scheduler, ILoggerService loggerService,
         IGuiKeyboardEvents? gui = null) {
         _controller = controller;
         _loggerService = loggerService;

--- a/src/Spice86.Core/Emulator/Devices/Sound/Blaster/SoundBlaster.Definitions.cs
+++ b/src/Spice86.Core/Emulator/Devices/Sound/Blaster/SoundBlaster.Definitions.cs
@@ -6,11 +6,11 @@ using Spice86.Core.Emulator.Devices.DirectMemoryAccess;
 using Spice86.Core.Emulator.Devices.ExternalInput;
 using Spice86.Core.Emulator.Devices.Sound;
 using Spice86.Core.Emulator.VM.Clock;
-using Spice86.Core.Emulator.VM.EmulationLoopScheduler;
+using Spice86.Core.Emulator.VM.DeviceScheduler;
 
 using System;
 
-using EventHandler = VM.EmulationLoopScheduler.EventHandler;
+using EventHandler = Spice86.Core.Emulator.VM.DeviceScheduler.EventHandler;
 
 /// <summary>
 /// Constants, enums, nested types, static data, and instance field declarations
@@ -993,7 +993,7 @@ public partial class SoundBlaster {
     private readonly SoftwareMixer _mixer;
     private readonly SoundChannel _dacChannel;
     private readonly Opl3Fm _opl;
-    private readonly EmulationLoopScheduler _scheduler;
+    private readonly DeviceScheduler _scheduler;
     private readonly IEmulatedClock _clock;
     private readonly DmaBus _dmaBus;
     private readonly RWQueue<AudioFrame> _outputQueue = new(4096);

--- a/src/Spice86.Core/Emulator/Devices/Sound/Blaster/SoundBlaster.cs
+++ b/src/Spice86.Core/Emulator/Devices/Sound/Blaster/SoundBlaster.cs
@@ -10,7 +10,7 @@ using Spice86.Core.Emulator.Devices.ExternalInput;
 using Spice86.Core.Emulator.Devices.Sound;
 using Spice86.Core.Emulator.IOPorts;
 using Spice86.Core.Emulator.VM.Clock;
-using Spice86.Core.Emulator.VM.EmulationLoopScheduler;
+using Spice86.Core.Emulator.VM.DeviceScheduler;
 using Spice86.Shared.Interfaces;
 
 using System;
@@ -46,7 +46,7 @@ public partial class SoundBlaster : DefaultIOPortHandler, IRequestInterrupt, IBl
         SoftwareMixer mixer,
         Opl3Fm opl,
         ILoggerService loggerService,
-        EmulationLoopScheduler scheduler,
+        DeviceScheduler scheduler,
         IEmulatedClock clock,
         SoundBlasterHardwareConfig soundBlasterHardwareConfig)
         : base(state, false, loggerService) {

--- a/src/Spice86.Core/Emulator/Devices/Sound/PcSpeaker.cs
+++ b/src/Spice86.Core/Emulator/Devices/Sound/PcSpeaker.cs
@@ -6,7 +6,7 @@ using Spice86.Core.Emulator.CPU;
 using Spice86.Core.Emulator.Devices.Timer;
 using Spice86.Core.Emulator.IOPorts;
 using Spice86.Core.Emulator.VM.Clock;
-using Spice86.Core.Emulator.VM.EmulationLoopScheduler;
+using Spice86.Core.Emulator.VM.DeviceScheduler;
 using Spice86.Shared.Interfaces;
 
 using System.Diagnostics;
@@ -40,7 +40,7 @@ public class PcSpeaker : DefaultIOPortHandler, IPitSpeaker, IAudioQueueDevice<fl
     private const float MsPerPitTick = 1000.0f / PitTimer.PitTickRate;
     private static readonly int MinimumCounter = Math.Max(1, 2 * PitTimer.PitTickRate / SampleRateHz);
     private IPitControl? _pitControl;
-    private readonly EmulationLoopScheduler _scheduler;
+    private readonly DeviceScheduler _scheduler;
     private readonly IEmulatedClock _clock;
     private readonly float[] _impulseLookup = new float[SincFilterWidth];
     private readonly ILoggerService _logger;
@@ -110,7 +110,7 @@ public class PcSpeaker : DefaultIOPortHandler, IPitSpeaker, IAudioQueueDevice<fl
         State state,
         IOPortDispatcher ioPortDispatcher,
         ILoggerService loggerService,
-        EmulationLoopScheduler scheduler,
+        DeviceScheduler scheduler,
         IEmulatedClock clock,
         bool failOnUnhandledPort)
         : base(state, failOnUnhandledPort, loggerService) {

--- a/src/Spice86.Core/Emulator/Devices/Timer/PitTimer.cs
+++ b/src/Spice86.Core/Emulator/Devices/Timer/PitTimer.cs
@@ -6,7 +6,7 @@ using Spice86.Core.Emulator.CPU;
 using Spice86.Core.Emulator.Devices.ExternalInput;
 using Spice86.Core.Emulator.IOPorts;
 using Spice86.Core.Emulator.VM.Clock;
-using Spice86.Core.Emulator.VM.EmulationLoopScheduler;
+using Spice86.Core.Emulator.VM.DeviceScheduler;
 using Spice86.Shared.Interfaces;
 
 using System.Diagnostics;
@@ -37,7 +37,7 @@ public sealed class PitTimer : DefaultIOPortHandler, IPitControl, ITimeMultiplie
     private readonly IOPortDispatcher _ioPortDispatcher;
     private readonly IPitSpeaker _pcSpeaker;
     private readonly DualPic _pic;
-    private readonly EmulationLoopScheduler _scheduler;
+    private readonly DeviceScheduler _scheduler;
     private readonly IEmulatedClock _clock;
 
     // Three PIT channels are supported. Each uses the same state machine while addressing distinct peripherals.
@@ -67,7 +67,7 @@ public sealed class PitTimer : DefaultIOPortHandler, IPitControl, ITimeMultiplie
     /// <param name="loggerService">Logger for trace output.</param>
     /// <param name="failOnUnhandledPort">Whether to throw on unhandled port access.</param>
     public PitTimer(IOPortDispatcher ioPortDispatcher, State state, DualPic pic, IPitSpeaker pcSpeaker, 
-        EmulationLoopScheduler scheduler, IEmulatedClock clock, ILoggerService loggerService, bool failOnUnhandledPort)
+        DeviceScheduler scheduler, IEmulatedClock clock, ILoggerService loggerService, bool failOnUnhandledPort)
         : base(state, failOnUnhandledPort, loggerService) {
         _ioPortDispatcher = ioPortDispatcher;
         _pic = pic;

--- a/src/Spice86.Core/Emulator/Devices/Video/IVgaRenderer.cs
+++ b/src/Spice86.Core/Emulator/Devices/Video/IVgaRenderer.cs
@@ -20,12 +20,7 @@ public interface IVgaRenderer {
     int BufferSize { get; }
 
     /// <summary>
-    /// Gets the time it took to render the last frame.
-    /// </summary>
-    TimeSpan LastFrameRenderTime { get; }
-
-    /// <summary>
-    ///     Render the current video memory to a buffer.
+    ///     Copy the latest completed frame to the provided buffer.
     /// </summary>
     /// <param name="buffer">The framebuffer used by the VGA card to draw the image on screen.</param>
     void Render(Span<uint> buffer);

--- a/src/Spice86.Core/Emulator/Devices/Video/IVgaRenderer256Color.cs
+++ b/src/Spice86.Core/Emulator/Devices/Video/IVgaRenderer256Color.cs
@@ -1,0 +1,23 @@
+namespace Spice86.Core.Emulator.Devices.Video;
+
+using System;
+
+/// <summary>
+///     Strategy interface for 256-color VGA scanline rendering.
+///     Implementations provide scalar, SSE4.1, or AVX2 code paths,
+///     selected once at construction time based on hardware capabilities.
+/// </summary>
+public interface IVgaRenderer256Color {
+
+
+    /// <summary>
+    ///     Renders a 256-color scanline with pixel doubling (each VRAM byte produces two identical pixels).
+    /// </summary>
+    /// <param name="frameBuffer">The destination ARGB frame buffer.</param>
+    /// <param name="vram">The VRAM span containing palette indices.</param>
+    /// <param name="paletteMap">The 256-entry palette lookup table.</param>
+    /// <param name="byteCount">The number of VRAM bytes to process (produces 2× pixels).</param>
+    /// <param name="destOffset">Current write position; updated on return.</param>
+    void RenderDoubledScanline(Span<uint> frameBuffer, ReadOnlySpan<byte> vram,
+        uint[] paletteMap, int byteCount, ref int destOffset);
+}

--- a/src/Spice86.Core/Emulator/Devices/Video/IVideoMemory.cs
+++ b/src/Spice86.Core/Emulator/Devices/Video/IVideoMemory.cs
@@ -1,5 +1,7 @@
 namespace Spice86.Core.Emulator.Devices.Video;
 
+using System;
+
 using Spice86.Core.Emulator.Memory;
 
 /// <summary>
@@ -7,7 +9,21 @@ using Spice86.Core.Emulator.Memory;
 /// </summary>
 public interface IVideoMemory : IMemoryDevice {
     /// <summary>
-    ///     Provides access to the 4 planes of video memory.
+    ///     Raw interleaved VRAM buffer. Plane p at VGA address a = VRam[a * 4 + p].
+    ///     Mode 13h chain-4 pixel N = VRam[N].
     /// </summary>
-    byte[,] Planes { get; }
+    byte[] VRam { get; }
+
+    /// <summary>
+    ///     Accessor that preserves the <c>Planes[plane, address]</c> syntax while forwarding
+    ///     to the interleaved <see cref="VRam"/> buffer.
+    /// </summary>
+    PlaneAccessor Planes { get; }
+
+    /// <summary>
+    ///     Returns a read-only span over the interleaved VRAM starting at the given linear byte offset.
+    /// </summary>
+    /// <param name="linearByteOffset">The byte offset into VRam.</param>
+    /// <param name="length">The number of bytes to return.</param>
+    ReadOnlySpan<byte> GetLinearSpan(int linearByteOffset, int length);
 }

--- a/src/Spice86.Core/Emulator/Devices/Video/IVideoState.cs
+++ b/src/Spice86.Core/Emulator/Devices/Video/IVideoState.cs
@@ -35,4 +35,10 @@ public interface IVideoState {
     ///     Contains the attribute controller registers.
     /// </summary>
     public AttributeControllerRegisters AttributeControllerRegisters { get; }
+
+    /// <summary>
+    ///     Whether any VGA register write has occurred since the last reset.
+    ///     Set by <see cref="VgaIoPortHandler"/> on port writes; cleared by <see cref="Renderer"/> at frame start.
+    /// </summary>
+    public bool IsRenderingDirty { get; set; }
 }

--- a/src/Spice86.Core/Emulator/Devices/Video/PlaneAccessor.cs
+++ b/src/Spice86.Core/Emulator/Devices/Video/PlaneAccessor.cs
@@ -1,0 +1,27 @@
+namespace Spice86.Core.Emulator.Devices.Video;
+
+/// <summary>
+///     Provides a two-parameter indexer over the flat interleaved VRAM buffer,
+///     preserving the <c>Planes[plane, address]</c> calling syntax.
+/// </summary>
+public sealed class PlaneAccessor {
+    private readonly byte[] _vram;
+
+    /// <summary>
+    ///     Creates a new accessor backed by the given interleaved VRAM buffer.
+    /// </summary>
+    /// <param name="vram">The flat interleaved VRAM array where plane p at VGA address a is at index a * 4 + p.</param>
+    internal PlaneAccessor(byte[] vram) {
+        _vram = vram;
+    }
+
+    /// <summary>
+    ///     Gets or sets the byte at the specified plane and VGA address.
+    /// </summary>
+    /// <param name="plane">The plane index (0–3).</param>
+    /// <param name="address">The VGA address within the plane.</param>
+    public byte this[int plane, int address] {
+        get => _vram[address * 4 + plane];
+        set => _vram[address * 4 + plane] = value;
+    }
+}

--- a/src/Spice86.Core/Emulator/Devices/Video/Registers/DacRegisters.cs
+++ b/src/Spice86.Core/Emulator/Devices/Video/Registers/DacRegisters.cs
@@ -9,6 +9,7 @@ public class DacRegisters {
     private int _indexRegister;
     private byte _internalIndex;
     private int _tripletCounter;
+    private byte _pixelMask = 0xFF;
 
     /// <summary>
     /// The DAC Palette, represented as a 256 * 3 array. Stores the current set of colors.
@@ -16,16 +17,53 @@ public class DacRegisters {
     public readonly byte[,] Palette = new byte[256, 3];
 
     /// <summary>
+    /// Precomputed ARGB pixel values for 8-bit (256-colour) mode. Index is the direct DAC
+    /// palette index; value is the packed 0xAARRGGBB pixel with <see cref="PixelMask"/> already applied.
+    /// Rebuilt automatically whenever the DAC palette or <see cref="PixelMask"/> changes.
+    /// </summary>
+    public readonly uint[] PaletteMap = new uint[256];
+
+    /// <summary>
+    /// Precomputed ARGB pixel values for 4-bit attribute-indexed modes (EGA, CGA, text).
+    /// Index is the 4-bit attribute value (0–15); value is the final packed pixel after the
+    /// InternalPalette + ColorSelect register translation and <see cref="PixelMask"/> masking.
+    /// Rebuilt by calling <see cref="RebuildAttributeMap"/> whenever any relevant attribute
+    /// register changes.
+    /// </summary>
+    public readonly uint[] AttributeMap = new uint[16];
+
+    /// <summary>
+    /// Set to <c>true</c> after a full RGB triplet has been written via <see cref="DataRegister"/>.
+    /// Cleared at the start of each write. Consumers (e.g. <c>VgaIoPortHandler</c>) can test
+    /// this flag to decide when to call <see cref="RebuildAttributeMap"/>.
+    /// </summary>
+    public bool TripletJustCompleted { get; private set; }
+
+    /// <summary>
+    /// The palette index whose triplet was most recently completed via <see cref="DataRegister"/>.
+    /// Valid only when <see cref="TripletJustCompleted"/> is <c>true</c>.
+    /// </summary>
+    public byte LastWrittenPaletteIndex { get; private set; }
+
+    /// <summary>
     /// Initializes a new instance.
     /// </summary>
     public DacRegisters() {
         ArgbPalette = new ArgbPalette(Palette);
+        RebuildAllPaletteMap();
     }
 
     /// <summary>
     ///     Which bits to use for the palette address.
+    ///     Changing this mask rebuilds all 256 <see cref="PaletteMap"/> entries immediately.
     /// </summary>
-    public byte PixelMask { get; set; }
+    public byte PixelMask {
+        get => _pixelMask;
+        set {
+            _pixelMask = value;
+            RebuildAllPaletteMap();
+        }
+    }
 
     /// <summary>
     ///     Status bits indicate the I/O address of the last CPU write to the external DAC/Color Palette:
@@ -73,12 +111,16 @@ public class DacRegisters {
             return result;
         }
         set {
+            TripletJustCompleted = false;
             try {
                 Palette[_internalIndex, _tripletCounter++] = (byte)(value & 0x3F);
                 if (_tripletCounter == 3) {
+                    LastWrittenPaletteIndex = _internalIndex;
+                    RebuildPaletteMapEntry(_internalIndex);
                     _indexRegister++;
                     _internalIndex++;
                     _tripletCounter = 0;
+                    TripletJustCompleted = true;
                 }
                 State = 0;
             } catch (Exception e) {
@@ -95,6 +137,59 @@ public class DacRegisters {
 
     /// <summary>
     ///     Converts the internal palette to an array of ARGB values.
+    ///     Retained for UI and diagnostic use. Hot rendering paths should use <see cref="PaletteMap"/>
+    ///     or <see cref="AttributeMap"/> instead.
     /// </summary>
     public ArgbPalette ArgbPalette { get; }
+
+    /// <summary>
+    /// Rebuilds a single entry in <see cref="PaletteMap"/>.
+    /// The colour stored at <paramref name="index"/> is the DAC palette colour at
+    /// <c>index &amp; <see cref="PixelMask"/></c>, converted to ARGB.
+    /// </summary>
+    public void RebuildPaletteMapEntry(int index) {
+        int maskedIndex = index & _pixelMask;
+        byte r6 = Palette[maskedIndex, 0];
+        byte g6 = Palette[maskedIndex, 1];
+        byte b6 = Palette[maskedIndex, 2];
+        PaletteMap[index] = ToArgb(r6, g6, b6);
+    }
+
+    /// <summary>
+    /// Rebuilds all 256 entries in <see cref="PaletteMap"/>. Call this when
+    /// <see cref="PixelMask"/> changes (all mappings are affected).
+    /// </summary>
+    public void RebuildAllPaletteMap() {
+        for (int i = 0; i < 256; i++) {
+            RebuildPaletteMapEntry(i);
+        }
+    }
+
+    /// <summary>
+    /// Rebuilds all 16 entries in <see cref="AttributeMap"/> using the current attribute-controller
+    /// registers. Call this whenever <see cref="AttributeControllerRegisters.InternalPalette"/>,
+    /// <see cref="AttributeControllerRegisters.AttributeControllerModeRegister"/> (VideoOutput45Select),
+    /// or <see cref="AttributeControllerRegisters.ColorSelectRegister"/> changes, and also after
+    /// any change to <see cref="PaletteMap"/> (DAC write or mask change).
+    /// </summary>
+    public void RebuildAttributeMap(AttributeControllerRegisters attr) {
+        bool videoOutput45Select = attr.AttributeControllerModeRegister.VideoOutput45Select;
+        int bits67 = attr.ColorSelectRegister.Bits67 << 6;
+        int bits45FromColorSelect = attr.ColorSelectRegister.Bits45 << 4;
+
+        for (int i = 0; i < 16; i++) {
+            int fromPaletteRam6Bits = attr.InternalPalette[i];
+            int bits0To3 = fromPaletteRam6Bits & 0x0F;
+            int bits4And5 = videoOutput45Select ? bits45FromColorSelect : (fromPaletteRam6Bits & 0x30);
+            int dacIndex = bits67 | bits4And5 | bits0To3;
+            AttributeMap[i] = PaletteMap[dacIndex];
+        }
+    }
+
+    private static uint ToArgb(byte r6, byte g6, byte b6) {
+        uint r8 = (uint)(r6 << 2 | r6 >> 4);
+        uint g8 = (uint)(g6 << 2 | g6 >> 4);
+        uint b8 = (uint)(b6 << 2 | b6 >> 4);
+        return 0xFF000000U | (r8 << 16) | (g8 << 8) | b8;
+    }
 }

--- a/src/Spice86.Core/Emulator/Devices/Video/Renderer.cs
+++ b/src/Spice86.Core/Emulator/Devices/Video/Renderer.cs
@@ -1,30 +1,76 @@
 namespace Spice86.Core.Emulator.Devices.Video;
 
+using System;
+using System.Threading;
+
 using Spice86.Core.Emulator.Devices.Video.Registers.CrtController;
+using Spice86.Core.Emulator.Devices.Video.Registers;
 using Spice86.Core.Emulator.Devices.Video.Registers.Graphics;
 using Spice86.Core.Emulator.Memory;
-using Spice86.Core.Emulator.VM.Clock;
 using Spice86.Logging;
 
 using ClockSelect = Registers.General.MiscellaneousOutput.ClockSelectValue;
 
 /// <inheritdoc cref="IVgaRenderer" />
 public class Renderer : IVgaRenderer {
-    private static readonly object RenderLock = new();
     private readonly VideoMemory _memory;
     private readonly IVideoState _state;
-    private readonly IEmulatedClock _clock;
+    private readonly VgaBlinkState _blinkState;
+    private readonly IVgaRenderer256Color _renderer256Color;
+
+    private uint[] _frontBuffer = Array.Empty<uint>();
+    private uint[] _backBuffer = Array.Empty<uint>();
+    private uint[] _renderBuffer = Array.Empty<uint>();
+    // Holds the most recently completed frame. Written only by the renderer
+    // CompleteFrame(), read only by the renderer in InitBackBufferFromFront().
+    // Never touched by the UI-thread buffer rotation, so it is always exactly one frame old.
+    private uint[] _lastPublishedFrame = Array.Empty<uint>();
+    private int _hasPendingFrame;
+    // Guard to prevent re-entrant Render() calls on the UI path.
+    private int _renderInProgress;
+
+    // Dirty-skip state: true if all scanlines should skip pixel drawing this frame.
+    private bool _skipThisFrame;
+    private int _frameOutputRows;
+
+    // Per-frame latched state (set in BeginFrame, constant for the frame).
+    private int _frameSkew;
+    private int _frameCharacterClockMask;
+    private MemoryWidth _frameMemoryWidthMode;
+    private bool _frameScanLineBit0ForAddressBit13;
+    private bool _frameScanLineBit0ForAddressBit14;
+    private int _frameVerticalDisplayEnd;
+    private int _frameTotalHeight;
+    private bool _frameActive;
+
+    // Mutable state (advances per scanline via RenderScanline).
+    private int _frameRowMemoryAddressCounter;
+    private int _frameDestinationAddress;
+    private bool _frameVerticalBlanking;
+    private int _frameLineCounter;
+    private int _frameCharRowScanline;
+    private int _frameDoubleScanIndex;
+    private int _frameDestinationAddressLatch;
+
+    // Per-character-row state (re-read from registers at each row boundary).
+    private int _frameHorizontalDisplayEnd;
+    private int _frameTotalWidth;
+    private bool[] _framePlanesEnabled = Array.Empty<bool>();
+    private byte _frameMaximumScanline;
+    private int _frameDrawLinesPerScanLine;
 
     /// <summary>
     ///     Create a new VGA renderer.
     /// </summary>
     /// <param name="memory">The video memory implementation.</param>
     /// <param name="state">The video state implementation.</param>
-    /// <param name="clock">The emulated clock used to schedule rendering timing.</param>
+    /// <param name="blinkState">Shared blink state for text-mode attribute blinking.</param>
     /// <param name="loggerService">The logger service implementation.</param>
-    public Renderer(IMemory memory, IVideoState state, IEmulatedClock clock, LoggerService loggerService) {
+    /// <param name="renderer256Color">The 256-color scanline renderer selected for the current CPU.</param>
+    public Renderer(IMemory memory, IVideoState state, VgaBlinkState blinkState, LoggerService loggerService, IVgaRenderer256Color renderer256Color) {
         _state = state;
-        _clock = clock;
+        _blinkState = blinkState;
+        _renderer256Color = renderer256Color;
         const uint videoBaseAddress = MemoryMap.GraphicVideoMemorySegment << 4;
         _memory = new VideoMemory(_state, loggerService);
         memory.RegisterMapping(videoBaseAddress, _memory.Size, _memory);
@@ -45,143 +91,215 @@ public class Renderer : IVgaRenderer {
     /// <inheritdoc />
     public int BufferSize { get; private set; }
 
-    /// <inheritdoc />
-    public TimeSpan LastFrameRenderTime { get; private set; }
+    /// <summary>
+    ///     Called by <see cref="VgaTimingEngine"/> at frame start on the emulation thread.
+    ///     Latches per-frame register values and prepares the back buffer for scanline rendering.
+    /// </summary>
+    public void BeginFrame() {
+        bool isDirty = _memory.HasChanged || _state.IsRenderingDirty || _blinkState.HasChanged;
+        _memory.ResetChanged();
+        _state.IsRenderingDirty = false;
+        _blinkState.ResetChanged();
+
+        _skipThisFrame = !isDirty;
+        _frameOutputRows = 0;
+
+        int width = Width;
+        int height = Height;
+        int requiredSize = width * height;
+        if (requiredSize <= 0) {
+            _frameActive = false;
+            return;
+        }
+        if (_backBuffer.Length != requiredSize) {
+            _backBuffer = new uint[requiredSize];
+        }
+        BufferSize = requiredSize;
+        _frameActive = true;
+
+        _frameVerticalDisplayEnd = _state.CrtControllerRegisters.VerticalDisplayEndValue;
+        _frameTotalHeight = _state.CrtControllerRegisters.VerticalTotalValue + 2;
+        _frameSkew = _state.CrtControllerRegisters.HorizontalBlankingEndRegister.DisplayEnableSkew;
+        _frameCharacterClockMask = _state.CrtControllerRegisters.UnderlineRowScanlineRegister.CountByFour
+            ? 3
+            : _state.CrtControllerRegisters.CrtModeControlRegister.CountByTwo
+                ? 1
+                : 0;
+        _frameRowMemoryAddressCounter = _state.CrtControllerRegisters.ScreenStartAddress
+            + _state.CrtControllerRegisters.PresetRowScanRegister.BytePanning;
+        _frameMemoryWidthMode = DetermineMemoryWidthMode();
+        _frameScanLineBit0ForAddressBit13 = !_state.CrtControllerRegisters.CrtModeControlRegister.CompatibilityModeSupport;
+        _frameScanLineBit0ForAddressBit14 = !_state.CrtControllerRegisters.CrtModeControlRegister.SelectRowScanCounter;
+
+        _frameDestinationAddress = 0;
+        _frameVerticalBlanking = false;
+        _frameLineCounter = _state.CrtControllerRegisters.PresetRowScanRegister.PresetRowScan;
+        _frameCharRowScanline = 0;
+        _frameDoubleScanIndex = 0;
+        _frameDestinationAddressLatch = 0;
+
+        InitCharRow();
+    }
+
+    /// <summary>
+    ///     Called by <see cref="VgaTimingEngine"/> for each physical scanline on the emulation thread.
+    ///     Renders one horizontal line of pixels from VRAM into the back buffer and advances state.
+    /// </summary>
+    public void RenderScanline() {
+        if (!_frameActive || _frameLineCounter >= _frameTotalHeight) {
+            return;
+        }
+
+        if (_skipThisFrame && (_memory.HasChanged || _state.IsRenderingDirty)) {
+            _skipThisFrame = false;
+            InitBackBufferFromFront();
+            _frameDestinationAddressLatch = _frameOutputRows * Width;
+            _frameDestinationAddress = _frameDestinationAddressLatch;
+        }
+
+        Span<uint> frameBuffer = _backBuffer.AsSpan();
+
+        if (_frameDoubleScanIndex == 0) {
+            _frameDestinationAddressLatch = _frameDestinationAddress;
+        }
+
+        int memoryAddressCounter = _frameRowMemoryAddressCounter;
+        _frameDestinationAddress = _frameDestinationAddressLatch;
+
+        bool horizontalBlanking = true;
+
+        if (!_skipThisFrame) {
+            // Hoist per-scanline constants out of the per-character loop to avoid
+            // repeated interface dispatch and property-chain traversals.
+            uint[] paletteMap = _state.DacRegisters.PaletteMap;
+            uint[] attrMap = _state.DacRegisters.AttributeMap;
+            bool in256ColorMode = _state.GraphicsControllerRegisters.GraphicsModeRegister.In256ColorMode;
+            bool inGraphicsMode = _state.GraphicsControllerRegisters.MiscellaneousGraphicsRegister.GraphicsMode;
+            int pixelsPerChar = inGraphicsMode ? 8 : _state.SequencerRegisters.ClockingModeRegister.DotsPerClock;
+
+            VgaAddressMapper addressMapper = new VgaAddressMapper(
+                _frameMemoryWidthMode,
+                _frameScanLineBit0ForAddressBit13,
+                _frameScanLineBit0ForAddressBit14,
+                _frameCharRowScanline & 1);
+
+            if (in256ColorMode && !_frameVerticalBlanking) {
+                Render256ColorScanline(frameBuffer, paletteMap, addressMapper, memoryAddressCounter);
+            } else {
+                for (int characterCounter = 0; characterCounter < _frameTotalWidth; characterCounter++) {
+                    if (characterCounter == _frameSkew) {
+                        horizontalBlanking = false;
+                    }
+                    if (characterCounter == _frameHorizontalDisplayEnd) {
+                        horizontalBlanking = true;
+                    }
+                    if (horizontalBlanking || _frameVerticalBlanking) {
+                        continue;
+                    }
+
+                    if (_frameDestinationAddress + pixelsPerChar > frameBuffer.Length) {
+                        break;
+                    }
+
+                    (byte plane0, byte plane1, byte plane2, byte plane3) = ReadVideoMemory(memoryAddressCounter, addressMapper);
+
+                    if (inGraphicsMode) {
+                        DrawGraphicsMode(frameBuffer, attrMap, ref _frameDestinationAddress, plane0, plane1, plane2, plane3);
+                    } else {
+                        DrawTextMode(frameBuffer, attrMap, ref _frameDestinationAddress, plane0, plane1, _frameCharRowScanline);
+                    }
+                    memoryAddressCounter += (characterCounter & _frameCharacterClockMask) == 0 ? 1 : 0;
+                }
+            }
+        }
+
+        if (_frameLineCounter == _state.CrtControllerRegisters.LineCompareValue) {
+            _frameRowMemoryAddressCounter = 0;
+        }
+        if (_frameLineCounter == _frameVerticalDisplayEnd) {
+            _frameVerticalBlanking = true;
+        }
+
+        if (!(_state.CrtControllerRegisters.CrtModeControlRegister.VerticalTimingHalved
+              && (_frameCharRowScanline & 1) != 1)) {
+            _frameLineCounter++;
+        }
+
+        _frameDoubleScanIndex++;
+        if (_frameDoubleScanIndex >= _frameDrawLinesPerScanLine) {
+            _frameDoubleScanIndex = 0;
+            if (!_frameVerticalBlanking) {
+                _frameOutputRows++;
+            }
+            _frameCharRowScanline++;
+            if (_frameCharRowScanline > _frameMaximumScanline) {
+                _frameCharRowScanline = 0;
+                _frameRowMemoryAddressCounter += _state.CrtControllerRegisters.Offset << 1;
+                if (_frameLineCounter < _frameTotalHeight) {
+                    InitCharRow();
+                }
+            }
+        }
+    }
+
+    /// <summary>
+    ///     Called by <see cref="VgaTimingEngine"/> at vertical retrace on the emulation thread.
+    ///     Publishes the completed back buffer by swapping it with the front buffer.
+    /// </summary>
+    public void CompleteFrame() {
+        if (!_frameActive) {
+            return;
+        }
+        if (_skipThisFrame) {
+            _frameActive = false;
+            return;
+        }
+        _backBuffer = Interlocked.Exchange(ref _frontBuffer, _backBuffer);
+        // Publish the most recently completed frame with a release store so
+        // readers that observe `_hasPendingFrame` will see the fully-published
+        // buffer contents when they do a Volatile.Read on `_lastPublishedFrame`.
+        Volatile.Write(ref _lastPublishedFrame, Volatile.Read(ref _frontBuffer));
+        Volatile.Write(ref _hasPendingFrame, 1);
+        _frameActive = false;
+    }
 
     /// <inheritdoc />
     public void Render(Span<uint> frameBuffer) {
-        if (!Monitor.TryEnter(RenderLock)) {
-            // We're already rendering. Get out of here.
+        // Prevent re-entrant UI callbacks from overlapping this method.
+        if (Interlocked.CompareExchange(ref _renderInProgress, 1, 0) != 0) {
             return;
         }
+
         try {
-            BufferSize = frameBuffer.Length;
-            if (Width * Height > BufferSize) {
-                // Resolution change hasn't caught up yet. Skip a frame.
+            if (Interlocked.Exchange(ref _hasPendingFrame, 0) == 0) {
                 return;
             }
 
-            // Some timing helpers.
-            double horizontalLineDurationMs = 1000.0 / 31469.0; // Duration of one horizontal line in ms.
-            SpinWait waitSpinner = new SpinWait();
-            double frameStartMs = _clock.ElapsedTimeMs;
+            _renderBuffer = Interlocked.Exchange(ref _frontBuffer, _renderBuffer);
 
-            // I _think_ changes to these are ignored during the frame, so we latch them here.
-            int verticalDisplayEnd = _state.CrtControllerRegisters.VerticalDisplayEndValue;
-            int totalHeight = _state.CrtControllerRegisters.VerticalTotalValue + 2;
-            int skew = _state.CrtControllerRegisters.HorizontalBlankingEndRegister.DisplayEnableSkew; // Skew controls the delay of enabling the display at the start of the line.
-            int characterClockMask = _state.CrtControllerRegisters.UnderlineRowScanlineRegister.CountByFour
-                ? 3
-                : _state.CrtControllerRegisters.CrtModeControlRegister.CountByTwo
-                    ? 1
-                    : 0;
-            int rowMemoryAddressCounter = _state.CrtControllerRegisters.ScreenStartAddress + _state.CrtControllerRegisters.PresetRowScanRegister.BytePanning;
-
-            // Memory reading parameters.
-            MemoryWidth memoryWidthMode = DetermineMemoryWidthMode();
-            bool scanLineBit0ForAddressBit13 = !_state.CrtControllerRegisters.CrtModeControlRegister.CompatibilityModeSupport;
-            bool scanLineBit0ForAddressBit14 = !_state.CrtControllerRegisters.CrtModeControlRegister.SelectRowScanCounter;
-
-            _state.GeneralRegisters.InputStatusRegister1.VerticalRetrace = false;
-            _state.GeneralRegisters.InputStatusRegister1.DisplayDisabled = true;
-            int destinationAddress = 0;
-            bool verticalBlanking = false;
-
-            /////////////////////////
-            // Start Vertical loop //
-            /////////////////////////
-            int lineCounter = _state.CrtControllerRegisters.PresetRowScanRegister.PresetRowScan;
-            while (lineCounter < totalHeight) {
-                // These registers can change mid-frame, so we need to check them every scanline.
-                // I _think_ changes to these are ignored during a scanline, so we latch them here. 
-                int horizontalDisplayEnd = _state.CrtControllerRegisters.HorizontalDisplayEnd + 1 + skew;
-                int totalWidth = _state.CrtControllerRegisters.HorizontalTotal + 3;
-                bool[] planesEnabled = _state.AttributeControllerRegisters.ColorPlaneEnableRegister.PlanesEnabled;
-                byte maximumScanline = _state.CrtControllerRegisters.MaximumScanlineRegister.MaximumScanline;
-                int drawLinesPerScanLine = _state.CrtControllerRegisters.MaximumScanlineRegister.CrtcScanDouble ? 2 : 1;
-
-                // For every row we can have multiple lines. In text-modes this is used for character height, and in graphics
-                // modes this is used for double-scanning.
-                for (int scanline = 0; scanline <= maximumScanline; scanline++) {
-                    // We latch the destination address here, so that the double-scan lines are drawn on top of each other.
-                    int destinationAddressLatch = destinationAddress;
-                    for (int doubleScan = 0; doubleScan < drawLinesPerScanLine; doubleScan++) {
-                        int memoryAddressCounter = rowMemoryAddressCounter;
-                        destinationAddress = destinationAddressLatch;
-
-                        double msAtStartOfRow = _clock.ElapsedTimeMs;
-                        bool horizontalBlanking = true;
-
-                        ///////////////////////////
-                        // Start Horizontal loop //
-                        ///////////////////////////
-                        // We loop through the entire horizontal line, even if we're in blanking. This allows programs
-                        // to detect the brief disabling and enabling of the display during horizontal blanking.
-                        for (int characterCounter = 0; characterCounter < totalWidth; characterCounter++) {
-                            // Skew controls the delay of enabling the display at the start of the line.
-                            if (characterCounter == skew) {
-                                horizontalBlanking = false;
-                            }
-                            // For simplicity we ignore horizontal blanking registers and use the display end register.
-                            if (characterCounter == horizontalDisplayEnd) {
-                                horizontalBlanking = true;
-                            }
-                            if (horizontalBlanking || verticalBlanking) {
-                                _state.GeneralRegisters.InputStatusRegister1.DisplayDisabled = true;
-                                // No need to read memory or render pixels.
-                                continue;
-                            }
-
-                            // No blanking, so we're rendering pixels.
-                            _state.GeneralRegisters.InputStatusRegister1.DisplayDisabled = false;
-
-                            (byte plane0, byte plane1, byte plane2, byte plane3) = ReadVideoMemory(memoryWidthMode, memoryAddressCounter, scanLineBit0ForAddressBit13, scanline, scanLineBit0ForAddressBit14, planesEnabled);
-
-                            // Convert the 4 bytes into 8 pixels.
-                            if (_state.GraphicsControllerRegisters.GraphicsModeRegister.In256ColorMode) {
-                                Draw256ColorMode(frameBuffer, ref destinationAddress, plane0, plane1, plane2, plane3);
-                            } else if (_state.GraphicsControllerRegisters.MiscellaneousGraphicsRegister.GraphicsMode) {
-                                DrawGraphicsMode(frameBuffer, ref destinationAddress, plane0, plane1, plane2, plane3);
-                            } else {
-                                DrawTextMode(frameBuffer, ref destinationAddress, plane0, plane1, scanline);
-                            }
-                            // This increases the memory address counter after each character, taking count-by-two and count-by-four into account.
-                            memoryAddressCounter += (characterCounter & characterClockMask) == 0 ? 1 : 0;
-                        } // End of horizontal loop
-
-                        // When the LineCompare register value is reached, the video memory address is reset to 0. This allows a split-screen effect.
-                        if (lineCounter == _state.CrtControllerRegisters.LineCompareValue) {
-                            rowMemoryAddressCounter = 0;
-                        }
-                        // To maximize the time spent in vertical retrace, we start it at the end of display.
-                        if (lineCounter == verticalDisplayEnd) {
-                            _state.GeneralRegisters.InputStatusRegister1.VerticalRetrace = true;
-                            verticalBlanking = true;
-                        }
-
-                        // We wait at the end of each line to create the correct horizontal timing of 31.46875 kHz
-                        // This allows programs running in the CPU thread to detect the horizontal retrace.
-                        while (!_clock.IsPaused && _clock.ElapsedTimeMs - msAtStartOfRow < horizontalLineDurationMs) {
-                            waitSpinner.SpinOnce(-1);
-                        }
-                        // If the VerticalTiming is halved, we only increase the line counter every other scanline.
-                        if (_state.CrtControllerRegisters.CrtModeControlRegister.VerticalTimingHalved && (scanline & 1) != 1) {
-                            continue;
-                        }
-                        lineCounter++;
-                    } // End of doubleScan
-                } // end of scanline loop
-
-                // Rather than simply continuing increasing memory addresses, an offset is added at the end of each line.
-                // This allows creating a "virtual screen" that is larger than the displayed area.
-                rowMemoryAddressCounter += _state.CrtControllerRegisters.Offset << 1;
-            } // End of vertical loop
-
-            LastFrameRenderTime = TimeSpan.FromMilliseconds(_clock.ElapsedTimeMs - frameStartMs);
-        } catch (IndexOutOfRangeException) {
-            // Resolution changed during rendering, discard the rest of this frame.
+            uint[] render = Volatile.Read(ref _renderBuffer);
+            if (render.Length > 0 && render.Length <= frameBuffer.Length) {
+                render.AsSpan().CopyTo(frameBuffer);
+            }
         } finally {
-            Monitor.Exit(RenderLock);
+            Interlocked.Exchange(ref _renderInProgress, 0);
+        }
+    }
+
+    private void InitCharRow() {
+        _frameHorizontalDisplayEnd = _state.CrtControllerRegisters.HorizontalDisplayEnd + 1 + _frameSkew;
+        _frameTotalWidth = _state.CrtControllerRegisters.HorizontalTotal + 3;
+        _framePlanesEnabled = _state.AttributeControllerRegisters.ColorPlaneEnableRegister.PlanesEnabled;
+        _frameMaximumScanline = _state.CrtControllerRegisters.MaximumScanlineRegister.MaximumScanline;
+        _frameDrawLinesPerScanLine = _state.CrtControllerRegisters.MaximumScanlineRegister.CrtcScanDouble ? 2 : 1;
+    }
+
+    private void InitBackBufferFromFront() {
+        // Use an acquire read to ensure we see the contents published by
+        // `CompleteFrame()` which does a release write.
+        uint[] last = Volatile.Read(ref _lastPublishedFrame);
+        if (last.Length == _backBuffer.Length) {
+            last.AsSpan().CopyTo(_backBuffer.AsSpan());
         }
     }
 
@@ -199,115 +317,207 @@ public class Renderer : IVgaRenderer {
         return memoryWidthMode;
     }
 
-    private (byte plane0, byte plane1, byte plane2, byte plane3) ReadVideoMemory(
-        MemoryWidth memoryWidthMode, int memoryAddressCounter,
-        bool scanLineBit0ForAddressBit13, int scanline,
-        bool scanLineBit0ForAddressBit14, ReadOnlySpan<bool> planesEnabled) {
-        // Convert logical address to physical address.
-        ushort physicalAddress = memoryWidthMode switch {
-            MemoryWidth.Byte => (ushort)memoryAddressCounter,
-            MemoryWidth.Word13 => (ushort)(memoryAddressCounter << 1 | memoryAddressCounter >> 13 & 1),
-            MemoryWidth.Word15 => (ushort)(memoryAddressCounter << 1 | memoryAddressCounter >> 15 & 1),
-            MemoryWidth.DoubleWord => (ushort)((memoryAddressCounter << 2) | ((memoryAddressCounter >> 14) & 3)),
-            _ => throw new InvalidOperationException($"Unsupported memory width: {memoryWidthMode}")
-        };
-        if (scanLineBit0ForAddressBit13) {
-            // Use the scan line counter rather than the memory address counter for bit 13.
-            // In effect this causes all odd scanline reads to be read from memory address + 0x2000.
-            physicalAddress = (ushort)(physicalAddress & ~0x2000 | ((scanline & 1) != 0 ? 0x2000 : 0));
-        }
-        if (scanLineBit0ForAddressBit14) {
-            // Use the scan line counter rather than the memory address counter for bit 14.
-            // In effect this causes all odd scanline reads to be read from memory address + 0x4000.
-            physicalAddress = (ushort)(physicalAddress & ~0x4000 | ((scanline & 1) != 0 ? 0x4000 : 0));
+    private void Render256ColorScanline(Span<uint> frameBuffer, uint[] paletteMap,
+        VgaAddressMapper addressMapper, int memoryAddressCounter) {
+        int visibleChars = _frameHorizontalDisplayEnd - _frameSkew;
+        if (visibleChars <= 0) {
+            return;
         }
 
-        // Read 4 bytes from the 4 planes.
-        byte plane0 = (byte)(planesEnabled[0] ? _memory.Planes[0, physicalAddress] : 0);
-        byte plane1 = (byte)(planesEnabled[1] ? _memory.Planes[1, physicalAddress] : 0);
-        byte plane2 = (byte)(planesEnabled[2] ? _memory.Planes[2, physicalAddress] : 0);
-        byte plane3 = (byte)(planesEnabled[3] ? _memory.Planes[3, physicalAddress] : 0);
+        // Fast path: when addresses are contiguous (Byte mode, mask == 0),
+        // hand a single VRAM span to the SIMD renderer (zero-copy).
+        if (_frameCharacterClockMask == 0) {
+            ushort startPhysical = addressMapper.ComputeAddress(memoryAddressCounter);
+            bool isContiguous;
+            if (visibleChars <= 1) {
+                isContiguous = true;
+            } else {
+                ushort endPhysical = addressMapper.ComputeAddress(memoryAddressCounter + visibleChars - 1);
+                isContiguous = endPhysical - startPhysical == visibleChars - 1;
+            }
+            if (isContiguous) {
+                RenderContiguous256(frameBuffer, paletteMap, startPhysical, visibleChars);
+                return;
+            }
+        }
+
+        // Non-contiguous path: read each character's VRAM data and write
+        // pixels directly to the frame buffer in a single pass.
+        RenderDirect256(frameBuffer, paletteMap, addressMapper, memoryAddressCounter, visibleChars);
+    }
+
+    private void RenderContiguous256(Span<uint> frameBuffer, uint[] paletteMap,
+        ushort startPhysical, int visibleChars) {
+        int vramLinearStart = startPhysical * 4;
+        int vramByteCount = visibleChars * 4;
+
+        if (vramLinearStart + vramByteCount > _memory.VRam.Length) {
+            vramByteCount = _memory.VRam.Length - vramLinearStart;
+        }
+        if (vramByteCount <= 0) {
+            return;
+        }
+
+        ReadOnlySpan<byte> vram = _memory.GetLinearSpan(vramLinearStart, vramByteCount);
+
+        int pixelCount = vramByteCount * 2;
+        if (_frameDestinationAddress + pixelCount > frameBuffer.Length) {
+            pixelCount = frameBuffer.Length - _frameDestinationAddress;
+        }
+        if (pixelCount <= 0) {
+            return;
+        }
+
+        _renderer256Color.RenderDoubledScanline(frameBuffer, vram, paletteMap, pixelCount / 2, ref _frameDestinationAddress);
+    }
+
+    private void RenderDirect256(Span<uint> frameBuffer, uint[] paletteMap,
+        VgaAddressMapper addressMapper, int memoryAddressCounter, int visibleChars) {
+        int dest = _frameDestinationAddress;
+        byte[] vram = _memory.VRam;
+        int currCounter = memoryAddressCounter;
+        for (int i = 0; i < visibleChars; i++) {
+            ushort physical = addressMapper.ComputeAddress(currCounter);
+            int baseIdx = physical * 4;
+            if (baseIdx + 4 > vram.Length || dest + 8 > frameBuffer.Length) {
+                break;
+            }
+            uint c0 = paletteMap[vram[baseIdx]];
+            uint c1 = paletteMap[vram[baseIdx + 1]];
+            uint c2 = paletteMap[vram[baseIdx + 2]];
+            uint c3 = paletteMap[vram[baseIdx + 3]];
+            frameBuffer[dest] = c0;
+            frameBuffer[dest + 1] = c0;
+            frameBuffer[dest + 2] = c1;
+            frameBuffer[dest + 3] = c1;
+            frameBuffer[dest + 4] = c2;
+            frameBuffer[dest + 5] = c2;
+            frameBuffer[dest + 6] = c3;
+            frameBuffer[dest + 7] = c3;
+            dest += 8;
+            int characterCounter = _frameSkew + i;
+            currCounter += (characterCounter & _frameCharacterClockMask) == 0 ? 1 : 0;
+        }
+        _frameDestinationAddress = dest;
+    }
+
+    private (byte plane0, byte plane1, byte plane2, byte plane3) ReadVideoMemory(int memoryAddressCounter, VgaAddressMapper addressMapper) {
+        ushort physicalAddress = addressMapper.ComputeAddress(memoryAddressCounter);
+        int baseIdx = physicalAddress * 4;
+
+        byte plane0 = (byte)(_framePlanesEnabled[0] ? _memory.VRam[baseIdx] : 0);
+        byte plane1 = (byte)(_framePlanesEnabled[1] ? _memory.VRam[baseIdx + 1] : 0);
+        byte plane2 = (byte)(_framePlanesEnabled[2] ? _memory.VRam[baseIdx + 2] : 0);
+        byte plane3 = (byte)(_framePlanesEnabled[3] ? _memory.VRam[baseIdx + 3] : 0);
 
         return (plane0, plane1, plane2, plane3);
     }
 
-    private void DrawTextMode(Span<uint> frameBuffer, ref int destinationAddress, byte plane0, byte plane1, int scanline) {
+    private readonly struct VgaAddressMapper {
+        private readonly MemoryWidth _mode;
+        private readonly ushort _andMask13;
+        private readonly ushort _orMask13;
+        private readonly ushort _andMask14;
+        private readonly ushort _orMask14;
+
+        public VgaAddressMapper(MemoryWidth mode, bool scanLineBit0ForAddressBit13, bool scanLineBit0ForAddressBit14, int scanlineBit0) {
+            _mode = mode;
+            _andMask13 = scanLineBit0ForAddressBit13 ? (ushort)(~0x2000 & 0xFFFF) : (ushort)0xFFFF;
+            _orMask13 = (scanLineBit0ForAddressBit13 && scanlineBit0 != 0) ? (ushort)0x2000 : (ushort)0;
+            _andMask14 = scanLineBit0ForAddressBit14 ? (ushort)(~0x4000 & 0xFFFF) : (ushort)0xFFFF;
+            _orMask14 = (scanLineBit0ForAddressBit14 && scanlineBit0 != 0) ? (ushort)0x4000 : (ushort)0;
+        }
+
+        public ushort ComputeAddress(int counter) {
+            ushort p = _mode switch {
+                MemoryWidth.Byte => (ushort)counter,
+                MemoryWidth.Word13 => (ushort)((counter << 1) | ((counter >> 13) & 1)),
+                MemoryWidth.Word15 => (ushort)((counter << 1) | ((counter >> 15) & 1)),
+                MemoryWidth.DoubleWord => (ushort)((counter << 2) | ((counter >> 14) & 3)),
+                _ => throw new InvalidOperationException($"Unsupported memory width: {_mode}")
+            };
+            p = (ushort)((p & _andMask13) | _orMask13);
+            p = (ushort)((p & _andMask14) | _orMask14);
+            return p;
+        }
+    }
+
+    private void DrawTextMode(Span<uint> frameBuffer, uint[] attrMap, ref int destinationAddress, byte plane0, byte plane1, int scanline) {
         // Text mode
         // Plane 0 contains the character codes.
         int fontAddress = 32 * plane0; // No idea why this seems to work for all character heights. It shouldn't.
         // The byte in plane 1 contains the foreground and background colors.
-        uint backGroundColor = GetDacPaletteColor(plane1 >> 4 & 0b1111);
+        uint backGroundColor = attrMap[(plane1 >> 4) & 0xF];
         int index;
-        if (_state.SequencerRegisters.MemoryModeRegister.ExtendedMemory) {
+        SequencerRegisters sequencer = _state.SequencerRegisters;
+        if (sequencer.MemoryModeRegister.ExtendedMemory) {
             // Bit 3 controls which font is used.
             if ((plane1 & 0x8) != 0) {
-                fontAddress += _state.SequencerRegisters.CharacterMapSelectRegister.CharacterMapA;
+                fontAddress += sequencer.CharacterMapSelectRegister.CharacterMapA;
             } else {
-                fontAddress += _state.SequencerRegisters.CharacterMapSelectRegister.CharacterMapB;
+                fontAddress += sequencer.CharacterMapSelectRegister.CharacterMapB;
             }
             index = plane1 & 0x7;
         } else {
             // Bit 3 controls color intensity.
             index = plane1 & 0xF;
         }
-        uint foreGroundColor = GetDacPaletteColor(index);
+        uint foreGroundColor = attrMap[index];
         if (_state.AttributeControllerRegisters.AttributeControllerModeRegister.BlinkingEnabled
-            && (plane1 & 0x80) != 0) {
-            double blinkPhaseMs = _clock.ElapsedTimeMs % 1000.0;
-            if (blinkPhaseMs < 500.0) {
-                // Blinking is enabled and the blink bit is set and the current time is in the first half of the second.
-                // Swap the foreground and background colors.
-                (foreGroundColor, backGroundColor) = (backGroundColor & 0x7, foreGroundColor);
-            }
+            && (plane1 & 0x80) != 0
+            && !_blinkState.IsBlinkPhaseHigh) {
+            (foreGroundColor, backGroundColor) = (backGroundColor & 0x7, foreGroundColor);
         }
-             
+
+        int dotsPerClock = sequencer.ClockingModeRegister.DotsPerClock;
         // The 8 pixels to render this line come from the font which is stored in plane 2.
-        byte fontByte = _memory.Planes[2, fontAddress + scanline];
-        for (int x = 0; x < _state.SequencerRegisters.ClockingModeRegister.DotsPerClock; x++) {
-            uint pixel = (fontByte & 0x80 >> x) != 0 ? foreGroundColor : backGroundColor;
+        byte fontByte = _memory.VRam[(fontAddress + scanline) * 4 + 2];
+        byte mask = 0x80;
+        for (int x = 0; x < dotsPerClock; x++, mask >>= 1) {
+            uint pixel = (fontByte & mask) != 0 ? foreGroundColor : backGroundColor;
             frameBuffer[destinationAddress++] = pixel;
         }
     }
 
-    private void DrawGraphicsMode(Span<uint> frameBuffer, ref int destinationAddress, byte plane0, byte plane1, byte plane2, byte plane3) {
+    private void DrawGraphicsMode(Span<uint> frameBuffer, uint[] attrMap, ref int destinationAddress, byte plane0, byte plane1, byte plane2, byte plane3) {
         // There are 2 graphics modes, Ega compatible and Cga compatible.
         if (_state.GraphicsControllerRegisters.GraphicsModeRegister.ShiftRegisterMode == ShiftRegisterMode.Ega) {
-            DrawEgaModeGraphics(frameBuffer, ref destinationAddress, plane0, plane1, plane2, plane3);
+            DrawEgaModeGraphics(frameBuffer, attrMap, ref destinationAddress, plane0, plane1, plane2, plane3);
         } else {
-            DrawCgaModeGraphics(frameBuffer, ref destinationAddress, plane0, plane1, plane2, plane3);
+            DrawCgaModeGraphics(frameBuffer, attrMap, ref destinationAddress, plane0, plane1, plane2, plane3);
         }
     }
 
-    private void DrawCgaModeGraphics(Span<uint> frameBuffer, ref int destinationAddress, byte plane0, byte plane1, byte plane2, byte plane3) {
+    private void DrawCgaModeGraphics(Span<uint> frameBuffer, uint[] attrMap, ref int destinationAddress, byte plane0, byte plane1, byte plane2, byte plane3) {
         // Cga mode has a different shift register mode, where the bits are interleaved.
         // First 4 pixels are created from planes 0 and 2.
         for (int bitNr = 6; bitNr >= 0; bitNr -= 2) {
             int index = (plane2 >> bitNr & 3) << 2 | plane0 >> bitNr & 3;
-            frameBuffer[destinationAddress++] = GetDacPaletteColor(index);
+            frameBuffer[destinationAddress++] = attrMap[index];
         }
         // Then 4 pixels are created from planes 1 and 3.
         for (int bitNr = 6; bitNr >= 0; bitNr -= 2) {
             int index = (plane3 >> bitNr & 3) << 2 | plane1 >> bitNr & 3;
-            frameBuffer[destinationAddress++] = GetDacPaletteColor(index);
+            frameBuffer[destinationAddress++] = attrMap[index];
         }
     }
 
-    private void DrawEgaModeGraphics(Span<uint> frameBuffer, ref int destinationAddress, byte plane0, byte plane1, byte plane2, byte plane3) {
+    private void DrawEgaModeGraphics(Span<uint> frameBuffer, uint[] attrMap, ref int destinationAddress, byte plane0, byte plane1, byte plane2, byte plane3) {
         // Loop through those bytes and create an index from the 4 planes for each bit,
         // outputting 8 pixels.
         for (int bitNr = 7; bitNr >= 0; bitNr--) {
             int index = (plane3 >> bitNr & 1) << 3 | (plane2 >> bitNr & 1) << 2 | (plane1 >> bitNr & 1) << 1 | plane0 >> bitNr & 1;
-            frameBuffer[destinationAddress++] = GetDacPaletteColor(index);
+            frameBuffer[destinationAddress++] = attrMap[index];
         }
     }
 
-    private void Draw256ColorMode(Span<uint> frameBuffer, ref int destinationAddress, byte plane0, byte plane1, byte plane2, byte plane3) {
+    private void Draw256ColorMode(Span<uint> frameBuffer, uint[] paletteMap, ref int destinationAddress, byte plane0, byte plane1, byte plane2, byte plane3) {
         // 256-color mode is simply using the video memory bytes directly.
         // Output 8 pixels by drawing each of the 4 pixels twice.
-        uint pixel12Color = GetDacPaletteColor(plane0);
-        uint pixel34Color = GetDacPaletteColor(plane1);
-        uint pixel56Color = GetDacPaletteColor(plane2);
-        uint pixel78Color = GetDacPaletteColor(plane3);
+        uint pixel12Color = paletteMap[plane0];
+        uint pixel34Color = paletteMap[plane1];
+        uint pixel56Color = paletteMap[plane2];
+        uint pixel78Color = paletteMap[plane3];
         frameBuffer[destinationAddress++] = pixel12Color;
         frameBuffer[destinationAddress++] = pixel12Color;
         frameBuffer[destinationAddress++] = pixel34Color;
@@ -318,23 +528,7 @@ public class Renderer : IVgaRenderer {
         frameBuffer[destinationAddress++] = pixel78Color;
     }
 
-    private uint GetDacPaletteColor(int index) {
-        switch (_state.AttributeControllerRegisters.AttributeControllerModeRegister.PixelWidth8) {
-            case true:
-                return _state.DacRegisters.ArgbPalette[index];
-            default: {
-                int fromPaletteRam6Bits = _state.AttributeControllerRegisters.InternalPalette[index & 0x0F];
-                int bits0To3 = fromPaletteRam6Bits & 0b00001111;
-                int bits4And5 = _state.AttributeControllerRegisters.AttributeControllerModeRegister.VideoOutput45Select
-                    ? _state.AttributeControllerRegisters.ColorSelectRegister.Bits45 << 4
-                    : fromPaletteRam6Bits & 0b00110000;
-                int bits6And7 = _state.AttributeControllerRegisters.ColorSelectRegister.Bits67 << 6;
-                int dacIndex8Bits = bits6And7 | bits4And5 | bits0To3;
-                int paletteIndex = dacIndex8Bits & _state.DacRegisters.PixelMask;
-                return _state.DacRegisters.ArgbPalette[paletteIndex];
-            }
-        }
-    }
+
 }
 
 internal enum MemoryWidth {

--- a/src/Spice86.Core/Emulator/Devices/Video/VgaBlinkState.cs
+++ b/src/Spice86.Core/Emulator/Devices/Video/VgaBlinkState.cs
@@ -1,0 +1,38 @@
+namespace Spice86.Core.Emulator.Devices.Video;
+
+using System.Threading;
+
+/// <summary>
+///     Shared mutable state for text-mode attribute blinking, driven by
+///     <see cref="VgaTimingEngine"/> on the emulation thread and read by
+///     <see cref="Renderer"/> during pixel conversion.
+/// </summary>
+public sealed class VgaBlinkState {
+    // Backing ints so we can use Volatile/Interlocked semantics across threads.
+    private int _isBlinkPhaseHigh;
+    private int _hasChanged;
+
+    /// <summary>
+    ///     Whether the blink phase is currently high (visible).
+    ///     Written only on the emulation thread; read during rendering.
+    /// </summary>
+    public bool IsBlinkPhaseHigh {
+        get => Volatile.Read(ref _isBlinkPhaseHigh) != 0;
+        set => Volatile.Write(ref _isBlinkPhaseHigh, value ? 1 : 0);
+    }
+
+    /// <summary>
+    ///     Whether the blink state has changed since the last call to <see cref="ResetChanged"/>.
+    /// </summary>
+    public bool HasChanged => Volatile.Read(ref _hasChanged) != 0;
+
+    /// <summary>
+    ///     Marks the blink state as changed.
+    /// </summary>
+    public void MarkChanged() => Volatile.Write(ref _hasChanged, 1);
+
+    /// <summary>
+    ///     Resets the <see cref="HasChanged"/> flag to <c>false</c>.
+    /// </summary>
+    public void ResetChanged() => Interlocked.Exchange(ref _hasChanged, 0);
+}

--- a/src/Spice86.Core/Emulator/Devices/Video/VgaCard.cs
+++ b/src/Spice86.Core/Emulator/Devices/Video/VgaCard.cs
@@ -46,9 +46,9 @@ public class VgaCard {
             return true;
         }
         _gui?.SetResolution(_renderer.Width, _renderer.Height);
-        // Wait for it to be applied
-        while (_renderer.Width != _gui?.Width || _renderer.Height != _gui?.Height);
-        // Report that resolution did not match
+        // Resolution change is asynchronous via Dispatcher.Post; skip this frame
+        // to avoid blocking the UI thread (the previous busy-wait would deadlock
+        // now that DrawScreen runs on the UI thread via DispatcherTimer).
         return false;
     }
     

--- a/src/Spice86.Core/Emulator/Devices/Video/VgaIoPortHandler.cs
+++ b/src/Spice86.Core/Emulator/Devices/Video/VgaIoPortHandler.cs
@@ -18,6 +18,7 @@ public class VgaIoPortHandler : DefaultIOPortHandler {
     private readonly GeneralRegisters _generalRegisters;
     private readonly GraphicsControllerRegisters _graphicsRegisters;
     private readonly SequencerRegisters _sequencerRegisters;
+    private readonly IVideoState _videoState;
     private bool _attributeDataMode;
 
     /// <summary>
@@ -38,6 +39,7 @@ public class VgaIoPortHandler : DefaultIOPortHandler {
         _crtRegisters = videoState.CrtControllerRegisters;
         _generalRegisters = videoState.GeneralRegisters;
         _dacRegisters = videoState.DacRegisters;
+        _videoState = videoState;
         InitPortHandlers(ioPortDispatcher);
     }
 
@@ -219,6 +221,7 @@ public class VgaIoPortHandler : DefaultIOPortHandler {
 
     /// <inheritdoc />
     public override void WriteByte(ushort port, byte value) {
+        _videoState.IsRenderingDirty = true;
         switch (port) {
             case Ports.DacAddressReadIndex:
                 if (_loggerService.IsEnabled(LogEventLevel.Debug)) {
@@ -239,13 +242,17 @@ public class VgaIoPortHandler : DefaultIOPortHandler {
                     _loggerService.Verbose("[{Port:X4}] Write to DacData: {Value:X2}", port, value);
                 }
                 _dacRegisters.DataRegister = value;
+                if (_dacRegisters.TripletJustCompleted) {
+                    _dacRegisters.RebuildAttributeMap(_attributeRegisters);
+                }
                 break;
 
             case Ports.DacPelMask:
                 if (_loggerService.IsEnabled(LogEventLevel.Verbose)) {
                     _loggerService.Verbose("[{Port:X4}] Write to DacPelMask: {Value:X2}", port, value);
                 }
-                _dacRegisters.PixelMask = value;
+                _dacRegisters.PixelMask = value;  // setter calls RebuildAllPaletteMap internally
+                _dacRegisters.RebuildAttributeMap(_attributeRegisters);
                 break;
 
             case Ports.GraphicsControllerAddress:
@@ -295,6 +302,7 @@ public class VgaIoPortHandler : DefaultIOPortHandler {
                         _loggerService.Debug("[{Port:X4}] Write to Attribute register {Register}: {Value:X2} {Binary}", port, _attributeRegisters.AddressRegister, value, Convert.ToString(value, 2).PadLeft(8, '0'));
                     }
                     _attributeRegisters.WriteRegister(_attributeRegisters.AddressRegister, value);
+                    _dacRegisters.RebuildAttributeMap(_attributeRegisters);
                 }
 
                 _attributeDataMode = !_attributeDataMode;
@@ -305,6 +313,7 @@ public class VgaIoPortHandler : DefaultIOPortHandler {
                     _loggerService.Debug("[{Port:X4}] Write to Attribute register {Register}: {Value:X2} {Binary}", port, _attributeRegisters.AddressRegister, value, Convert.ToString(value, 2).PadLeft(8, '0'));
                 }
                 _attributeRegisters.WriteRegister(_attributeRegisters.AddressRegister, value);
+                _dacRegisters.RebuildAttributeMap(_attributeRegisters);
                 break;
 
             case Ports.CrtControllerAddress or Ports.CrtControllerAddressAlt or Ports.CrtControllerAddressAltMirror1 or Ports.CrtControllerAddressAltMirror2:

--- a/src/Spice86.Core/Emulator/Devices/Video/VgaRenderer256ColorAvx2.cs
+++ b/src/Spice86.Core/Emulator/Devices/Video/VgaRenderer256ColorAvx2.cs
@@ -1,0 +1,50 @@
+namespace Spice86.Core.Emulator.Devices.Video;
+
+using System;
+using System.Runtime.CompilerServices;
+using System.Runtime.Intrinsics;
+using System.Runtime.Intrinsics.X86;
+
+/// <summary>
+///     AVX2-accelerated renderer for 256-color VGA mode.
+///     Processes 8 pixels per iteration using gather instructions.
+/// </summary>
+internal sealed class VgaRenderer256ColorAvx2 : IVgaRenderer256Color {
+    /// <inheritdoc />
+    [MethodImpl(MethodImplOptions.AggressiveOptimization)]
+    public unsafe void RenderDoubledScanline(Span<uint> frameBuffer, ReadOnlySpan<byte> vram,
+        uint[] paletteMap, int byteCount, ref int destOffset) {
+        int dest = destOffset;
+        int i = 0;
+
+        fixed (byte* vramPtr = vram)
+        fixed (uint* destPtr = frameBuffer)
+        fixed (uint* palPtr = paletteMap) {
+            int count8 = byteCount & ~7;
+            while (i < count8) {
+                Vector128<byte> raw = Sse2.LoadScalarVector128((ulong*)(vramPtr + i)).AsByte();
+                Vector256<int> idx = Avx2.ConvertToVector256Int32(raw);
+                Vector256<int> pixels = Avx2.GatherVector256((int*)palPtr, idx, 4);
+
+                Vector256<int> lo = Avx2.UnpackLow(pixels, pixels);
+                Vector256<int> hi = Avx2.UnpackHigh(pixels, pixels);
+
+                Vector256<int> first8 = Avx2.Permute2x128(lo, hi, 0x20);
+                Vector256<int> second8 = Avx2.Permute2x128(lo, hi, 0x31);
+
+                Avx2.Store((int*)(destPtr + dest), first8);
+                Avx2.Store((int*)(destPtr + dest + 8), second8);
+                dest += 16;
+                i += 8;
+            }
+
+            while (i < byteCount) {
+                uint color = palPtr[vramPtr[i++]];
+                destPtr[dest++] = color;
+                destPtr[dest++] = color;
+            }
+        }
+
+        destOffset = dest;
+    }
+}

--- a/src/Spice86.Core/Emulator/Devices/Video/VgaRenderer256ColorScalar.cs
+++ b/src/Spice86.Core/Emulator/Devices/Video/VgaRenderer256ColorScalar.cs
@@ -1,0 +1,39 @@
+namespace Spice86.Core.Emulator.Devices.Video;
+
+using System;
+
+/// <summary>
+///     Scalar (non-SIMD) batch renderer for 256-color VGA mode.
+///     Processes 4 pixels per iteration to improve instruction-level parallelism.
+/// </summary>
+internal sealed class VgaRenderer256ColorScalar : IVgaRenderer256Color {
+    /// <inheritdoc />
+    public void RenderDoubledScanline(Span<uint> frameBuffer, ReadOnlySpan<byte> vram,
+        uint[] paletteMap, int byteCount, ref int destOffset) {
+        int dest = destOffset;
+        int i = 0;
+        int count4 = byteCount & ~3;
+        while (i < count4) {
+            uint c0 = paletteMap[vram[i]];
+            uint c1 = paletteMap[vram[i + 1]];
+            uint c2 = paletteMap[vram[i + 2]];
+            uint c3 = paletteMap[vram[i + 3]];
+            frameBuffer[dest] = c0;
+            frameBuffer[dest + 1] = c0;
+            frameBuffer[dest + 2] = c1;
+            frameBuffer[dest + 3] = c1;
+            frameBuffer[dest + 4] = c2;
+            frameBuffer[dest + 5] = c2;
+            frameBuffer[dest + 6] = c3;
+            frameBuffer[dest + 7] = c3;
+            dest += 8;
+            i += 4;
+        }
+        while (i < byteCount) {
+            uint color = paletteMap[vram[i++]];
+            frameBuffer[dest++] = color;
+            frameBuffer[dest++] = color;
+        }
+        destOffset = dest;
+    }
+}

--- a/src/Spice86.Core/Emulator/Devices/Video/VgaRenderer256ColorSimd.cs
+++ b/src/Spice86.Core/Emulator/Devices/Video/VgaRenderer256ColorSimd.cs
@@ -1,0 +1,23 @@
+namespace Spice86.Core.Emulator.Devices.Video;
+
+using System.Runtime.Intrinsics.X86;
+
+/// <summary>
+///     Factory that selects the best available <see cref="IVgaRenderer256Color"/>
+///     implementation based on the CPU's SIMD capabilities.
+/// </summary>
+public static class VgaRenderer256ColorSimd {
+    /// <summary>
+    ///     Creates the fastest 256-color renderer supported by the current CPU.
+    /// </summary>
+    /// <returns>An AVX2, SSE4.1, or scalar renderer instance.</returns>
+    public static IVgaRenderer256Color CreateBestRenderer() {
+        if (Avx2.IsSupported) {
+            return new VgaRenderer256ColorAvx2();
+        }
+        if (Sse41.IsSupported) {
+            return new VgaRenderer256ColorSse41();
+        }
+        return new VgaRenderer256ColorScalar();
+    }
+}

--- a/src/Spice86.Core/Emulator/Devices/Video/VgaRenderer256ColorSse41.cs
+++ b/src/Spice86.Core/Emulator/Devices/Video/VgaRenderer256ColorSse41.cs
@@ -1,0 +1,50 @@
+namespace Spice86.Core.Emulator.Devices.Video;
+
+using System;
+using System.Runtime.CompilerServices;
+using System.Runtime.Intrinsics;
+using System.Runtime.Intrinsics.X86;
+
+/// <summary>
+///     SSE4.1-accelerated renderer for 256-color VGA mode.
+///     Processes 4 pixels per iteration with manual gather via element extraction.
+/// </summary>
+internal sealed class VgaRenderer256ColorSse41 : IVgaRenderer256Color {
+    /// <inheritdoc />
+    [MethodImpl(MethodImplOptions.AggressiveOptimization)]
+    public unsafe void RenderDoubledScanline(Span<uint> frameBuffer, ReadOnlySpan<byte> vram,
+        uint[] paletteMap, int byteCount, ref int destOffset) {
+        int dest = destOffset;
+        int i = 0;
+
+        fixed (byte* vramPtr = vram)
+        fixed (uint* destPtr = frameBuffer)
+        fixed (uint* palPtr = paletteMap) {
+            int count4 = byteCount & ~3;
+            while (i < count4) {
+                Vector128<int> idx = Sse41.ConvertToVector128Int32(
+                    Sse2.LoadScalarVector128((int*)(vramPtr + i)).AsByte());
+
+                uint p0 = palPtr[(uint)Sse2.ConvertToInt32(idx)];
+                uint p1 = palPtr[(uint)Sse41.Extract(idx, 1)];
+                uint p2 = palPtr[(uint)Sse41.Extract(idx, 2)];
+                uint p3 = palPtr[(uint)Sse41.Extract(idx, 3)];
+
+                Vector128<uint> doubled0 = Vector128.Create(p0, p0, p1, p1);
+                Vector128<uint> doubled1 = Vector128.Create(p2, p2, p3, p3);
+                Sse2.Store(destPtr + dest, doubled0);
+                Sse2.Store(destPtr + dest + 4, doubled1);
+                dest += 8;
+                i += 4;
+            }
+
+            while (i < byteCount) {
+                uint color = palPtr[vramPtr[i++]];
+                destPtr[dest++] = color;
+                destPtr[dest++] = color;
+            }
+        }
+
+        destOffset = dest;
+    }
+}

--- a/src/Spice86.Core/Emulator/Devices/Video/VgaTimingEngine.cs
+++ b/src/Spice86.Core/Emulator/Devices/Video/VgaTimingEngine.cs
@@ -1,0 +1,122 @@
+namespace Spice86.Core.Emulator.Devices.Video;
+
+using Spice86.Core.Emulator.VM.Clock;
+using Spice86.Core.Emulator.VM.DeviceScheduler;
+
+/// <summary>
+///     Drives VGA timing signals (vertical retrace, display-disabled) via the
+///     <see cref="DeviceScheduler"/> so that they fire deterministically
+///     on the emulation thread instead of on a UI timer.
+///     Each scanline event chains to the next, matching the hardware beam progression.
+/// </summary>
+public class VgaTimingEngine {
+    private const double BlinkPeriodMs = 500.0;
+    private const double HorizontalLineDurationMs = 1000.0 / 31469.0;
+
+    private readonly IVideoState _state;
+    private readonly DeviceScheduler _scheduler;
+    private readonly IEmulatedClock _clock;
+    private readonly Renderer _renderer;
+    private readonly VgaBlinkState _blinkState;
+
+    private int _totalScanlines;
+    private int _verticalDisplayEndScanline;
+    private double _lastFrameStartMs;
+    private double _activeDisplayMs;
+    private double _hblankDurationMs;
+
+    /// <summary>
+    ///     The emulated duration of the last completed frame (active display period).
+    /// </summary>
+    public TimeSpan LastFrameDuration { get; private set; }
+
+    /// <summary>
+    ///     Creates a new VGA timing engine and schedules the initial frame and blink events.
+    /// </summary>
+    /// <param name="state">The video state holding CRT controller registers.</param>
+    /// <param name="scheduler">The emulation loop scheduler for deterministic event scheduling.</param>
+    /// <param name="clock">The emulated clock providing the master time source.</param>
+    /// <param name="renderer">The renderer to invoke for per-scanline pixel conversion.</param>
+    /// <param name="blinkState">Shared blink state toggled by this engine for text-mode blinking.</param>
+    public VgaTimingEngine(IVideoState state, DeviceScheduler scheduler,
+        IEmulatedClock clock, Renderer renderer, VgaBlinkState blinkState) {
+        _state = state;
+        _scheduler = scheduler;
+        _clock = clock;
+        _renderer = renderer;
+        _blinkState = blinkState;
+        _scheduler.AddEvent(OnFrameStart, 0);
+        _scheduler.AddEvent(OnBlinkToggle, BlinkPeriodMs);
+    }
+
+    private void RecomputeTimingParameters() {
+        int totalHeight = _state.CrtControllerRegisters.VerticalTotalValue + 2;
+        int verticalDisplayEnd = _state.CrtControllerRegisters.VerticalDisplayEndValue;
+        bool verticalTimingHalved = _state.CrtControllerRegisters.CrtModeControlRegister.VerticalTimingHalved;
+
+        _totalScanlines = totalHeight;
+        _verticalDisplayEndScanline = verticalDisplayEnd;
+
+        if (verticalTimingHalved) {
+            _totalScanlines = totalHeight * 2;
+            _verticalDisplayEndScanline = verticalDisplayEnd * 2;
+        }
+
+        int horizontalDisplayEnd = _state.CrtControllerRegisters.HorizontalDisplayEnd + 1;
+        int skew = _state.CrtControllerRegisters.HorizontalBlankingEndRegister.DisplayEnableSkew;
+        int totalWidth = _state.CrtControllerRegisters.HorizontalTotal + 3;
+        double characterClockDurationMs = HorizontalLineDurationMs / totalWidth;
+        _activeDisplayMs = (horizontalDisplayEnd + skew) * characterClockDurationMs;
+        _hblankDurationMs = HorizontalLineDurationMs - _activeDisplayMs;
+    }
+
+    private void OnFrameStart(uint value) {
+        RecomputeTimingParameters();
+        _lastFrameStartMs = _clock.ElapsedTimeMs;
+
+        _state.GeneralRegisters.InputStatusRegister1.VerticalRetrace = false;
+        _state.GeneralRegisters.InputStatusRegister1.DisplayDisabled = false;
+
+        _renderer.BeginFrame();
+
+        if (_verticalDisplayEndScanline > 0) {
+            _scheduler.AddEvent(OnScanlineActive, 0, 0);
+        } else {
+            _scheduler.AddEvent(OnVerticalRetraceStart, 0);
+        }
+    }
+
+    private void OnScanlineActive(uint scanline) {
+        _state.GeneralRegisters.InputStatusRegister1.DisplayDisabled = false;
+        _renderer.RenderScanline();
+        _scheduler.AddEvent(OnScanlineHBlank, _activeDisplayMs, scanline);
+    }
+
+    private void OnScanlineHBlank(uint scanline) {
+        _state.GeneralRegisters.InputStatusRegister1.DisplayDisabled = true;
+
+        if (scanline + 1 < (uint)_verticalDisplayEndScanline) {
+            _scheduler.AddEvent(OnScanlineActive, _hblankDurationMs, scanline + 1);
+        } else {
+            _scheduler.AddEvent(OnVerticalRetraceStart, _hblankDurationMs);
+        }
+    }
+
+    private void OnVerticalRetraceStart(uint value) {
+        _state.GeneralRegisters.InputStatusRegister1.VerticalRetrace = true;
+        _state.GeneralRegisters.InputStatusRegister1.DisplayDisabled = true;
+        LastFrameDuration = TimeSpan.FromMilliseconds(_clock.ElapsedTimeMs - _lastFrameStartMs);
+
+        _renderer.CompleteFrame();
+
+        int blankingLines = _totalScanlines - _verticalDisplayEndScanline;
+        double vBlankDurationMs = blankingLines * HorizontalLineDurationMs;
+        _scheduler.AddEvent(OnFrameStart, vBlankDurationMs);
+    }
+
+    private void OnBlinkToggle(uint value) {
+        _blinkState.IsBlinkPhaseHigh = !_blinkState.IsBlinkPhaseHigh;
+        _blinkState.MarkChanged();
+        _scheduler.AddEvent(OnBlinkToggle, BlinkPeriodMs);
+    }
+}

--- a/src/Spice86.Core/Emulator/Devices/Video/VideoMemory.cs
+++ b/src/Spice86.Core/Emulator/Devices/Video/VideoMemory.cs
@@ -1,5 +1,9 @@
 namespace Spice86.Core.Emulator.Devices.Video;
 
+using System;
+using System.Runtime.InteropServices;
+using System.Threading;
+
 using Spice86.Core.Emulator.Devices.Video.Registers;
 using Spice86.Core.Emulator.Devices.Video.Registers.Graphics;
 using Spice86.Shared.Interfaces;
@@ -11,6 +15,8 @@ public class VideoMemory : IVideoMemory {
     private readonly byte[] _latches;
     private readonly IVideoState _state;
     private readonly ILoggerService _logger;
+    // 0 = not changed, 1 = changed. Use int so we can use Interlocked/Volatile APIs.
+    private int _hasChanged;
 
     /// <summary>
     ///     Create a new instance of the video memory.
@@ -20,7 +26,8 @@ public class VideoMemory : IVideoMemory {
     public VideoMemory(IVideoState state, ILoggerService logger) {
         _state = state;
         Size = 128 * 1024; // This covers the 128kb of video memory address space from 0xA0000 to 0xBFFFF
-        Planes = new byte[4, 64 * 1024]; // VRAM consists of 4 planes of 64kb
+        VRam = new byte[4 * 64 * 1024];
+        Planes = new PlaneAccessor(VRam);
         _latches = new byte[4];
         _logger = logger;
     }
@@ -36,10 +43,12 @@ public class VideoMemory : IVideoMemory {
             return 0;
         }
         (byte plane, uint offset) = DecodeReadAddress(address);
-        _latches[0] = Planes[0, offset];
-        _latches[1] = Planes[1, offset];
-        _latches[2] = Planes[2, offset];
-        _latches[3] = Planes[3, offset];
+        // Load all 4 plane latches from the interleaved buffer.
+        int baseIdx = (int)offset * 4;
+        _latches[0] = VRam[baseIdx];
+        _latches[1] = VRam[baseIdx + 1];
+        _latches[2] = VRam[baseIdx + 2];
+        _latches[3] = VRam[baseIdx + 3];
         byte result = 0;
         switch (_state.GraphicsControllerRegisters.GraphicsModeRegister.ReadMode) {
             case ReadMode.ReadMode0:
@@ -136,7 +145,25 @@ public class VideoMemory : IVideoMemory {
     }
 
     /// <inheritdoc />
-    public byte[,] Planes { get; }
+    public byte[] VRam { get; }
+
+    /// <inheritdoc />
+    public PlaneAccessor Planes { get; }
+
+    /// <inheritdoc />
+    public ReadOnlySpan<byte> GetLinearSpan(int linearByteOffset, int length) {
+        return VRam.AsSpan(linearByteOffset, length);
+    }
+
+    /// <summary>
+    ///     Whether any plane byte has been modified since the last call to <see cref="ResetChanged"/>.
+    /// </summary>
+    public bool HasChanged => Volatile.Read(ref _hasChanged) != 0;
+
+    /// <summary>
+    ///     Resets the <see cref="HasChanged"/> flag to <c>false</c>.
+    /// </summary>
+    public void ResetChanged() => System.Threading.Interlocked.Exchange(ref _hasChanged, 0);
 
     private void HandleWriteMode3(byte value, Register8 planeEnable, ReadOnlySpan<bool> writePlane, Register8 setReset, uint offset) {
         value.Ror(_state.GraphicsControllerRegisters.DataRotateRegister.RotateCount);
@@ -152,7 +179,7 @@ public class VideoMemory : IVideoMemory {
             tempValue &= bitMask;
             tempValue |= (byte)(_latches[plane] & ~bitMask);
             // write the data
-            Planes[plane, offset] = tempValue;
+            WriteValue(plane, offset, tempValue);
         }
     }
 
@@ -174,7 +201,7 @@ public class VideoMemory : IVideoMemory {
             tempValue &= _state.GraphicsControllerRegisters.BitMask;
             tempValue |= (byte)(_latches[plane] & ~_state.GraphicsControllerRegisters.BitMask);
             // write the data
-            Planes[plane, offset] = tempValue;
+            WriteValue(plane, offset, tempValue);
         }
     }
 
@@ -182,7 +209,8 @@ public class VideoMemory : IVideoMemory {
         // Foreach plane
         for (int plane = 0; plane < 4; plane++) {
             if (planeEnable[plane] && writePlane[plane]) {
-                Planes[plane, offset] = _latches[plane];
+                byte tempValue = _latches[plane];
+                WriteValue(plane, offset, tempValue);
             }
         }
     }
@@ -209,7 +237,7 @@ public class VideoMemory : IVideoMemory {
             tempValue &= _state.GraphicsControllerRegisters.BitMask;
             tempValue |= (byte)(_latches[plane] & ~_state.GraphicsControllerRegisters.BitMask);
             // write the data
-            Planes[plane, offset] = tempValue;
+            WriteValue(plane, offset, tempValue);
         }
     }
 
@@ -236,6 +264,16 @@ public class VideoMemory : IVideoMemory {
         }
 
         return tempValue;
+    }
+
+    private void WriteValue(int plane, uint offset, byte value) {
+        int idx = (int)offset * 4 + plane;
+        if (VRam[idx] != value) {
+            VRam[idx] = value;
+            // Publish the change after the VRAM write so readers observing the flag
+            // will also see the updated VRAM contents. Volatile.Write provides release semantics.
+            Volatile.Write(ref _hasChanged, 1);
+        }
     }
 
     private (byte plane, uint offset) DecodeReadAddress(uint address) {

--- a/src/Spice86.Core/Emulator/Devices/Video/VideoState.cs
+++ b/src/Spice86.Core/Emulator/Devices/Video/VideoState.cs
@@ -33,4 +33,7 @@ public class VideoState : IVideoState {
 
     /// <inheritdoc />
     public AttributeControllerRegisters AttributeControllerRegisters { get; }
+
+    /// <inheritdoc />
+    public bool IsRenderingDirty { get; set; }
 }

--- a/src/Spice86.Core/Emulator/InterruptHandlers/Bios/SystemBiosInt15Handler.cs
+++ b/src/Spice86.Core/Emulator/InterruptHandlers/Bios/SystemBiosInt15Handler.cs
@@ -9,7 +9,7 @@ using Spice86.Core.Emulator.InterruptHandlers.Bios.Enums;
 using Spice86.Core.Emulator.InterruptHandlers.Bios.Structures;
 using Spice86.Core.Emulator.IOPorts;
 using Spice86.Core.Emulator.Memory;
-using Spice86.Core.Emulator.VM.EmulationLoopScheduler;
+using Spice86.Core.Emulator.VM.DeviceScheduler;
 using Spice86.Shared.Emulator.Memory;
 using Spice86.Shared.Interfaces;
 using Spice86.Shared.Utils;
@@ -24,7 +24,7 @@ public class SystemBiosInt15Handler : InterruptHandler {
     private readonly Configuration _configuration;
     private readonly BiosDataArea _biosDataArea;
     private readonly IOPortDispatcher _ioPortDispatcher;
-    private readonly EmulationLoopScheduler _emulationLoopScheduler;
+    private readonly DeviceScheduler _emulationLoopScheduler;
 
     /// <summary>
     /// Initializes a new instance.
@@ -42,7 +42,7 @@ public class SystemBiosInt15Handler : InterruptHandler {
     /// <param name="loggerService">The logger service implementation.</param>
     public SystemBiosInt15Handler(Configuration configuration, IMemory memory,
         IFunctionHandlerProvider functionHandlerProvider, Stack stack,
-        State state, A20Gate a20Gate, BiosDataArea biosDataArea, EmulationLoopScheduler emulationLoopScheduler,
+        State state, A20Gate a20Gate, BiosDataArea biosDataArea, DeviceScheduler emulationLoopScheduler,
         IOPortDispatcher ioPortDispatcher, ILoggerService loggerService, bool initializeResetVector)
         : base(memory, functionHandlerProvider, stack, state, loggerService) {
         _a20Gate = a20Gate;

--- a/src/Spice86.Core/Emulator/VM/DeviceScheduler/DeviceScheduler.cs
+++ b/src/Spice86.Core/Emulator/VM/DeviceScheduler/DeviceScheduler.cs
@@ -1,13 +1,12 @@
-﻿namespace Spice86.Core.Emulator.VM.EmulationLoopScheduler;
+namespace Spice86.Core.Emulator.VM.DeviceScheduler;
 
 using Serilog.Events;
 
 using Spice86.Core.Emulator.VM.Clock;
+using Spice86.Shared.Collections;
 using Spice86.Shared.Interfaces;
 
 using System.Collections.Generic;
-
-using Priority_Queue;
 
 /// <summary>
 ///     Represents the callback signature invoked when a queued event fires.
@@ -18,29 +17,36 @@ public delegate void EventHandler(uint value);
 /// <summary>
 ///     Manages deterministic scheduling of emulation events using an emulated clock.
 /// </summary>
-public class EmulationLoopScheduler {
+public class DeviceScheduler {
     public const int MaxQueueSize = 8192;
 
     private readonly IEmulatedClock _clock;
     private readonly ILoggerService _logger;
 
-    private readonly FastPriorityQueue<ScheduledEntry> _queue = new(MaxQueueSize);
+    private readonly TimePriorityQueue<ScheduledEntry> _queue = new(MaxQueueSize);
     private readonly Stack<ScheduledEntry> _entryPool = new(MaxQueueSize);
-    private readonly Dictionary<EventHandler, List<ScheduledEntry>> _activeEventsByHandler = new();
-    private readonly EmulationLoopSchedulerMonitor _monitor;
+    
+    private readonly DeviceSchedulerMonitor? _monitor;
 
     private bool _isServicingEvents;
     private double _activeEventScheduledTime;
+    private double _loopEntryTime;
 
     /// <summary>
-    ///     Initializes a new scheduler.
+    ///     Gets the scheduled time of the next queued event, or <see cref="double.MaxValue"/> if the queue is empty.
+    /// </summary>
+    public double? NextEventTime => _queue.Count > 0 ? _queue.First.Priority : null;
+
+    /// <summary>
+    ///     Initializes a new scheduler with a descriptive instance name.
     /// </summary>
     /// <param name="clock">The emulated clock that provides the master time source.</param>
     /// <param name="logger">Logger used for diagnostic reporting.</param>
-    public EmulationLoopScheduler(IEmulatedClock clock, ILoggerService logger) {
+    /// <param name="instanceName">The name used to identify this scheduler in logs.</param>
+    public DeviceScheduler(IEmulatedClock clock, ILoggerService logger, string instanceName) {
         _clock = clock;
         _logger = logger;
-        _monitor = new EmulationLoopSchedulerMonitor(logger);
+        _monitor = _logger.IsEnabled(LogEventLevel.Debug) ? new DeviceSchedulerMonitor(logger, instanceName) : null;
     }
 
     /// <summary>
@@ -58,42 +64,52 @@ public class EmulationLoopScheduler {
             return;
         }
 
-        double baseTime = _isServicingEvents ? _activeEventScheduledTime : _clock.ElapsedTimeMs;
-        double absoluteScheduledTime = baseTime + delay;
-
-        ScheduledEntry entry = GetEntry(handler, absoluteScheduledTime, val);
-
-        _queue.Enqueue(entry, (float)absoluteScheduledTime);
-
-        if (!_activeEventsByHandler.TryGetValue(handler, out List<ScheduledEntry>? events)) {
-            events = new List<ScheduledEntry>();
-            _activeEventsByHandler[handler] = events;
+        // Compute absolute scheduled time taking into account we're currently servicing events.
+        // Use the active event's scheduled time + delay when that yields a time in the future
+        // relative to the loop entry. Otherwise schedule just after the loop entry to avoid
+        // putting events in the past (prevents infinite re-queuing on slow machines).
+        const double MinFutureOffsetMs = 0.0001;
+        double absoluteScheduledTime;
+        if (!_isServicingEvents) {
+            absoluteScheduledTime = _clock.ElapsedTimeMs + delay;
+        } else {
+            double candidate = _activeEventScheduledTime + delay;
+            absoluteScheduledTime = candidate >= _loopEntryTime
+                ? candidate
+                : _loopEntryTime + MinFutureOffsetMs;
         }
 
-        events.Add(entry);
+        ScheduledEntry entry = GetEntry(handler, val);
+
+        _queue.Enqueue(entry, absoluteScheduledTime);
     }
 
     /// <summary>
     ///     Removes all queued events matching the provided handler.
     /// </summary>
     public void RemoveEvents(EventHandler handler) {
-        if (!_activeEventsByHandler.TryGetValue(handler, out List<ScheduledEntry>? events)) {
+        if (_queue.Count == 0) {
             return;
         }
 
-        foreach (ScheduledEntry entry in events) {
-            if (_queue.Contains(entry)) {
-                _queue.Remove(entry);
-                ReturnEntry(entry);
+        int removedCount = 0;
+        List<ScheduledEntry> toRemove = new();
+
+        for (int i = 1; i <= _queue.Count; i++) {
+            ScheduledEntry entry = _queue.NodeAt(i);
+            if (entry.Handler == handler) {
+                toRemove.Add(entry);
             }
         }
 
-        int count = events.Count;
-        events.Clear();
-        _activeEventsByHandler.Remove(handler);
+        foreach (ScheduledEntry entry in toRemove) {
+            _queue.Remove(entry);
+            ReturnEntry(entry);
+            removedCount++;
+        }
 
-        if (count > 0 && _logger.IsEnabled(LogEventLevel.Debug)) {
-            _logger.Debug("Cancelled all {EventCount} events for handler {Handler}", count, GetHandlerName(handler));
+        if (removedCount > 0 && _logger.IsEnabled(LogEventLevel.Debug)) {
+            _logger.Debug("Cancelled all {EventCount} events for handler {Handler}", removedCount, GetHandlerName(handler));
         }
     }
 
@@ -107,21 +123,14 @@ public class EmulationLoopScheduler {
 
         _isServicingEvents = true;
         double currentTime = _clock.ElapsedTimeMs;
+        _loopEntryTime = currentTime;
 
-        while (_queue.Count > 0 && _queue.First.ScheduledTime <= currentTime) {
+        while (_queue.Count > 0 && _queue.First.Priority <= currentTime) {
             ScheduledEntry entry = _queue.Dequeue();
-            _monitor.OnEventExecuted(entry.ScheduledTime, currentTime, _queue.Count);
-
-            // Remove from active handler tracking
-            if (_activeEventsByHandler.TryGetValue(entry.Handler, out List<ScheduledEntry>? events)) {
-                events.Remove(entry);
-                if (events.Count == 0) {
-                    _activeEventsByHandler.Remove(entry.Handler);
-                }
-            }
+            _monitor?.OnEventExecuted(entry.Priority, currentTime, _queue.Count);
 
             // Important for events that re-schedules another event, to ensure it will fire at the correct time not taking into account lag
-            _activeEventScheduledTime = entry.ScheduledTime;
+            _activeEventScheduledTime = entry.Priority;
             try {
                 entry.Handler.Invoke(entry.Value);
             } finally {
@@ -132,15 +141,14 @@ public class EmulationLoopScheduler {
         _isServicingEvents = false;
     }
 
-    private ScheduledEntry GetEntry(EventHandler handler, double scheduledTime, uint value) {
+    private ScheduledEntry GetEntry(EventHandler handler, uint value) {
         if (_entryPool.TryPop(out ScheduledEntry? entry)) {
             entry.Handler = handler;
-            entry.ScheduledTime = scheduledTime;
             entry.Value = value;
             return entry;
         }
 
-        return new ScheduledEntry(handler, scheduledTime, value);
+        return new ScheduledEntry(handler, value);
     }
 
     private void ReturnEntry(ScheduledEntry entry) {
@@ -153,14 +161,12 @@ public class EmulationLoopScheduler {
         return string.IsNullOrEmpty(name) ? "<anonymous>" : name;
     }
 
-    private sealed class ScheduledEntry : FastPriorityQueueNode {
+    private sealed class ScheduledEntry : TimePriorityQueueNode {
         public EventHandler Handler { get; set; }
-        public double ScheduledTime { get; set; }
         public uint Value { get; set; }
 
-        public ScheduledEntry(EventHandler handler, double scheduledTime, uint value) {
+        public ScheduledEntry(EventHandler handler, uint value) {
             Handler = handler;
-            ScheduledTime = scheduledTime;
             Value = value;
         }
     }

--- a/src/Spice86.Core/Emulator/VM/DeviceScheduler/DeviceSchedulerMonitor.cs
+++ b/src/Spice86.Core/Emulator/VM/DeviceScheduler/DeviceSchedulerMonitor.cs
@@ -1,12 +1,17 @@
-namespace Spice86.Core.Emulator.VM.EmulationLoopScheduler;
+namespace Spice86.Core.Emulator.VM.DeviceScheduler;
 
 using Spice86.Shared.Interfaces;
 
 /// <summary>
-/// Monitors the behavior of the <see cref="EmulationLoopScheduler"/>, tracking lag and queue size.
+/// Monitors the behavior of the <see cref="DeviceScheduler"/>, tracking lag and queue size.
 /// </summary>
-public class EmulationLoopSchedulerMonitor {
+public class DeviceSchedulerMonitor {
+    private const long DefaultLogInterval = 5000;
+    private const int DefaultMaxQueueSizeThreshold = 10;
+    private const double DefaultMaxLagThreshold = 10;
+
     private readonly ILoggerService _logger;
+    private readonly string _instanceName;
     private readonly long _logInterval;
     private readonly int _maxQueueSizeThreshold;
     private readonly double _maxLagThreshold;
@@ -21,14 +26,24 @@ public class EmulationLoopSchedulerMonitor {
     private int _currentWindowMinQueueSize = int.MaxValue;
 
     /// <summary>
-    /// Initializes a new instance of the <see cref="EmulationLoopSchedulerMonitor"/> class.
+    /// Initializes a new instance of the <see cref="DeviceSchedulerMonitor"/> class.
     /// </summary>
     /// <param name="logger">The logger service.</param>
+    /// <param name="instanceName">The name of the scheduler instance being monitored.</param>
+    public DeviceSchedulerMonitor(ILoggerService logger, string instanceName)
+        : this(logger, instanceName, DefaultLogInterval, DefaultMaxQueueSizeThreshold, DefaultMaxLagThreshold) {
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="DeviceSchedulerMonitor"/> class.</summary>
+    /// <param name="logger">The logger service.</param>
+    /// <param name="instanceName">The name of the scheduler instance being monitored.</param>
     /// <param name="logInterval">The number of events to process before logging statistics.</param>
     /// <param name="maxQueueSizeThreshold">The maximum queue size before a warning is logged.</param>
     /// <param name="maxLagThreshold">The maximum lag in milliseconds before a warning is logged.</param>
-    public EmulationLoopSchedulerMonitor(ILoggerService logger, long logInterval = 5000, int maxQueueSizeThreshold = 10, double maxLagThreshold = 10) {
+    public DeviceSchedulerMonitor(ILoggerService logger, string instanceName, long logInterval, int maxQueueSizeThreshold, double maxLagThreshold) {
         _logger = logger;
+        _instanceName = instanceName;
         _logInterval = logInterval;
         _maxQueueSizeThreshold = maxQueueSizeThreshold;
         _maxLagThreshold = maxLagThreshold;
@@ -66,8 +81,8 @@ public class EmulationLoopSchedulerMonitor {
                 double avgLag = _currentWindowTotalLag / _currentWindowCount;
                 double avgQueueSize = (double)_currentWindowTotalQueueSize / _currentWindowCount;
 
-                _logger.Warning("Scheduler Monitor: Lag between event scheduled and execution time [Min={MinLag:F4}ms Avg={AvgLag:F4}ms Max={MaxLag:F4}ms] Queue state [Min={MinQueue} Avg={AvgQueue:F2} Max={MaxQueue}]", 
-                    _currentWindowMinLag, avgLag, _currentWindowMaxLag, 
+                _logger.Warning("Scheduler Monitor [{InstanceName}]: Lag between event scheduled and execution time [Min={MinLag:F4}ms Avg={AvgLag:F4}ms Max={MaxLag:F4}ms] Queue state [Min={MinQueue} Avg={AvgQueue:F2} Max={MaxQueue}]", 
+                    _instanceName, _currentWindowMinLag, avgLag, _currentWindowMaxLag,
                     _currentWindowMinQueueSize, avgQueueSize, _currentWindowMaxQueueSize);
             }
             

--- a/src/Spice86.Core/Emulator/VM/DeviceScheduler/DeviceSchedulerThread.cs
+++ b/src/Spice86.Core/Emulator/VM/DeviceScheduler/DeviceSchedulerThread.cs
@@ -1,0 +1,79 @@
+namespace Spice86.Core.Emulator.VM.DeviceScheduler;
+
+using Spice86.Core.Emulator.VM.Clock;
+using Spice86.Shared.Interfaces;
+
+using System.Threading;
+
+/// <summary>
+///     Pumps a <see cref="DeviceScheduler"/> on a dedicated background thread with
+///     hybrid sleep/spin waiting for sub-millisecond timing precision.
+/// </summary>
+public sealed class DeviceSchedulerThread : IDisposable {
+
+    private readonly DeviceScheduler _scheduler;
+    private readonly IEmulatedClock _clock;
+    private readonly IPauseHandler _pauseHandler;
+    private readonly Thread _thread;
+
+    private volatile bool _shouldStop;
+    private bool _disposed;
+
+    /// <summary>
+    ///     Creates and starts the timing thread.
+    /// </summary>
+    /// <param name="scheduler">The device scheduler to pump.</param>
+    /// <param name="clock">The emulated clock used for time queries.</param>
+    /// <param name="pauseHandler">Pause handler for pause/resume integration.</param>
+    /// <param name="threadName">Name assigned to the background thread.</param>
+    public DeviceSchedulerThread(DeviceScheduler scheduler, IEmulatedClock clock,
+        IPauseHandler pauseHandler, string threadName) {
+        _scheduler = scheduler;
+        _clock = clock;
+        _pauseHandler = pauseHandler;
+
+        _thread = new Thread(ThreadLoop) {
+            Name = threadName,
+            IsBackground = true
+        };
+        _thread.Start();
+    }
+
+    private void ThreadLoop() {
+        while (!_shouldStop) {
+            _pauseHandler.WaitIfPaused();
+
+            if (_shouldStop) {
+                break;
+            }
+
+            _scheduler.ProcessEvents();
+
+            double? nextEventTime = _scheduler.NextEventTime;
+            if(nextEventTime is not null) {
+                double currentTime = _clock.ElapsedTimeMs;
+                double waitMs = nextEventTime.Value - currentTime;
+                if(waitMs > 0) {
+                    Thread.Sleep((int)waitMs);
+                }
+            } else {
+                // No events
+                Thread.Sleep(1);
+            }
+        }
+    }
+
+    /// <inheritdoc />
+    public void Dispose() {
+        if (_disposed) {
+            return;
+        }
+
+        _shouldStop = true;
+        if (_thread.IsAlive) {
+            _thread.Join(TimeSpan.FromSeconds(2));
+        }
+
+        _disposed = true;
+    }
+}

--- a/src/Spice86.Core/Emulator/VM/EmulationLoop.cs
+++ b/src/Spice86.Core/Emulator/VM/EmulationLoop.cs
@@ -26,8 +26,8 @@ public class EmulationLoop {
     private readonly Stopwatch _performanceStopwatch = new();
     private readonly ICyclesLimiter _cyclesLimiter;
     private readonly InputEventHub _inputEventQueue;
-    private readonly EmulationLoopScheduler.EmulationLoopScheduler _emulationLoopScheduler;
-    private readonly EmulationLoopScheduler.EventHandler _inputEventsHandler;
+    private readonly DeviceScheduler.DeviceScheduler _emulationLoopScheduler;
+    private readonly DeviceScheduler.EventHandler _inputEventsHandler;
 
     /// <summary>
     /// Gets or sets whether the emulation is paused.
@@ -55,7 +55,7 @@ public class EmulationLoop {
     /// <param name="cyclesLimiter">Limits the number of executed instructions per slice</param>
     /// <param name="loggerService">The logger service implementation.</param>
     public EmulationLoop(FunctionHandler functionHandler, CfgCpu cpu, State cpuState,
-        EmulationLoopScheduler.EmulationLoopScheduler emulationLoopScheduler,
+        DeviceScheduler.DeviceScheduler emulationLoopScheduler,
         EmulatorBreakpointsManager emulatorBreakpointsManager,
         IPauseHandler pauseHandler, InputEventHub inputEventQueue,
         ICyclesLimiter cyclesLimiter, ILoggerService loggerService) {
@@ -68,7 +68,7 @@ public class EmulationLoop {
         _pauseHandler = pauseHandler;
         _inputEventQueue = inputEventQueue;
         _cyclesLimiter = cyclesLimiter;
-        _inputEventsHandler = new EmulationLoopScheduler.EventHandler(InputEventsHandler);
+        _inputEventsHandler = new DeviceScheduler.EventHandler(InputEventsHandler);
         _emulationLoopScheduler.AddEvent(_inputEventsHandler, 100);
     }
 

--- a/src/Spice86.Core/Spice86.Core.csproj
+++ b/src/Spice86.Core/Spice86.Core.csproj
@@ -28,7 +28,6 @@
     <ItemGroup>
         <PackageReference Include="CommunityToolkit.HighPerformance" />
         <PackageReference Include="JetBrains.Annotations" />
-        <PackageReference Include="OptimizedPriorityQueue" />
         <PackageReference Include="Serilog" />
         <PackageReference Include="Serilog.Sinks.File" />
 		<PackageReference Include="Spectre.Console.Cli" />

--- a/src/Spice86.Shared/Collections/TimePriorityQueue.cs
+++ b/src/Spice86.Shared/Collections/TimePriorityQueue.cs
@@ -1,0 +1,318 @@
+namespace Spice86.Shared.Collections;
+
+using System;
+using System.Runtime.CompilerServices;
+
+/// <summary>
+/// A min-heap priority queue using <see cref="double"/> priorities.
+/// Nodes must extend <see cref="TimePriorityQueueNode"/>.
+/// Provides O(1) <see cref="Contains"/> and O(log n) <see cref="Enqueue"/>,
+/// <see cref="Dequeue"/>, <see cref="UpdatePriority"/>, and <see cref="Remove"/> operations.
+/// </summary>
+/// <typeparam name="T">The node type. Must extend <see cref="TimePriorityQueueNode"/>.</typeparam>
+public sealed class TimePriorityQueue<T> where T : TimePriorityQueueNode {
+    private int _count;
+    private T?[] _nodes;
+
+    /// <summary>
+    /// Creates a new priority queue with the specified maximum capacity.
+    /// </summary>
+    /// <param name="maxNodes">The maximum number of nodes the queue can hold. Must be greater than zero.</param>
+    public TimePriorityQueue(int maxNodes) {
+        if (maxNodes <= 0) {
+            throw new ArgumentOutOfRangeException(nameof(maxNodes), "Max nodes must be greater than zero.");
+        }
+        _count = 0;
+        _nodes = new T?[maxNodes + 1];
+    }
+
+    /// <summary>
+    /// The number of nodes currently in the queue.
+    /// </summary>
+    public int Count => _count;
+
+    /// <summary>
+    /// The maximum number of nodes the queue can hold before a resize is needed.
+    /// </summary>
+    public int MaxSize => _nodes.Length - 1;
+
+    /// <summary>
+    /// Returns the node with the lowest priority without removing it.
+    /// </summary>
+    /// <exception cref="InvalidOperationException">Thrown when the queue is empty.</exception>
+    public T First {
+        get {
+            if (_count <= 0) {
+                throw new InvalidOperationException("Cannot access First on an empty queue.");
+            }
+            return _nodes[1] ?? throw new InvalidOperationException("Queue invariant broken: root node is null.");
+        }
+    }
+
+    /// <summary>
+    /// Adds a node to the queue with the specified priority.
+    /// </summary>
+    /// <param name="node">The node to add.</param>
+    /// <param name="priority">The priority value. Lower values are dequeued first.</param>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="node"/> is null.</exception>
+    /// <exception cref="InvalidOperationException">Thrown when the queue is full or the node is already enqueued.</exception>
+    public void Enqueue(T node, double priority) {
+        if (node == null) {
+            throw new ArgumentNullException(nameof(node));
+        }
+        if (_count >= MaxSize) {
+            throw new InvalidOperationException("Queue is full — cannot enqueue node.");
+        }
+        if (ReferenceEquals(node.QueueOwner, this) && node.QueueIndex >= 1 && node.QueueIndex <= _count && _nodes[node.QueueIndex] == node) {
+            throw new InvalidOperationException("Node is already enqueued in this queue.");
+        }
+
+        node.Priority = priority;
+        node.QueueOwner = this;
+        _count++;
+        _nodes[_count] = node;
+        node.QueueIndex = _count;
+        CascadeUp(node);
+    }
+
+    /// <summary>
+    /// Removes and returns the node with the lowest priority.
+    /// </summary>
+    /// <returns>The node with the lowest priority.</returns>
+    /// <exception cref="InvalidOperationException">Thrown when the queue is empty.</exception>
+    public T Dequeue() {
+        if (_count <= 0) {
+            throw new InvalidOperationException("Cannot dequeue from an empty queue.");
+        }
+
+        T returnNode = _nodes[1] ?? throw new InvalidOperationException("Queue invariant broken: root node is null.");
+        if (_count == 1) {
+            _nodes[1] = null;
+            _count = 0;
+            returnNode.QueueIndex = -1;
+            returnNode.QueueOwner = null;
+            return returnNode;
+        }
+
+        T lastNode = _nodes[_count] ?? throw new InvalidOperationException("Queue invariant broken: last node is null.");
+        _nodes[1] = lastNode;
+        lastNode.QueueIndex = 1;
+        _nodes[_count] = null;
+        _count--;
+
+        CascadeDown(lastNode);
+
+        returnNode.QueueIndex = -1;
+        returnNode.QueueOwner = null;
+        return returnNode;
+    }
+
+    /// <summary>
+    /// Removes all nodes from the queue.
+    /// </summary>
+    public void Clear() {
+        for (int i = 1; i <= _count; i++) {
+            T? node = _nodes[i];
+            if (node != null) {
+                node.QueueIndex = -1;
+                node.QueueOwner = null;
+            }
+            _nodes[i] = null;
+        }
+        _count = 0;
+    }
+
+    /// <summary>
+    /// Determines whether the specified node is currently in this queue. O(1).
+    /// </summary>
+    /// <param name="node">The node to check.</param>
+    /// <returns><c>true</c> if the node is in this queue; otherwise, <c>false</c>.</returns>
+    public bool Contains(T node) {
+        if (node == null) {
+            throw new ArgumentNullException(nameof(node));
+        }
+        if (node.QueueIndex < 1 || node.QueueIndex > _count) {
+            return false;
+        }
+        return _nodes[node.QueueIndex] == node;
+    }
+
+    /// <summary>
+    /// Updates the priority of a node that is already in the queue.
+    /// </summary>
+    /// <param name="node">The node whose priority to update.</param>
+    /// <param name="priority">The new priority value.</param>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="node"/> is null.</exception>
+    /// <exception cref="InvalidOperationException">Thrown when the node is not in this queue.</exception>
+    public void UpdatePriority(T node, double priority) {
+        if (node == null) {
+            throw new ArgumentNullException(nameof(node));
+        }
+        if (!Contains(node)) {
+            throw new InvalidOperationException("Cannot update priority of a node that is not in this queue.");
+        }
+
+        double oldPriority = node.Priority;
+        node.Priority = priority;
+
+        if (priority < oldPriority) {
+            CascadeUp(node);
+        } else if (priority > oldPriority) {
+            CascadeDown(node);
+        }
+    }
+
+    /// <summary>
+    /// Removes a specific node from the queue.
+    /// Attempts O(log n) removal using the node's stored index. Falls back to an O(n)
+    /// linear scan if the index is stale.
+    /// </summary>
+    /// <param name="node">The node to remove.</param>
+    /// <returns><c>true</c> if the node was found and removed; <c>false</c> otherwise.</returns>
+    public bool Remove(T node) {
+        if (node == null) {
+            throw new ArgumentNullException(nameof(node));
+        }
+
+        // Fast path: node's QueueIndex points to the correct slot.
+        if (node.QueueIndex >= 1 && node.QueueIndex <= _count && _nodes[node.QueueIndex] == node) {
+            RemoveAt(node.QueueIndex);
+            return true;
+        }
+
+        // Slow fallback: linear scan for stale index.
+        for (int i = 1; i <= _count; i++) {
+            if (_nodes[i] == node) {
+                RemoveAt(i);
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /// <summary>
+    /// Returns the node at the given 1-based heap index. Useful for iterating over all nodes.
+    /// Index 1 is the root (minimum priority); indices 2 through <see cref="Count"/> are the remaining nodes.
+    /// </summary>
+    /// <param name="index">A 1-based index into the internal heap array.</param>
+    /// <returns>The node at the specified index.</returns>
+    /// <exception cref="ArgumentOutOfRangeException">Thrown when <paramref name="index"/> is out of range.</exception>
+    public T NodeAt(int index) {
+        if (index < 1 || index > _count) {
+            throw new ArgumentOutOfRangeException(nameof(index),
+                $"Index {index} is out of range. Valid range: 1 to {_count}.");
+        }
+        return _nodes[index] ?? throw new InvalidOperationException($"Queue invariant broken: node at index {index} is null.");
+    }
+
+    /// <summary>
+    /// Resizes the internal array to accommodate a new maximum number of nodes.
+    /// All currently enqueued nodes are preserved.
+    /// </summary>
+    /// <param name="maxNodes">The new maximum capacity. Must be at least as large as the current <see cref="Count"/>.</param>
+    /// <exception cref="ArgumentOutOfRangeException">Thrown when <paramref name="maxNodes"/> is less than 1.</exception>
+    /// <exception cref="InvalidOperationException">Thrown when <paramref name="maxNodes"/> is smaller than the current count.</exception>
+    public void Resize(int maxNodes) {
+        if (maxNodes <= 0) {
+            throw new ArgumentOutOfRangeException(nameof(maxNodes), "Max nodes must be greater than zero.");
+        }
+        if (maxNodes < _count) {
+            throw new InvalidOperationException(
+                $"Cannot resize to {maxNodes}: queue currently contains {_count} nodes.");
+        }
+
+        T?[] newArray = new T?[maxNodes + 1];
+        int copyLength = Math.Min(maxNodes, _count) + 1;
+        Array.Copy(_nodes, newArray, copyLength);
+        _nodes = newArray;
+    }
+
+    /// <summary>
+    /// Removes the node at the given 1-based heap index.
+    /// </summary>
+    private void RemoveAt(int index) {
+        T removedNode = _nodes[index] ?? throw new InvalidOperationException("Queue invariant broken: removed node is null.");
+        removedNode.QueueIndex = -1;
+        removedNode.QueueOwner = null;
+
+        if (index == _count) {
+            // Removing the last element — no re-heapification needed.
+            _nodes[_count] = null;
+            _count--;
+            return;
+        }
+
+        // Move the last node into the vacated slot.
+        T lastNode = _nodes[_count] ?? throw new InvalidOperationException("Queue invariant broken: last node is null.");
+        _nodes[_count] = null;
+        _count--;
+
+        _nodes[index] = lastNode;
+        lastNode.QueueIndex = index;
+
+        // Restore the heap property: try cascading up first, then down.
+        int parentIndex = index >> 1;
+        if (parentIndex >= 1 && lastNode.Priority < (_nodes[parentIndex] ?? throw new InvalidOperationException("Queue invariant broken: parent node is null.")).Priority) {
+            CascadeUp(lastNode);
+        } else {
+            CascadeDown(lastNode);
+        }
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private void CascadeUp(T node) {
+        int current = node.QueueIndex;
+        int parent = current >> 1;
+
+        while (parent >= 1) {
+            T parentNode = _nodes[parent] ?? throw new InvalidOperationException("Queue invariant broken: parent node is null.");
+            if (parentNode.Priority <= node.Priority) {
+                break;
+            }
+
+            // Parent has higher priority value (lower priority), so move parent down.
+            _nodes[current] = parentNode;
+            parentNode.QueueIndex = current;
+
+            current = parent;
+            parent = current >> 1;
+        }
+
+        _nodes[current] = node;
+        node.QueueIndex = current;
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private void CascadeDown(T node) {
+        int current = node.QueueIndex;
+
+        while (true) {
+            int leftChild = current << 1;
+            if (leftChild > _count) {
+                break;
+            }
+
+            // Find the child with the smallest priority.
+            int smallestChild = leftChild;
+            int rightChild = leftChild + 1;
+            if (rightChild <= _count && (_nodes[rightChild] ?? throw new InvalidOperationException("Queue invariant broken: right child node is null.")).Priority < (_nodes[leftChild] ?? throw new InvalidOperationException("Queue invariant broken: left child node is null.")).Priority) {
+                smallestChild = rightChild;
+            }
+
+            T childNode = _nodes[smallestChild] ?? throw new InvalidOperationException("Queue invariant broken: child node is null.");
+            if (node.Priority <= childNode.Priority) {
+                break;
+            }
+
+            // Move the smaller child up.
+            _nodes[current] = childNode;
+            childNode.QueueIndex = current;
+
+            current = smallestChild;
+        }
+
+        _nodes[current] = node;
+        node.QueueIndex = current;
+    }
+}

--- a/src/Spice86.Shared/Collections/TimePriorityQueueNode.cs
+++ b/src/Spice86.Shared/Collections/TimePriorityQueueNode.cs
@@ -1,0 +1,24 @@
+namespace Spice86.Shared.Collections;
+
+/// <summary>
+/// Base class for nodes stored in a <see cref="TimePriorityQueue{T}"/>.
+/// Each node tracks its position in the heap and its priority value.
+/// </summary>
+public abstract class TimePriorityQueueNode {
+    /// <summary>
+    /// The index of this node within the backing array of the queue.
+    /// A value of <c>-1</c> indicates the node is not currently in any queue.
+    /// </summary>
+    public int QueueIndex { get; set; } = -1;
+
+    /// <summary>
+    /// The priority of this node. Lower values indicate higher priority.
+    /// </summary>
+    public double Priority { get; set; }
+
+    /// <summary>
+    /// The queue instance that currently owns this node, or <c>null</c> if not enqueued.
+    /// Used internally for validation.
+    /// </summary>
+    internal object? QueueOwner { get; set; }
+}

--- a/src/Spice86/Spice86DependencyInjection.cs
+++ b/src/Spice86/Spice86DependencyInjection.cs
@@ -49,7 +49,7 @@ using Spice86.Core.Emulator.VM;
 using Spice86.Core.Emulator.VM.Breakpoint;
 using Spice86.Core.Emulator.VM.Clock;
 using Spice86.Core.Emulator.VM.CpuSpeedLimit;
-using Spice86.Core.Emulator.VM.EmulationLoopScheduler;
+using Spice86.Core.Emulator.VM.DeviceScheduler;
 using Spice86.Logging;
 using Spice86.Shared.Diagnostics;
 using Spice86.Shared.Emulator.Memory;
@@ -84,6 +84,7 @@ public class Spice86DependencyInjection : IDisposable {
     public FunctionCatalogue FunctionCatalogue { get; }
 
     private readonly McpHttpHost? _mcpHttpTransport;
+    private readonly DeviceSchedulerThread? _vgaTimingThread;
     private bool _disposed;
     private bool _machineDisposedAfterRun;
 
@@ -198,7 +199,7 @@ public class Spice86DependencyInjection : IDisposable {
         pauseHandler.Pausing += () => _emulatedClock.OnPause();
         pauseHandler.Resumed += () => _emulatedClock.OnResume();
 
-        EmulationLoopScheduler emulationLoopScheduler = new(_emulatedClock, loggerService);
+        DeviceScheduler emulationLoopScheduler = new(_emulatedClock, loggerService, "Emulation loop");
 
         var dualPic = new DualPic(ioPortDispatcher, state, loggerService, configuration.FailOnUnhandledPort);
 
@@ -298,7 +299,20 @@ public class Spice86DependencyInjection : IDisposable {
         VideoState videoState = new();
         VgaIoPortHandler vgaIoPortHandler = new(state, ioPortDispatcher,
             loggerService, videoState, configuration.FailOnUnhandledPort);
-        Renderer vgaRenderer = new(memory, videoState, _emulatedClock, loggerService);
+        VgaBlinkState vgaBlinkState = new();
+        IVgaRenderer256Color renderer256Color = VgaRenderer256ColorSimd.CreateBestRenderer();
+        Renderer vgaRenderer = new(memory, videoState, vgaBlinkState, loggerService, renderer256Color);
+
+        bool isSyncRendering = configuration.RenderingMode == RenderingMode.Sync;
+
+        // In sync mode, VGA events go on the emulation loop's scheduler.
+        // In async mode, a separate scheduler is created for the UI thread.
+        DeviceScheduler vgaScheduler = isSyncRendering
+            ? emulationLoopScheduler
+            : new DeviceScheduler(_emulatedClock, loggerService, "VGA");
+
+        VgaTimingEngine vgaTimingEngine = new(videoState, vgaScheduler,
+            _emulatedClock, vgaRenderer, vgaBlinkState);
         VgaRom vgaRom = new();
         VgaFunctionality vgaFunctionality = new VgaFunctionality(memory,
             interruptVectorTable, ioPortDispatcher,
@@ -478,6 +492,10 @@ public class Spice86DependencyInjection : IDisposable {
             state, emulationLoopScheduler, emulatorBreakpointsManager,
             pauseHandler, inputEventHub, cyclesLimiter, loggerService);
 
+        // In async mode, a dedicated thread pumps VGA timing events.
+        _vgaTimingThread = isSyncRendering
+            ? null
+            : new DeviceSchedulerThread(vgaScheduler, _emulatedClock, pauseHandler, "VGA Timing");
         VgaCard vgaCard = new(_gui, vgaRenderer, loggerService);
         vgaCard.SubscribeToEvents();
 
@@ -676,7 +694,7 @@ public class Spice86DependencyInjection : IDisposable {
             PaletteViewModel paletteViewModel = new(videoState.DacRegisters.ArgbPalette,
                 uiDispatcher);
 
-            VideoCardViewModel videoCardViewModel = new(vgaRenderer, videoState, hostStorageProvider);
+            VideoCardViewModel videoCardViewModel = new(vgaRenderer, videoState, vgaTimingEngine, hostStorageProvider);
 
             CpuViewModel cpuViewModel = new(state, memory, pauseHandler, uiDispatcher);
 
@@ -824,6 +842,7 @@ public class Spice86DependencyInjection : IDisposable {
         }
 
         _machineDisposedAfterRun = true;
+        _vgaTimingThread?.Dispose();
         _emulatedClock.Dispose();
         _httpApiServer?.Dispose();
         Machine.Dispose();

--- a/src/Spice86/ViewModels/MainWindowViewModel.cs
+++ b/src/Spice86/ViewModels/MainWindowViewModel.cs
@@ -25,7 +25,6 @@ using Spice86.Shared.Interfaces;
 using Spice86.ViewModels.Services;
 
 using MouseButton = Spice86.Shared.Emulator.Mouse.MouseButton;
-using Timer = System.Timers.Timer;
 
 /// <inheritdoc cref="Spice86.Shared.Interfaces.IGuiVideoPresentation" />
 public sealed partial class MainWindowViewModel : ViewModelWithErrorDialog, IGuiVideoPresentation,
@@ -83,8 +82,7 @@ public sealed partial class MainWindowViewModel : ViewModelWithErrorDialog, IGui
     private bool _isSettingResolution;
     private bool _isAppClosing;
 
-    private readonly Timer _drawTimer = new(1000.0 / ScreenRefreshHz);
-    private readonly SemaphoreSlim? _drawingSemaphoreSlim = new(1, 1);
+    private DispatcherTimer? _drawTimer;
 
     public event EventHandler<KeyboardEventArgs>? KeyUp;
     public event EventHandler<KeyboardEventArgs>? KeyDown;
@@ -293,16 +291,9 @@ public sealed partial class MainWindowViewModel : ViewModelWithErrorDialog, IGui
                     return;
                 }
 
-                _drawingSemaphoreSlim?.Wait();
-                try {
-                    Bitmap?.Dispose();
-                    Bitmap = new WriteableBitmap(new PixelSize(Width, Height), new Vector(96, 96), PixelFormat.Bgra8888,
-                        AlphaFormat.Opaque);
-                } finally {
-                    if (!_disposed) {
-                        _drawingSemaphoreSlim?.Release();
-                    }
-                }
+                Bitmap?.Dispose();
+                Bitmap = new WriteableBitmap(new PixelSize(Width, Height), new Vector(96, 96), PixelFormat.Bgra8888,
+                    AlphaFormat.Opaque);
             }
 
             _isSettingResolution = false;
@@ -382,7 +373,8 @@ public sealed partial class MainWindowViewModel : ViewModelWithErrorDialog, IGui
         }
 
         _renderingTimerInitialized = true;
-        _drawTimer.Elapsed += (_, _) => DrawScreen();
+        _drawTimer = new DispatcherTimer(TimeSpan.FromMilliseconds(1000.0 / ScreenRefreshHz),
+            DispatcherPriority.Render, (_, _) => DrawScreen());
         _drawTimer.Start();
     }
 
@@ -392,17 +384,10 @@ public sealed partial class MainWindowViewModel : ViewModelWithErrorDialog, IGui
             return;
         }
 
-        _drawingSemaphoreSlim?.Wait();
-        try {
-            using ILockedFramebuffer pixels = Bitmap.Lock();
-            var uiRenderEventArgs = new UIRenderEventArgs(pixels.Address, pixels.RowBytes * pixels.Size.Height / 4);
-            RenderScreen.Invoke(this, uiRenderEventArgs);
-            _uiDispatcher.Post(() => InvalidateBitmap?.Invoke(), DispatcherPriority.Background);
-        } finally {
-            if (!_disposed) {
-                _drawingSemaphoreSlim?.Release();
-            }
-        }
+        using ILockedFramebuffer pixels = Bitmap.Lock();
+        UIRenderEventArgs uiRenderEventArgs = new UIRenderEventArgs(pixels.Address, pixels.RowBytes * pixels.Size.Height / 4);
+        RenderScreen.Invoke(this, uiRenderEventArgs);
+        InvalidateBitmap?.Invoke();
     }
 
     internal void StartEmulator() {
@@ -440,16 +425,14 @@ public sealed partial class MainWindowViewModel : ViewModelWithErrorDialog, IGui
                 _pauseHandler.Resumed -= OnResumed;
                 _pauseHandler.Dispose();
 
-                _drawTimer.Stop();
-                _drawTimer.Dispose();
+                _drawTimer?.Stop();
+                _drawTimer = null;
 
                 // Dispose of UI-related resources in the UI thread
                 _uiDispatcher.Post(() => {
                     Bitmap?.Dispose();
                     Cursor?.Dispose();
                 }, DispatcherPriority.MaxValue);
-
-                _drawingSemaphoreSlim?.Dispose();
 
                 PlayCommand.Execute(null);
                 IsEmulatorRunning = false;

--- a/src/Spice86/ViewModels/PropertiesMappers/MapperExtensions.cs
+++ b/src/Spice86/ViewModels/PropertiesMappers/MapperExtensions.cs
@@ -65,7 +65,6 @@ public static class MapperExtensions {
         videoCardInfo.RendererWidth = vgaRenderer.Width;
         videoCardInfo.RendererHeight = vgaRenderer.Height;
         videoCardInfo.RendererBufferSize = vgaRenderer.BufferSize;
-        videoCardInfo.LastFrameRenderTime = vgaRenderer.LastFrameRenderTime;
     }
 
     public static void CopyToVideoCardInfo(this IVideoState videoState, VideoCardInfo videoCardInfo) {

--- a/src/Spice86/ViewModels/Services/HeadlessGui.cs
+++ b/src/Spice86/ViewModels/Services/HeadlessGui.cs
@@ -10,7 +10,6 @@ public sealed class HeadlessGui : IGuiVideoPresentation, IGuiMouseEvents,
     IGuiKeyboardEvents, IDisposable {
     private const double ScreenRefreshHz = 60;
     private static readonly TimeSpan RefreshInterval = TimeSpan.FromMilliseconds(1000.0 / ScreenRefreshHz);
-    private readonly SemaphoreSlim? _drawingSemaphoreSlim = new(1, 1);
 
     private bool _disposed;
 
@@ -71,18 +70,11 @@ public sealed class HeadlessGui : IGuiVideoPresentation, IGuiMouseEvents,
 
                 int bufferSize = width * height * 4;
 
-                _drawingSemaphoreSlim?.Wait();
-                try {
-                    if (_pixelBuffer == null || _pixelBuffer.Length != bufferSize) {
-                        _pixelBuffer = new byte[bufferSize];
-                    }
-
-                    Array.Clear(_pixelBuffer, 0, _pixelBuffer.Length);
-                } finally {
-                    if (!_disposed) {
-                        _drawingSemaphoreSlim?.Release();
-                    }
+                if (_pixelBuffer == null || _pixelBuffer.Length != bufferSize) {
+                    _pixelBuffer = new byte[bufferSize];
                 }
+
+                Array.Clear(_pixelBuffer, 0, _pixelBuffer.Length);
             }
         } finally {
             _isSettingResolution = false;
@@ -114,19 +106,12 @@ public sealed class HeadlessGui : IGuiVideoPresentation, IGuiMouseEvents,
             return;
         }
 
-        _drawingSemaphoreSlim?.Wait();
-        try {
-            fixed (byte* bufferPtr = pixelBuffer) {
-                int rowBytes = Width * 4; // 4 bytes per pixel (BGRA)
-                int length = rowBytes * Height / 4;
+        fixed (byte* bufferPtr = _pixelBuffer) {
+            int rowBytes = Width * 4; // 4 bytes per pixel (BGRA)
+            int length = rowBytes * Height / 4;
 
-                var uiRenderEventArgs = new UIRenderEventArgs((IntPtr)bufferPtr, length);
-                RenderScreen.Invoke(this, uiRenderEventArgs);
-            }
-        } finally {
-            if (!_disposed) {
-                _drawingSemaphoreSlim?.Release();
-            }
+            UIRenderEventArgs uiRenderEventArgs = new UIRenderEventArgs((IntPtr)bufferPtr, length);
+            RenderScreen.Invoke(this, uiRenderEventArgs);
         }
     }
 
@@ -140,21 +125,9 @@ public sealed class HeadlessGui : IGuiVideoPresentation, IGuiMouseEvents,
             return;
         }
 
-        // Stop the timer first to prevent any new callbacks
+        // Stop the timer to prevent any new callbacks
         _drawTimer?.Dispose();
 
-        // Wait for any ongoing draw operation to complete
-        // This prevents a race condition where the timer callback
-        // is in the middle of rendering when we dispose resources
-        try {
-            if (_drawingSemaphoreSlim?.Wait(TimeSpan.FromMilliseconds(100)) == true) {
-                _drawingSemaphoreSlim?.Release();
-            }
-        } catch (ObjectDisposedException) {
-            // Semaphore was already disposed, which is fine
-        }
-
         _pixelBuffer = null;
-        _drawingSemaphoreSlim?.Dispose();
     }
 }

--- a/src/Spice86/ViewModels/ValueViewModels/Debugging/VideoCardInfo.cs
+++ b/src/Spice86/ViewModels/ValueViewModels/Debugging/VideoCardInfo.cs
@@ -392,5 +392,5 @@ public partial class VideoCardInfo : ObservableObject {
     private int _rendererBufferSize;
 
     [ObservableProperty]
-    private TimeSpan _lastFrameRenderTime;
+    private TimeSpan _lastFrameDuration;
 }

--- a/src/Spice86/ViewModels/VideoCardViewModel.cs
+++ b/src/Spice86/ViewModels/VideoCardViewModel.cs
@@ -15,12 +15,14 @@ public partial class VideoCardViewModel  : ViewModelBase, IEmulatorObjectViewMod
     private VideoCardInfo _videoCard = new();
     private readonly IVgaRenderer _vgaRenderer;
     private readonly IVideoState _videoState;
+    private readonly VgaTimingEngine _vgaTimingEngine;
     private readonly IHostStorageProvider _storageProvider;
 
     public VideoCardViewModel(IVgaRenderer vgaRenderer, IVideoState videoState,
-        IHostStorageProvider storageProvider) {
+        VgaTimingEngine vgaTimingEngine, IHostStorageProvider storageProvider) {
         _vgaRenderer = vgaRenderer;
         _videoState = videoState;
+        _vgaTimingEngine = vgaTimingEngine;
         _storageProvider = storageProvider;
     }
 
@@ -37,6 +39,7 @@ public partial class VideoCardViewModel  : ViewModelBase, IEmulatorObjectViewMod
         }
         VisitVgaRenderer(_vgaRenderer);
         VisitVideoState(_videoState);
+        VideoCard.LastFrameDuration = _vgaTimingEngine.LastFrameDuration;
     }
 
     private void VisitVgaRenderer(IVgaRenderer vgaRenderer) {

--- a/src/Spice86/Views/VideoCardView.axaml
+++ b/src/Spice86/Views/VideoCardView.axaml
@@ -183,7 +183,7 @@
                     <TextBox IsReadOnly="True" Text="{Binding VideoCard.RendererWidth, StringFormat='Width: {0}'}" TextAlignment="Right" />
                     <TextBox IsReadOnly="True" Text="{Binding VideoCard.RendererHeight, StringFormat='Height: {0}'}" TextAlignment="Right" />
                     <TextBox IsReadOnly="True" Text="{Binding VideoCard.RendererBufferSize, StringFormat='BufferSize: {0}'}" TextAlignment="Right" />
-                    <TextBox IsReadOnly="True" Text="{Binding VideoCard.LastFrameRenderTime, StringFormat='FrameRenderTime: {0}'}" TextAlignment="Right" />
+                    <TextBox IsReadOnly="True" Text="{Binding VideoCard.LastFrameDuration, StringFormat='FrameDuration: {0}'}" TextAlignment="Right" />
                 </WrapPanel>
             </Grid>
         </WrapPanel>

--- a/tests/Directory.Packages.props
+++ b/tests/Directory.Packages.props
@@ -23,5 +23,6 @@
     <PackageVersion Include="Avalonia.Headless.XUnit" Version="11.3.12" />
     <PackageVersion Include="xunit" Version="2.9.3" />
     <PackageVersion Include="xunit.runner.visualstudio" Version="3.1.5" />
+    <PackageVersion Include="Xunit.SkippableFact" Version="1.4.8" />
   </ItemGroup>
 </Project>

--- a/tests/Spice86.Tests/Dos/DosFileManagerTests.cs
+++ b/tests/Spice86.Tests/Dos/DosFileManagerTests.cs
@@ -27,7 +27,7 @@ using Spice86.Core.Emulator.StateSerialization;
 using Spice86.Core.Emulator.VM;
 using Spice86.Core.Emulator.VM.Breakpoint;
 using Spice86.Core.Emulator.VM.Clock;
-using Spice86.Core.Emulator.VM.EmulationLoopScheduler;
+using Spice86.Core.Emulator.VM.DeviceScheduler;
 using Spice86.Shared.Interfaces;
 using Spice86.Tests.Utility;
 

--- a/tests/Spice86.Tests/Dos/DosTestFixture.cs
+++ b/tests/Spice86.Tests/Dos/DosTestFixture.cs
@@ -22,7 +22,7 @@ using Spice86.Core.Emulator.OperatingSystem;
 using Spice86.Core.Emulator.VM;
 using Spice86.Core.Emulator.VM.Breakpoint;
 using Spice86.Core.Emulator.VM.Clock;
-using Spice86.Core.Emulator.VM.EmulationLoopScheduler;
+using Spice86.Core.Emulator.VM.DeviceScheduler;
 using Spice86.Logging;
 using Spice86.Shared.Interfaces;
 
@@ -57,7 +57,7 @@ public class DosTestFixture {
         Memory = new(memoryBreakpoints, ram, a20Gate,
             initializeResetVector: configuration.InitializeDOS is true);
         IEmulatedClock emulatedClock = new EmulatedClock();
-        EmulationLoopScheduler emulationLoopScheduler = new(emulatedClock, LoggerService);
+        DeviceScheduler emulationLoopScheduler = new(emulatedClock, LoggerService, "Emulation loop");
         EmulatorBreakpointsManager emulatorBreakpointsManager = new(pauseHandler, state, Memory, memoryBreakpoints, ioBreakpoints);
 
         BiosDataArea biosDataArea =

--- a/tests/Spice86.Tests/Emulator/Devices/ExternalInput/DeviceSchedulerTests.cs
+++ b/tests/Spice86.Tests/Emulator/Devices/ExternalInput/DeviceSchedulerTests.cs
@@ -6,23 +6,23 @@ using NSubstitute;
 
 using Spice86.Core.Emulator.CPU;
 using Spice86.Core.Emulator.VM.Clock;
-using Spice86.Core.Emulator.VM.EmulationLoopScheduler;
+using Spice86.Core.Emulator.VM.DeviceScheduler;
 using Spice86.Shared.Interfaces;
 
 using Xunit;
 
-public sealed class EmulationLoopSchedulerTests {
+public sealed class DeviceSchedulerTests {
     private readonly ILoggerService _logger;
     private readonly State _state;
     private readonly CyclesClock _cyclesClock;
-    private readonly EmulationLoopScheduler _scheduler;
+    private readonly DeviceScheduler _scheduler;
 
-    public EmulationLoopSchedulerTests() {
+    public DeviceSchedulerTests() {
         _logger = Substitute.For<ILoggerService>();
         _state = new State(CpuModel.INTEL_8086);
         // 1000 cycles = 1 second for simplicity in tests
         _cyclesClock = new CyclesClock(_state, 1000);
-        _scheduler = new EmulationLoopScheduler(_cyclesClock, _logger);
+        _scheduler = new DeviceScheduler(_cyclesClock, _logger, "Emulation loop");
     }
 
     [Fact]
@@ -157,7 +157,7 @@ public sealed class EmulationLoopSchedulerTests {
 
     [Fact]
     public void AddEvent_WhenQueueFull_ShouldIgnoreEventButExecuteExisting() {
-        int maxQueueSize = 8192; // Assuming this is the constant in EmulationLoopScheduler
+        int maxQueueSize = 8192; // Assuming this is the constant in DeviceScheduler
         int eventsCount = maxQueueSize + 10;
         var executedEvents = new List<int>();
 

--- a/tests/Spice86.Tests/Emulator/Devices/ExternalInput/Pit8254Tests.cs
+++ b/tests/Spice86.Tests/Emulator/Devices/ExternalInput/Pit8254Tests.cs
@@ -11,7 +11,7 @@ using Spice86.Core.Emulator.IOPorts;
 using Spice86.Core.Emulator.VM;
 using Spice86.Core.Emulator.VM.Breakpoint;
 using Spice86.Core.Emulator.VM.Clock;
-using Spice86.Core.Emulator.VM.EmulationLoopScheduler;
+using Spice86.Core.Emulator.VM.DeviceScheduler;
 using Spice86.Shared.Interfaces;
 
 using Xunit;
@@ -33,7 +33,7 @@ public class Pit8254Tests {
         _ioPortDispatcher = new IOPortDispatcher(new AddressReadWriteBreakpoints(), state, logger, false);
         var pic = new DualPic(_ioPortDispatcher, state, logger, false);
         var emulatedClock = new EmulatedClock();
-        var emulationLoopScheduler = new EmulationLoopScheduler(emulatedClock, logger);
+        var emulationLoopScheduler = new DeviceScheduler(emulatedClock, logger, "Emulation loop");
         _pit = new PitTimer(_ioPortDispatcher, state, pic, _speaker, emulationLoopScheduler, emulatedClock, logger, false);
     }
 

--- a/tests/Spice86.Tests/Emulator/Devices/ExternalInput/PitModeTests.cs
+++ b/tests/Spice86.Tests/Emulator/Devices/ExternalInput/PitModeTests.cs
@@ -11,7 +11,7 @@ using Spice86.Core.Emulator.IOPorts;
 using Spice86.Core.Emulator.VM;
 using Spice86.Core.Emulator.VM.Breakpoint;
 using Spice86.Core.Emulator.VM.Clock;
-using Spice86.Core.Emulator.VM.EmulationLoopScheduler;
+using Spice86.Core.Emulator.VM.DeviceScheduler;
 using Spice86.Shared.Interfaces;
 
 using Xunit;
@@ -32,7 +32,7 @@ public class PitModeTests {
         State state = new(CpuModel.INTEL_80286);
         _ioPortDispatcher = new IOPortDispatcher(new AddressReadWriteBreakpoints(), state, logger, false);
         _clock = new EmulatedClock();
-        var emulationLoopScheduler = new EmulationLoopScheduler(_clock, logger);
+        var emulationLoopScheduler = new DeviceScheduler(_clock, logger, "Emulation loop");
         _pic = new DualPic(_ioPortDispatcher, state, logger, false);
         _pit = new PitTimer(_ioPortDispatcher, state, _pic, _speaker, emulationLoopScheduler, _clock, logger, false);
     }

--- a/tests/Spice86.Tests/Emulator/Devices/ExternalInput/PitTimerTests.cs
+++ b/tests/Spice86.Tests/Emulator/Devices/ExternalInput/PitTimerTests.cs
@@ -10,7 +10,7 @@ using Spice86.Core.Emulator.Devices.Timer;
 using Spice86.Core.Emulator.IOPorts;
 using Spice86.Core.Emulator.VM.Breakpoint;
 using Spice86.Core.Emulator.VM.Clock;
-using Spice86.Core.Emulator.VM.EmulationLoopScheduler;
+using Spice86.Core.Emulator.VM.DeviceScheduler;
 using Spice86.Shared.Interfaces;
 
 using Xunit;
@@ -58,7 +58,7 @@ public sealed class PitTimerTests {
             DualPic = new DualPic(Dispatcher, State, Logger, false);
             Speaker = new StubPitSpeaker();
             var emulatedClock = new EmulatedClock();
-            var emulationLoopScheduler = new EmulationLoopScheduler(emulatedClock, Logger);
+            var emulationLoopScheduler = new DeviceScheduler(emulatedClock, Logger, "Emulation loop");
             PitTimer = new PitTimer(Dispatcher, State, DualPic, Speaker, emulationLoopScheduler, emulatedClock, Logger, false);
         }
 

--- a/tests/Spice86.Tests/Spice86.Tests.csproj
+++ b/tests/Spice86.Tests/Spice86.Tests.csproj
@@ -35,6 +35,7 @@
 		<PackageReference Include="SingleStepTests.Intel80386.67.80-67.FF"/>
 		<PackageReference Include="SingleStepTests.Intel80386.68-FF"/>
 		<PackageReference Include="xunit"/>
+		<PackageReference Include="Xunit.SkippableFact"/>
 		<PackageReference Include="xunit.runner.visualstudio">
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 			<PrivateAssets>all</PrivateAssets>

--- a/tests/Spice86.Tests/TimePriorityQueueTests.cs
+++ b/tests/Spice86.Tests/TimePriorityQueueTests.cs
@@ -1,0 +1,602 @@
+namespace Spice86.Tests;
+
+using FluentAssertions;
+
+using Spice86.Shared.Collections;
+
+using Xunit;
+
+/// <summary>
+/// Tests for <see cref="TimePriorityQueue{T}"/> and <see cref="TimePriorityQueueNode"/>.
+/// </summary>
+public class TimePriorityQueueTests {
+    private sealed class TestNode : TimePriorityQueueNode {
+        public string Label { get; }
+
+        public TestNode(string label) {
+            Label = label;
+        }
+
+        public override string ToString() => Label;
+    }
+
+    [Fact]
+    public void NewQueue_IsEmpty() {
+        TimePriorityQueue<TestNode> queue = new(10);
+
+        queue.Count.Should().Be(0);
+        queue.MaxSize.Should().Be(10);
+    }
+
+    [Fact]
+    public void Enqueue_Dequeue_SingleNode() {
+        TimePriorityQueue<TestNode> queue = new(10);
+        TestNode node = new("A");
+
+        queue.Enqueue(node, 5.0);
+
+        queue.Count.Should().Be(1);
+        queue.First.Should().BeSameAs(node);
+
+        TestNode dequeued = queue.Dequeue();
+        dequeued.Should().BeSameAs(node);
+        queue.Count.Should().Be(0);
+        node.QueueIndex.Should().Be(-1);
+    }
+
+    [Fact]
+    public void Enqueue_Dequeue_AscendingOrder() {
+        TimePriorityQueue<TestNode> queue = new(10);
+        TestNode a = new("A");
+        TestNode b = new("B");
+        TestNode c = new("C");
+
+        queue.Enqueue(a, 1.0);
+        queue.Enqueue(b, 2.0);
+        queue.Enqueue(c, 3.0);
+
+        queue.Dequeue().Should().BeSameAs(a);
+        queue.Dequeue().Should().BeSameAs(b);
+        queue.Dequeue().Should().BeSameAs(c);
+    }
+
+    [Fact]
+    public void Enqueue_Dequeue_DescendingOrder() {
+        TimePriorityQueue<TestNode> queue = new(10);
+        TestNode a = new("A");
+        TestNode b = new("B");
+        TestNode c = new("C");
+
+        queue.Enqueue(c, 3.0);
+        queue.Enqueue(b, 2.0);
+        queue.Enqueue(a, 1.0);
+
+        queue.Dequeue().Should().BeSameAs(a);
+        queue.Dequeue().Should().BeSameAs(b);
+        queue.Dequeue().Should().BeSameAs(c);
+    }
+
+    [Fact]
+    public void First_ReturnsLowestPriority() {
+        TimePriorityQueue<TestNode> queue = new(10);
+        TestNode a = new("A");
+        TestNode b = new("B");
+
+        queue.Enqueue(b, 10.0);
+        queue.Enqueue(a, 1.0);
+
+        queue.First.Should().BeSameAs(a);
+    }
+
+    [Fact]
+    public void First_ThrowsWhenEmpty() {
+        TimePriorityQueue<TestNode> queue = new(10);
+
+        Action act = () => _ = queue.First;
+        act.Should().Throw<InvalidOperationException>();
+    }
+
+    [Fact]
+    public void Dequeue_ThrowsWhenEmpty() {
+        TimePriorityQueue<TestNode> queue = new(10);
+
+        Action act = () => queue.Dequeue();
+        act.Should().Throw<InvalidOperationException>();
+    }
+
+    [Fact]
+    public void Contains_ReturnsTrueWhenEnqueued() {
+        TimePriorityQueue<TestNode> queue = new(10);
+        TestNode node = new("A");
+
+        queue.Enqueue(node, 1.0);
+
+        queue.Contains(node).Should().BeTrue();
+    }
+
+    [Fact]
+    public void Contains_ReturnsFalseWhenNotEnqueued() {
+        TimePriorityQueue<TestNode> queue = new(10);
+        TestNode node = new("A");
+
+        queue.Contains(node).Should().BeFalse();
+    }
+
+    [Fact]
+    public void Contains_ReturnsFalseAfterDequeue() {
+        TimePriorityQueue<TestNode> queue = new(10);
+        TestNode node = new("A");
+
+        queue.Enqueue(node, 1.0);
+        queue.Dequeue();
+
+        queue.Contains(node).Should().BeFalse();
+    }
+
+    [Fact]
+    public void UpdatePriority_MovesNodeUp() {
+        TimePriorityQueue<TestNode> queue = new(10);
+        TestNode a = new("A");
+        TestNode b = new("B");
+
+        queue.Enqueue(a, 5.0);
+        queue.Enqueue(b, 10.0);
+
+        // Move B ahead of A
+        queue.UpdatePriority(b, 1.0);
+
+        queue.First.Should().BeSameAs(b);
+        queue.Dequeue().Should().BeSameAs(b);
+        queue.Dequeue().Should().BeSameAs(a);
+    }
+
+    [Fact]
+    public void UpdatePriority_MovesNodeDown() {
+        TimePriorityQueue<TestNode> queue = new(10);
+        TestNode a = new("A");
+        TestNode b = new("B");
+
+        queue.Enqueue(a, 1.0);
+        queue.Enqueue(b, 5.0);
+
+        // Move A behind B
+        queue.UpdatePriority(a, 10.0);
+
+        queue.Dequeue().Should().BeSameAs(b);
+        queue.Dequeue().Should().BeSameAs(a);
+    }
+
+    [Fact]
+    public void UpdatePriority_ThrowsWhenNotInQueue() {
+        TimePriorityQueue<TestNode> queue = new(10);
+        TestNode node = new("A");
+
+        Action act = () => queue.UpdatePriority(node, 1.0);
+        act.Should().Throw<InvalidOperationException>();
+    }
+
+    [Fact]
+    public void Remove_RemovesNodeByValidIndex() {
+        TimePriorityQueue<TestNode> queue = new(10);
+        TestNode a = new("A");
+        TestNode b = new("B");
+        TestNode c = new("C");
+
+        queue.Enqueue(a, 1.0);
+        queue.Enqueue(b, 2.0);
+        queue.Enqueue(c, 3.0);
+
+        bool removed = queue.Remove(b);
+
+        removed.Should().BeTrue();
+        queue.Count.Should().Be(2);
+        queue.Contains(b).Should().BeFalse();
+        b.QueueIndex.Should().Be(-1);
+
+        // Remaining nodes should still dequeue in order.
+        queue.Dequeue().Should().BeSameAs(a);
+        queue.Dequeue().Should().BeSameAs(c);
+    }
+
+    [Fact]
+    public void Remove_ReturnsFalseForNodeNotInQueue() {
+        TimePriorityQueue<TestNode> queue = new(10);
+        TestNode node = new("A");
+
+        queue.Remove(node).Should().BeFalse();
+    }
+
+    [Fact]
+    public void Remove_RemovesFirstNode() {
+        TimePriorityQueue<TestNode> queue = new(10);
+        TestNode a = new("A");
+        TestNode b = new("B");
+
+        queue.Enqueue(a, 1.0);
+        queue.Enqueue(b, 2.0);
+
+        queue.Remove(a).Should().BeTrue();
+        queue.Count.Should().Be(1);
+        queue.First.Should().BeSameAs(b);
+    }
+
+    [Fact]
+    public void Remove_RemovesLastNode() {
+        TimePriorityQueue<TestNode> queue = new(10);
+        TestNode a = new("A");
+        TestNode b = new("B");
+
+        queue.Enqueue(a, 1.0);
+        queue.Enqueue(b, 2.0);
+
+        queue.Remove(b).Should().BeTrue();
+        queue.Count.Should().Be(1);
+        queue.First.Should().BeSameAs(a);
+    }
+
+    [Fact]
+    public void Remove_FallsBackToLinearScan_WhenIndexIsStale() {
+        TimePriorityQueue<TestNode> queue = new(10);
+        TestNode a = new("A");
+        TestNode b = new("B");
+        TestNode c = new("C");
+
+        queue.Enqueue(a, 1.0);
+        queue.Enqueue(b, 2.0);
+        queue.Enqueue(c, 3.0);
+
+        // Corrupt b's QueueIndex to simulate staleness.
+        b.QueueIndex = 99;
+
+        bool removed = queue.Remove(b);
+        removed.Should().BeTrue();
+        queue.Count.Should().Be(2);
+        queue.Contains(b).Should().BeFalse();
+    }
+
+    [Fact]
+    public void Clear_ResetsQueue() {
+        TimePriorityQueue<TestNode> queue = new(10);
+        TestNode a = new("A");
+        TestNode b = new("B");
+
+        queue.Enqueue(a, 1.0);
+        queue.Enqueue(b, 2.0);
+
+        queue.Clear();
+
+        queue.Count.Should().Be(0);
+        a.QueueIndex.Should().Be(-1);
+        b.QueueIndex.Should().Be(-1);
+        a.QueueOwner.Should().BeNull();
+        b.QueueOwner.Should().BeNull();
+    }
+
+    [Fact]
+    public void Resize_PreservesElements() {
+        TimePriorityQueue<TestNode> queue = new(4);
+        TestNode a = new("A");
+        TestNode b = new("B");
+
+        queue.Enqueue(a, 1.0);
+        queue.Enqueue(b, 2.0);
+
+        queue.Resize(20);
+
+        queue.MaxSize.Should().Be(20);
+        queue.Count.Should().Be(2);
+        queue.Dequeue().Should().BeSameAs(a);
+        queue.Dequeue().Should().BeSameAs(b);
+    }
+
+    [Fact]
+    public void Resize_ThrowsWhenSmallerThanCount() {
+        TimePriorityQueue<TestNode> queue = new(10);
+        TestNode a = new("A");
+        TestNode b = new("B");
+        TestNode c = new("C");
+
+        queue.Enqueue(a, 1.0);
+        queue.Enqueue(b, 2.0);
+        queue.Enqueue(c, 3.0);
+
+        Action act = () => queue.Resize(2);
+        act.Should().Throw<InvalidOperationException>();
+    }
+
+    [Fact]
+    public void Resize_ThrowsWhenZeroOrNegative() {
+        TimePriorityQueue<TestNode> queue = new(10);
+
+        Action act = () => queue.Resize(0);
+        act.Should().Throw<ArgumentOutOfRangeException>();
+    }
+
+    [Fact]
+    public void Enqueue_ThrowsWhenFull() {
+        TimePriorityQueue<TestNode> queue = new(2);
+        queue.Enqueue(new TestNode("A"), 1.0);
+        queue.Enqueue(new TestNode("B"), 2.0);
+
+        Action act = () => queue.Enqueue(new TestNode("C"), 3.0);
+        act.Should().Throw<InvalidOperationException>();
+    }
+
+    [Fact]
+    public void Enqueue_ThrowsWhenNodeAlreadyEnqueued() {
+        TimePriorityQueue<TestNode> queue = new(10);
+        TestNode node = new("A");
+
+        queue.Enqueue(node, 1.0);
+
+        Action act = () => queue.Enqueue(node, 2.0);
+        act.Should().Throw<InvalidOperationException>();
+    }
+
+    [Fact]
+    public void ManyItems_MaintainsCorrectOrder() {
+        TimePriorityQueue<TestNode> queue = new(100);
+        double[] priorities = { 50, 30, 70, 10, 90, 20, 80, 40, 60, 5 };
+        TestNode[] nodes = new TestNode[priorities.Length];
+
+        for (int i = 0; i < priorities.Length; i++) {
+            nodes[i] = new TestNode($"N{i}");
+            queue.Enqueue(nodes[i], priorities[i]);
+        }
+
+        Array.Sort(priorities);
+        for (int i = 0; i < priorities.Length; i++) {
+            TestNode dequeued = queue.Dequeue();
+            dequeued.Priority.Should().Be(priorities[i]);
+        }
+    }
+
+    [Fact]
+    public void Remove_MiddleNode_MaintainsHeapProperty() {
+        TimePriorityQueue<TestNode> queue = new(100);
+        TestNode[] nodes = new TestNode[10];
+        for (int i = 0; i < 10; i++) {
+            nodes[i] = new TestNode($"N{i}");
+            queue.Enqueue(nodes[i], i * 10.0);
+        }
+
+        // Remove node with priority 50 (index 5).
+        queue.Remove(nodes[5]).Should().BeTrue();
+
+        // Verify remaining nodes dequeue in order.
+        double lastPriority = double.MinValue;
+        while (queue.Count > 0) {
+            TestNode dequeued = queue.Dequeue();
+            dequeued.Priority.Should().BeGreaterThanOrEqualTo(lastPriority);
+            lastPriority = dequeued.Priority;
+        }
+    }
+
+    [Fact]
+    public void NodeReuse_AfterDequeue_CanBeReenqueued() {
+        TimePriorityQueue<TestNode> queue = new(10);
+        TestNode node = new("A");
+
+        queue.Enqueue(node, 5.0);
+        queue.Dequeue();
+
+        // Re-enqueue with a different priority.
+        queue.Enqueue(node, 1.0);
+
+        queue.Count.Should().Be(1);
+        queue.First.Should().BeSameAs(node);
+        node.Priority.Should().Be(1.0);
+    }
+
+    [Fact]
+    public void NodeReuse_AfterRemove_CanBeReenqueued() {
+        TimePriorityQueue<TestNode> queue = new(10);
+        TestNode node = new("A");
+
+        queue.Enqueue(node, 5.0);
+        queue.Remove(node);
+
+        queue.Enqueue(node, 2.0);
+
+        queue.Count.Should().Be(1);
+        queue.First.Should().BeSameAs(node);
+    }
+
+    [Fact]
+    public void Constructor_ThrowsOnInvalidCapacity() {
+        Action act = () => new TimePriorityQueue<TestNode>(0);
+        act.Should().Throw<ArgumentOutOfRangeException>();
+
+        act = () => new TimePriorityQueue<TestNode>(-1);
+        act.Should().Throw<ArgumentOutOfRangeException>();
+    }
+
+    [Fact]
+    public void EqualPriorities_DoNotCorruptQueue() {
+        TimePriorityQueue<TestNode> queue = new(10);
+        TestNode a = new("A");
+        TestNode b = new("B");
+        TestNode c = new("C");
+
+        queue.Enqueue(a, 5.0);
+        queue.Enqueue(b, 5.0);
+        queue.Enqueue(c, 5.0);
+
+        queue.Count.Should().Be(3);
+
+        // All should dequeue without error; order among ties is implementation-defined.
+        TestNode d1 = queue.Dequeue();
+        TestNode d2 = queue.Dequeue();
+        TestNode d3 = queue.Dequeue();
+
+        new[] { d1, d2, d3 }.Should().BeEquivalentTo(new[] { a, b, c });
+    }
+
+    [Fact]
+    public void DoublePrecisionPriorities_ArePreserved() {
+        TimePriorityQueue<TestNode> queue = new(10);
+        TestNode a = new("A");
+        TestNode b = new("B");
+
+        // These two values would be identical if cast to float.
+        double priorityA = 1000000.0001;
+        double priorityB = 1000000.0002;
+
+        queue.Enqueue(a, priorityA);
+        queue.Enqueue(b, priorityB);
+
+        queue.Dequeue().Should().BeSameAs(a);
+        queue.Dequeue().Should().BeSameAs(b);
+    }
+
+    [Fact]
+    public void NodeAt_ReturnsCorrectNode() {
+        TimePriorityQueue<TestNode> queue = new(10);
+        TestNode a = new("A");
+        TestNode b = new("B");
+        TestNode c = new("C");
+
+        queue.Enqueue(a, 1.0);
+        queue.Enqueue(b, 2.0);
+        queue.Enqueue(c, 3.0);
+
+        // Index 1 is always the minimum-priority node.
+        queue.NodeAt(1).Should().BeSameAs(a);
+        // All nodes at indices 1..Count are non-null.
+        for (int i = 1; i <= queue.Count; i++) {
+            queue.NodeAt(i).Should().NotBeNull();
+        }
+    }
+
+    [Fact]
+    public void NodeAt_ThrowsWhenIndexBelowRange() {
+        TimePriorityQueue<TestNode> queue = new(10);
+        queue.Enqueue(new TestNode("A"), 1.0);
+
+        Action act = () => queue.NodeAt(0);
+        act.Should().Throw<ArgumentOutOfRangeException>();
+    }
+
+    [Fact]
+    public void NodeAt_ThrowsWhenIndexAboveCount() {
+        TimePriorityQueue<TestNode> queue = new(10);
+        queue.Enqueue(new TestNode("A"), 1.0);
+
+        Action act = () => queue.NodeAt(2);
+        act.Should().Throw<ArgumentOutOfRangeException>();
+    }
+
+    [Fact]
+    public void NodeAt_ThrowsOnEmptyQueue() {
+        TimePriorityQueue<TestNode> queue = new(10);
+
+        Action act = () => queue.NodeAt(1);
+        act.Should().Throw<ArgumentOutOfRangeException>();
+    }
+
+    [Fact]
+    public void Remove_SingleElement_EmptiesQueue() {
+        TimePriorityQueue<TestNode> queue = new(10);
+        TestNode node = new("A");
+
+        queue.Enqueue(node, 5.0);
+        bool removed = queue.Remove(node);
+
+        removed.Should().BeTrue();
+        queue.Count.Should().Be(0);
+        node.QueueIndex.Should().Be(-1);
+        node.QueueOwner.Should().BeNull();
+    }
+
+    [Fact]
+    public void Clear_OnEmptyQueue_DoesNotThrow() {
+        TimePriorityQueue<TestNode> queue = new(10);
+
+        Action act = () => queue.Clear();
+        act.Should().NotThrow();
+        queue.Count.Should().Be(0);
+    }
+
+    [Fact]
+    public void UpdatePriority_SamePriority_NoChange() {
+        TimePriorityQueue<TestNode> queue = new(10);
+        TestNode a = new("A");
+        TestNode b = new("B");
+
+        queue.Enqueue(a, 1.0);
+        queue.Enqueue(b, 2.0);
+
+        // Updating A with its current priority should leave order unchanged.
+        queue.UpdatePriority(a, 1.0);
+
+        queue.Dequeue().Should().BeSameAs(a);
+        queue.Dequeue().Should().BeSameAs(b);
+    }
+
+    [Fact]
+    public void Resize_ToSameSize_Succeeds() {
+        TimePriorityQueue<TestNode> queue = new(10);
+        TestNode a = new("A");
+        queue.Enqueue(a, 1.0);
+
+        queue.Resize(10);
+
+        queue.MaxSize.Should().Be(10);
+        queue.Count.Should().Be(1);
+        queue.Dequeue().Should().BeSameAs(a);
+    }
+
+    [Fact]
+    public void Contains_NodeInDifferentQueue_ReturnsFalse() {
+        TimePriorityQueue<TestNode> queueA = new(10);
+        TimePriorityQueue<TestNode> queueB = new(10);
+        TestNode node = new("A");
+
+        queueA.Enqueue(node, 1.0);
+
+        queueB.Contains(node).Should().BeFalse();
+    }
+
+    [Fact]
+    public void Enqueue_AfterClear_CanReenqueueNodes() {
+        TimePriorityQueue<TestNode> queue = new(10);
+        TestNode a = new("A");
+        TestNode b = new("B");
+
+        queue.Enqueue(a, 1.0);
+        queue.Enqueue(b, 2.0);
+        queue.Clear();
+
+        // Both nodes should be re-enqueueable after Clear.
+        queue.Enqueue(a, 3.0);
+        queue.Enqueue(b, 1.0);
+
+        queue.Count.Should().Be(2);
+        queue.Dequeue().Should().BeSameAs(b);
+        queue.Dequeue().Should().BeSameAs(a);
+    }
+
+    [Fact]
+    public void NegativePriorities_OrderCorrectly() {
+        TimePriorityQueue<TestNode> queue = new(10);
+        TestNode a = new("A");
+        TestNode b = new("B");
+        TestNode c = new("C");
+
+        queue.Enqueue(a, -10.0);
+        queue.Enqueue(b, 0.0);
+        queue.Enqueue(c, -5.0);
+
+        queue.Dequeue().Should().BeSameAs(a);
+        queue.Dequeue().Should().BeSameAs(c);
+        queue.Dequeue().Should().BeSameAs(b);
+    }
+
+    [Fact]
+    public void Resize_ThrowsWhenNegative() {
+        TimePriorityQueue<TestNode> queue = new(10);
+
+        Action act = () => queue.Resize(-1);
+        act.Should().Throw<ArgumentOutOfRangeException>();
+    }
+}

--- a/tests/Spice86.Tests/Video/DacTest.cs
+++ b/tests/Spice86.Tests/Video/DacTest.cs
@@ -1,6 +1,7 @@
 namespace Spice86.Tests.Video;
 
 using Spice86.Core.Emulator.Devices.Video.Registers;
+using Spice86.Core.Emulator.Devices.Video.Registers.Enums;
 
 using Xunit;
 
@@ -35,7 +36,59 @@ public class DacTest {
         dac.DataRegister = 0b111111;
         dac.DataRegister = 0b111111;
 
-        // Assert
+        // Assert – both the legacy ArgbPalette view and the new fast PaletteMap must agree
         Assert.Equal(0xFFFFFFFF, dac.ArgbPalette[0]);
+        Assert.Equal(0xFFFFFFFF, dac.PaletteMap[0]);
+    }
+
+    [Fact]
+    public void PaletteMapRespectsPixelMask() {
+        // Arrange – write red (63,0,0) at index 1, black (0,0,0) at index 0
+        var dac = new DacRegisters();
+        // Index 1: red
+        dac.IndexRegisterWriteMode = 1;
+        dac.DataRegister = 63; // R
+        dac.DataRegister = 0;  // G
+        dac.DataRegister = 0;  // B
+
+        // With PixelMask=0xFF every index maps to itself
+        Assert.Equal(0xFFFF0000, dac.PaletteMap[1]); // red
+
+        // With PixelMask=0xFE index 1 is masked to index 0 (black)
+        dac.PixelMask = 0xFE;
+        Assert.Equal(0xFF000000, dac.PaletteMap[1]); // black (palette[0])
+
+        // Restoring mask restores the mapping
+        dac.PixelMask = 0xFF;
+        Assert.Equal(0xFFFF0000, dac.PaletteMap[1]); // red again
+    }
+
+    [Fact]
+    public void AttributeMapReflectsDacChanges() {
+        // Arrange – identity InternalPalette (entry i maps to DAC index i) with default ColorSelect
+        var dac = new DacRegisters();
+        var attr = new AttributeControllerRegisters();
+
+        // Set InternalPalette[5] = 5 (identity; default is 0, so set explicitly)
+        attr.WriteRegister((AttributeControllerRegister)5, 5);
+
+        // Write green (0,63,0) to DAC index 5
+        dac.IndexRegisterWriteMode = 5;
+        dac.DataRegister = 0;  // R
+        dac.DataRegister = 63; // G
+        dac.DataRegister = 0;  // B
+        // PaletteMap[5] is now green; rebuild AttributeMap to pick it up
+        dac.RebuildAttributeMap(attr);
+
+        Assert.Equal(0xFF00FF00, dac.AttributeMap[5]);
+
+        // Changing the DAC colour should be reflected after rebuild
+        dac.IndexRegisterWriteMode = 5;
+        dac.DataRegister = 0;  // R
+        dac.DataRegister = 0;  // G
+        dac.DataRegister = 63; // B
+        dac.RebuildAttributeMap(attr);
+
+        Assert.Equal(0xFF0000FF, dac.AttributeMap[5]);
     }
 }

--- a/tests/Spice86.Tests/Video/RendererAvx2Tests.cs
+++ b/tests/Spice86.Tests/Video/RendererAvx2Tests.cs
@@ -1,0 +1,15 @@
+namespace Spice86.Tests.Video;
+
+using Spice86.Core.Emulator.Devices.Video;
+
+using System.Runtime.Intrinsics.X86;
+
+/// <summary>
+///     Runs the <see cref="Renderer" /> test suite with the AVX2 256-color implementation.
+///     Tests are skipped automatically on machines that do not support AVX2.
+/// </summary>
+public sealed class RendererAvx2Tests : RendererTestsBase {
+    protected override bool IsSupported => Avx2.IsSupported;
+
+    protected override IVgaRenderer256Color Create256ColorRenderer() => new VgaRenderer256ColorAvx2();
+}

--- a/tests/Spice86.Tests/Video/RendererSse41Tests.cs
+++ b/tests/Spice86.Tests/Video/RendererSse41Tests.cs
@@ -1,0 +1,15 @@
+namespace Spice86.Tests.Video;
+
+using Spice86.Core.Emulator.Devices.Video;
+
+using System.Runtime.Intrinsics.X86;
+
+/// <summary>
+///     Runs the <see cref="Renderer" /> test suite with the SSE4.1 256-color implementation.
+///     Tests are skipped automatically on machines that do not support SSE4.1.
+/// </summary>
+public sealed class RendererSse41Tests : RendererTestsBase {
+    protected override bool IsSupported => Sse41.IsSupported;
+
+    protected override IVgaRenderer256Color Create256ColorRenderer() => new VgaRenderer256ColorSse41();
+}

--- a/tests/Spice86.Tests/Video/RendererTests.cs
+++ b/tests/Spice86.Tests/Video/RendererTests.cs
@@ -1,0 +1,12 @@
+﻿namespace Spice86.Tests.Video;
+
+using Spice86.Core.Emulator.Devices.Video;
+
+/// <summary>
+///     Runs the <see cref="Renderer" /> test suite with the scalar (non-SIMD) 256-color implementation.
+/// </summary>
+public sealed class RendererTests : RendererTestsBase {
+    protected override bool IsSupported => true;
+
+    protected override IVgaRenderer256Color Create256ColorRenderer() => new VgaRenderer256ColorScalar();
+}

--- a/tests/Spice86.Tests/Video/RendererTestsBase.cs
+++ b/tests/Spice86.Tests/Video/RendererTestsBase.cs
@@ -1,0 +1,1383 @@
+﻿namespace Spice86.Tests.Video;
+
+using FluentAssertions;
+
+using NSubstitute;
+
+using Spice86.Core.Emulator.Devices.Video;
+using Spice86.Core.Emulator.Devices.Video.Registers.CrtController;
+using Spice86.Core.Emulator.Devices.Video.Registers.Graphics;
+using Spice86.Core.Emulator.Memory;
+using Spice86.Logging;
+using Spice86.Shared.Interfaces;
+
+using Xunit;
+
+using ClockSelect = Spice86.Core.Emulator.Devices.Video.Registers.General.MiscellaneousOutput.ClockSelectValue;
+
+/// <summary>
+///     Base class for <see cref="Renderer" /> tests, parameterized by renderer implementation.
+/// </summary>
+public abstract class RendererTestsBase {
+    /// <summary>Returns true when the renderer under test is runnable on this machine.</summary>
+    protected abstract bool IsSupported { get; }
+
+    /// <summary>Creates the renderer implementation under test.</summary>
+    protected abstract IVgaRenderer256Color Create256ColorRenderer();
+
+    /// <summary>Skips the current test when the required instruction set is not supported.</summary>
+    protected void EnsureSupported() =>
+        Skip.IfNot(IsSupported, "The required CPU instruction set is not supported on this machine.");
+
+    // -------------------------------------------------- Width / Height --------------------------------------------------
+
+    [SkippableFact]
+    public void Width_25MHz_HalfDot_Returns320() {
+        EnsureSupported();
+        (Renderer renderer, _) = CreateRenderer(ConfigureBase(ClockSelect.Use25175Khz, halfDot: true));
+        renderer.Width.Should().Be(320);
+    }
+
+    [SkippableFact]
+    public void Width_25MHz_FullDot_Returns640() {
+        EnsureSupported();
+        (Renderer renderer, _) = CreateRenderer(ConfigureBase(ClockSelect.Use25175Khz, halfDot: false));
+        renderer.Width.Should().Be(640);
+    }
+
+    [SkippableFact]
+    public void Width_28MHz_HalfDot_Returns360() {
+        EnsureSupported();
+        (Renderer renderer, _) = CreateRenderer(ConfigureBase(ClockSelect.Use28322Khz, halfDot: true));
+        renderer.Width.Should().Be(360);
+    }
+
+    [SkippableFact]
+    public void Width_28MHz_FullDot_Returns720() {
+        EnsureSupported();
+        (Renderer renderer, _) = CreateRenderer(ConfigureBase(ClockSelect.Use28322Khz, halfDot: false));
+        renderer.Width.Should().Be(720);
+    }
+
+    [SkippableFact]
+    public void Height_NoScanDouble_ReturnsVerticalDisplayEndPlusOne() {
+        EnsureSupported();
+        VideoState state = ConfigureBase(ClockSelect.Use25175Khz, halfDot: true);
+        state.CrtControllerRegisters.VerticalDisplayEnd = 199;
+        state.CrtControllerRegisters.MaximumScanlineRegister.CrtcScanDouble = false;
+
+        (Renderer renderer, _) = CreateRenderer(state);
+        renderer.Height.Should().Be(200);
+    }
+
+    [SkippableFact]
+    public void Height_WithScanDouble_ReturnsHalf() {
+        EnsureSupported();
+        VideoState state = ConfigureBase(ClockSelect.Use25175Khz, halfDot: true);
+        state.CrtControllerRegisters.VerticalDisplayEnd = 199;
+        state.CrtControllerRegisters.MaximumScanlineRegister.CrtcScanDouble = true;
+
+        (Renderer renderer, _) = CreateRenderer(state);
+
+        renderer.Height.Should().Be(100);
+    }
+
+    // -------------------------------------------------- Buffer Management --------------------------------------------------
+
+    [SkippableFact]
+    public void BufferSize_AfterBeginFrame_MatchesWidthTimesHeight() {
+        EnsureSupported();
+        VideoState state = ConfigureGraphics256Color(1);
+        (Renderer renderer, _) = CreateRenderer(state);
+
+        state.IsRenderingDirty = true;
+        renderer.BeginFrame();
+
+        renderer.BufferSize.Should().Be(renderer.Width * renderer.Height);
+    }
+
+    [SkippableFact]
+    public void Render_NoPendingFrame_LeavesBufferUntouched() {
+        EnsureSupported();
+        VideoState state = ConfigureGraphics256Color(1);
+        (Renderer renderer, _) = CreateRenderer(state);
+
+        uint[] output = new uint[renderer.Width];
+        Array.Fill(output, 0xDEADBEEF);
+
+        renderer.Render(output);
+
+        output.Should().AllBeEquivalentTo(0xDEADBEEF);
+    }
+
+    [SkippableFact]
+    public void Render_WithPendingFrame_CopiesPixels() {
+        EnsureSupported();
+        VideoState state = ConfigureGraphics256Color(1);
+        (Renderer renderer, VideoMemory vram) = CreateRenderer(state);
+        SetIdentityPaletteMap(state);
+
+        vram.Planes[0, 0] = 7;
+        state.IsRenderingDirty = true;
+        RenderFullFrame(renderer, state);
+
+        uint[] output = new uint[renderer.Width * renderer.Height];
+        renderer.Render(output);
+
+        // First two pixels should be PaletteMap[7]
+        output[0].Should().Be(state.DacRegisters.PaletteMap[7]);
+        output[1].Should().Be(state.DacRegisters.PaletteMap[7]);
+    }
+
+    [SkippableFact]
+    public void ResolutionChange_ReallocatesBuffer() {
+        EnsureSupported();
+        VideoState state = ConfigureGraphics256Color(1);
+        (Renderer renderer, _) = CreateRenderer(state);
+
+        state.IsRenderingDirty = true;
+        renderer.BeginFrame();
+        renderer.BufferSize.Should().Be(320);
+
+        // Change to 2 lines
+        state.CrtControllerRegisters.VerticalDisplayEnd = 1;
+        state.CrtControllerRegisters.VerticalTotal = 1;
+        state.IsRenderingDirty = true;
+        renderer.BeginFrame();
+
+
+        renderer.BufferSize.Should().Be(640);
+    }
+
+    // -------------------------------------------------- 256-Color Mode --------------------------------------------------
+
+    [SkippableFact]
+    public void Render256Color_DoublesPlaneBytesToPixels() {
+        EnsureSupported();
+        VideoState state = ConfigureGraphics256Color(1);
+        (Renderer renderer, VideoMemory vram) = CreateRenderer(state);
+        SetIdentityPaletteMap(state);
+
+        // First character: planes[0..3] at address 0
+        vram.Planes[0, 0] = 10;
+        vram.Planes[1, 0] = 20;
+        vram.Planes[2, 0] = 30;
+        vram.Planes[3, 0] = 40;
+
+        state.IsRenderingDirty = true;
+        uint[] frame = RenderAndCapture(renderer, state);
+
+        // Each plane byte produces 2 consecutive identical pixels
+        frame[0].Should().Be(state.DacRegisters.PaletteMap[10]);
+        frame[1].Should().Be(state.DacRegisters.PaletteMap[10]);
+        frame[2].Should().Be(state.DacRegisters.PaletteMap[20]);
+        frame[3].Should().Be(state.DacRegisters.PaletteMap[20]);
+        frame[4].Should().Be(state.DacRegisters.PaletteMap[30]);
+        frame[5].Should().Be(state.DacRegisters.PaletteMap[30]);
+        frame[6].Should().Be(state.DacRegisters.PaletteMap[40]);
+        frame[7].Should().Be(state.DacRegisters.PaletteMap[40]);
+    }
+
+    [SkippableFact]
+    public void Render256Color_UsesPaletteMap() {
+        EnsureSupported();
+        VideoState state = ConfigureGraphics256Color(1);
+        (Renderer renderer, VideoMemory vram) = CreateRenderer(state);
+
+        // Set up specific palette colors
+        uint expectedColor = 0xFF_AA_BB_CC;
+        state.DacRegisters.PaletteMap[42] = expectedColor;
+
+        vram.Planes[0, 0] = 42;
+        state.IsRenderingDirty = true;
+        uint[] frame = RenderAndCapture(renderer, state);
+
+        frame[0].Should().Be(expectedColor);
+        frame[1].Should().Be(expectedColor);
+    }
+
+    [SkippableFact]
+    public void Render256Color_MultipleCharacters() {
+        EnsureSupported();
+        VideoState state = ConfigureGraphics256Color(1);
+        (Renderer renderer, VideoMemory vram) = CreateRenderer(state);
+        SetIdentityPaletteMap(state);
+
+        // Write two consecutive character positions
+        vram.Planes[0, 0] = 1;
+        vram.Planes[1, 0] = 2;
+        vram.Planes[2, 0] = 3;
+        vram.Planes[3, 0] = 4;
+
+        vram.Planes[0, 1] = 5;
+        vram.Planes[1, 1] = 6;
+        vram.Planes[2, 1] = 7;
+        vram.Planes[3, 1] = 8;
+
+        state.IsRenderingDirty = true;
+        uint[] frame = RenderAndCapture(renderer, state);
+
+        // Second character (address 1) starts at pixel 8
+        frame[8].Should().Be(state.DacRegisters.PaletteMap[5]);
+        frame[9].Should().Be(state.DacRegisters.PaletteMap[5]);
+        frame[10].Should().Be(state.DacRegisters.PaletteMap[6]);
+        frame[11].Should().Be(state.DacRegisters.PaletteMap[6]);
+    }
+
+    [SkippableFact]
+    public void Render256Color_MultipleScanlines() {
+        EnsureSupported();
+        VideoState state = ConfigureGraphics256Color(2);
+        (Renderer renderer, VideoMemory vram) = CreateRenderer(state);
+        SetIdentityPaletteMap(state);
+
+        // Line 0 pixel data at address 0
+        vram.Planes[0, 0] = 10;
+        // Line 1 pixel data: rowAddr advances by Offset << 1 = 80
+        vram.Planes[0, 80] = 20;
+
+        state.IsRenderingDirty = true;
+        uint[] frame = RenderAndCapture(renderer, state);
+
+        int width = renderer.Width;
+        frame[0].Should().Be(state.DacRegisters.PaletteMap[10], "line 0, first pixel pair");
+        frame[width].Should().Be(state.DacRegisters.PaletteMap[20], "line 1, first pixel pair");
+    }
+
+    // -------------------------------------------------- EGA Graphics Mode --------------------------------------------------
+
+    [SkippableFact]
+    public void RenderEgaGraphics_CombinesPlanesTo4BitIndex() {
+        EnsureSupported();
+        VideoState state = ConfigureGraphicsEga(1);
+        (Renderer renderer, VideoMemory vram) = CreateRenderer(state);
+        SetIdentityAttributeMap(state);
+
+        // All planes set bit 7 â†’ index = 0b1111 = 15
+        vram.Planes[0, 0] = 0x80; // bit 7 set
+        vram.Planes[1, 0] = 0x80;
+        vram.Planes[2, 0] = 0x80;
+        vram.Planes[3, 0] = 0x80;
+
+        state.IsRenderingDirty = true;
+        uint[] frame = RenderAndCapture(renderer, state);
+
+        // First pixel (bit 7) should be index 15
+        frame[0].Should().Be(state.DacRegisters.AttributeMap[15]);
+    }
+
+    [SkippableFact]
+    public void RenderEgaGraphics_EachBitProducesOnePixel() {
+        EnsureSupported();
+        VideoState state = ConfigureGraphicsEga(1);
+        (Renderer renderer, VideoMemory vram) = CreateRenderer(state);
+        SetIdentityAttributeMap(state);
+
+        // Only plane 0 has bit 7 set (others 0) â†’ index = 0b0001 = 1 for first pixel
+        // Only plane 0 has bit 6 set â†’ index = 1 for second pixel
+        vram.Planes[0, 0] = 0xFF; // all bits set
+        vram.Planes[1, 0] = 0x00;
+        vram.Planes[2, 0] = 0x00;
+        vram.Planes[3, 0] = 0x00;
+
+        state.IsRenderingDirty = true;
+        uint[] frame = RenderAndCapture(renderer, state);
+
+        // All 8 pixels should be attribute index 1 (only plane 0 contributes)
+        for (int i = 0; i < 8; i++) {
+            frame[i].Should().Be(state.DacRegisters.AttributeMap[1], $"pixel {i}");
+        }
+    }
+
+    [SkippableFact]
+    public void RenderEgaGraphics_AllPlanesContribute() {
+        EnsureSupported();
+        VideoState state = ConfigureGraphicsEga(1);
+        (Renderer renderer, VideoMemory vram) = CreateRenderer(state);
+        SetIdentityAttributeMap(state);
+
+        // Plane 0 bit 7, plane 1 bit 7, plane 2 bit 7, plane 3 clear â†’ index = 0b0111 = 7
+        vram.Planes[0, 0] = 0x80;
+        vram.Planes[1, 0] = 0x80;
+        vram.Planes[2, 0] = 0x80;
+        vram.Planes[3, 0] = 0x00;
+
+        state.IsRenderingDirty = true;
+        uint[] frame = RenderAndCapture(renderer, state);
+
+        frame[0].Should().Be(state.DacRegisters.AttributeMap[7]);
+    }
+
+    [SkippableFact]
+    public void RenderEgaGraphics_UsesAttributeMap() {
+        EnsureSupported();
+        VideoState state = ConfigureGraphicsEga(1);
+        (Renderer renderer, VideoMemory vram) = CreateRenderer(state);
+
+        uint expected = 0xFF_12_34_56;
+        state.DacRegisters.AttributeMap[5] = expected;
+
+        // Index 5 = 0b0101 â†’ plane0 bit set, plane2 bit set, others clear
+        vram.Planes[0, 0] = 0x80;
+        vram.Planes[1, 0] = 0x00;
+        vram.Planes[2, 0] = 0x80;
+        vram.Planes[3, 0] = 0x00;
+
+        state.IsRenderingDirty = true;
+        uint[] frame = RenderAndCapture(renderer, state);
+
+        frame[0].Should().Be(expected);
+    }
+
+    // -------------------------------------------------- CGA Graphics Mode --------------------------------------------------
+
+    [SkippableFact]
+    public void RenderCgaGraphics_InterleavesPlanes02And13() {
+        EnsureSupported();
+        VideoState state = ConfigureGraphicsCga(1);
+        (Renderer renderer, VideoMemory vram) = CreateRenderer(state);
+        SetIdentityAttributeMap(state);
+
+        // CGA mode: first 4 pixels from planes 0,2 interleaved; next 4 from planes 1,3
+        // Each 2-bit pair from each plane is combined: (plane2_bits << 2) | plane0_bits
+        // For bits 7-6: plane0 = 0b11xxxxxx, plane2 = 0b01xxxxxx â†’
+        //   index = (0b01 << 2) | 0b11 = 0b0111 = 7
+        vram.Planes[0, 0] = 0b11_00_00_00;
+        vram.Planes[2, 0] = 0b01_00_00_00;
+
+        state.IsRenderingDirty = true;
+        uint[] frame = RenderAndCapture(renderer, state);
+
+        frame[0].Should().Be(state.DacRegisters.AttributeMap[7], "first CGA pixel from planes 0,2");
+    }
+
+    [SkippableFact]
+    public void RenderCgaGraphics_SecondHalfFromPlanes13() {
+        EnsureSupported();
+        VideoState state = ConfigureGraphicsCga(1);
+        (Renderer renderer, VideoMemory vram) = CreateRenderer(state);
+        SetIdentityAttributeMap(state);
+
+        // Second 4 pixels come from planes 1 and 3
+        // Bits 7-6: plane1 = 0b10xxxxxx, plane3 = 0b11xxxxxx
+        //   index = (0b11 << 2) | 0b10 = 0b1110 = 14
+        vram.Planes[1, 0] = 0b10_00_00_00;
+        vram.Planes[3, 0] = 0b11_00_00_00;
+
+        state.IsRenderingDirty = true;
+        uint[] frame = RenderAndCapture(renderer, state);
+
+        // Pixels 4-7 are from planes 1,3
+        frame[4].Should().Be(state.DacRegisters.AttributeMap[14]);
+    }
+
+    [SkippableFact]
+    public void RenderCgaGraphics_FourPixelsPerHalf() {
+        EnsureSupported();
+        VideoState state = ConfigureGraphicsCga(1);
+        (Renderer renderer, VideoMemory vram) = CreateRenderer(state);
+        SetIdentityAttributeMap(state);
+
+        // All 4 bit-pairs in plane 0: 0b_11_10_01_00
+        // All 4 bit-pairs in plane 2: 0b_00_00_00_00
+        vram.Planes[0, 0] = 0b11_10_01_00;
+        vram.Planes[2, 0] = 0b00_00_00_00;
+
+        state.IsRenderingDirty = true;
+        uint[] frame = RenderAndCapture(renderer, state);
+
+        // 4 pixels from planes 0,2 with plane2 = 0: indices = 3, 2, 1, 0
+        frame[0].Should().Be(state.DacRegisters.AttributeMap[3]);
+        frame[1].Should().Be(state.DacRegisters.AttributeMap[2]);
+        frame[2].Should().Be(state.DacRegisters.AttributeMap[1]);
+        frame[3].Should().Be(state.DacRegisters.AttributeMap[0]);
+    }
+
+    // -------------------------------------------------- Text Mode --------------------------------------------------
+
+    [SkippableFact]
+    public void RenderTextMode_UsesFontFromPlane2() {
+        EnsureSupported();
+        VideoState state = ConfigureTextMode(1);
+        (Renderer renderer, VideoMemory vram) = CreateRenderer(state);
+        SetIdentityAttributeMap(state);
+
+        byte charCode = 65; // 'A'
+        byte attribute = 0x07; // white on black (fg=7, bg=0)
+        int fontAddress = 32 * charCode; // font byte address in plane 2
+
+        vram.Planes[0, 0] = charCode;
+        vram.Planes[1, 0] = attribute;
+        // Font for this char at scanline 0: all bits set = all foreground
+        vram.Planes[2, fontAddress] = 0xFF;
+
+        state.IsRenderingDirty = true;
+        uint[] frame = RenderAndCapture(renderer, state);
+
+        // All 8 pixels (DotsPerClock=8) should be foreground color (attribute index 7)
+        for (int i = 0; i < 8; i++) {
+            frame[i].Should().Be(state.DacRegisters.AttributeMap[7], $"pixel {i} should be foreground");
+        }
+    }
+
+    [SkippableFact]
+    public void RenderTextMode_BackgroundPixelsFromAttribute() {
+        EnsureSupported();
+        VideoState state = ConfigureTextMode(1);
+        (Renderer renderer, VideoMemory vram) = CreateRenderer(state);
+        SetIdentityAttributeMap(state);
+
+        byte charCode = 0;
+        byte attribute = 0x70; // black on white (fg=0, bg=7)
+
+        vram.Planes[0, 0] = charCode;
+        vram.Planes[1, 0] = attribute;
+        // Font byte = 0x00 â†’ all background
+        vram.Planes[2, 0] = 0x00;
+
+        state.IsRenderingDirty = true;
+        uint[] frame = RenderAndCapture(renderer, state);
+
+        // Background = (attribute >> 4) & 0xF = 7
+        for (int i = 0; i < 8; i++) {
+            frame[i].Should().Be(state.DacRegisters.AttributeMap[7], $"pixel {i} should be background");
+        }
+    }
+
+    [SkippableFact]
+    public void RenderTextMode_ForegroundAndBackgroundMixed() {
+        EnsureSupported();
+        VideoState state = ConfigureTextMode(1);
+        (Renderer renderer, VideoMemory vram) = CreateRenderer(state);
+        SetIdentityAttributeMap(state);
+
+        byte charCode = 0;
+        byte attribute = 0x12; // fg=2, bg=1
+        vram.Planes[0, 0] = charCode;
+        vram.Planes[1, 0] = attribute;
+        // Font byte = 0b10101010 â†’ alternating foreground/background
+        vram.Planes[2, 0] = 0b10101010;
+
+        state.IsRenderingDirty = true;
+        uint[] frame = RenderAndCapture(renderer, state);
+
+        uint fg = state.DacRegisters.AttributeMap[2];
+        uint bg = state.DacRegisters.AttributeMap[1];
+        frame[0].Should().Be(fg, "bit 7 set â†’ foreground");
+        frame[1].Should().Be(bg, "bit 6 clear â†’ background");
+        frame[2].Should().Be(fg, "bit 5 set â†’ foreground");
+        frame[3].Should().Be(bg, "bit 4 clear â†’ background");
+    }
+
+    [SkippableFact]
+    public void RenderTextMode_BlinkSwapsForegroundAndBackground() {
+        EnsureSupported();
+        VideoState state = ConfigureTextMode(1);
+        VgaBlinkState blinkState = new();
+        (Renderer renderer, VideoMemory vram) = CreateRenderer(state, blinkState);
+        SetIdentityAttributeMap(state);
+
+        // Enable blinking
+        state.AttributeControllerRegisters.AttributeControllerModeRegister.BlinkingEnabled = true;
+
+        // Use specific palette values so we can verify the swap formula:
+        // (foreground, background) = (backGroundColor & 0x7, foreGroundColor)
+        // where foreGroundColor and backGroundColor are ARGB uint values.
+        uint bgArgb = 0xFF_00_00_07; // low 3 bits = 7
+        uint fgArgb = 0xFF_AB_CD_EF;
+        // Attribute 0x92: bg_index = (0x92 >> 4) & 0xF = 9, fg_index = 0x92 & 0xF = 2
+        state.DacRegisters.AttributeMap[9] = bgArgb;
+        state.DacRegisters.AttributeMap[2] = fgArgb;
+
+        byte attribute = 0x92; // blink=1, bg_index=9, fg_index=2
+        vram.Planes[0, 0] = 0;
+        vram.Planes[1, 0] = attribute;
+        vram.Planes[2, 0] = 0xFF; // all foreground
+
+        // Blink phase low â†’ swap applied
+        blinkState.IsBlinkPhaseHigh = false;
+        blinkState.MarkChanged();
+        uint[] frame = RenderAndCapture(renderer, state);
+
+        // After swap: new foreground = bgArgb & 0x7 = 7
+        // Font = 0xFF â†’ all pixels use new foreground
+        uint expectedFg = bgArgb & 0x7;
+        frame[0].Should().Be(expectedFg, "blink low: foreground = backGroundColor & 0x7");
+    }
+
+    [SkippableFact]
+    public void RenderTextMode_BlinkHighShowsNormal() {
+        EnsureSupported();
+        VideoState state = ConfigureTextMode(1);
+        VgaBlinkState blinkState = new();
+        (Renderer renderer, VideoMemory vram) = CreateRenderer(state, blinkState);
+        SetIdentityAttributeMap(state);
+
+        state.AttributeControllerRegisters.AttributeControllerModeRegister.BlinkingEnabled = true;
+
+        byte attribute = 0x92; // blink=1, bg=1, fg=2
+        vram.Planes[0, 0] = 0;
+        vram.Planes[1, 0] = attribute;
+        vram.Planes[2, 0] = 0xFF;
+
+        // Blink phase high â†’ normal display
+        blinkState.IsBlinkPhaseHigh = true;
+        blinkState.MarkChanged();
+        uint[] frame = RenderAndCapture(renderer, state);
+
+        // No swap â†’ foreground = 2
+        frame[0].Should().Be(state.DacRegisters.AttributeMap[2], "blink high: normal fg");
+    }
+
+    // -------------------------------------------------- Dirty-skip Optimization --------------------------------------------------
+
+    [SkippableFact]
+    public void BeginFrame_NoDirty_SkipsRendering() {
+        EnsureSupported();
+        VideoState state = ConfigureGraphics256Color(1);
+        (Renderer renderer, VideoMemory vram) = CreateRenderer(state);
+        SetIdentityPaletteMap(state);
+
+        // First frame: dirty â†’ renders
+        vram.Planes[0, 0] = 42;
+        state.IsRenderingDirty = true;
+        RenderFullFrame(renderer, state);
+        uint[] frame1 = new uint[renderer.Width * renderer.Height];
+        renderer.Render(frame1);
+        frame1[0].Should().Be(state.DacRegisters.PaletteMap[42]);
+
+        // Second frame: nothing changed â†’ skipped, no pending frame
+        RenderFullFrame(renderer, state);
+        uint[] frame2 = new uint[renderer.Width * renderer.Height];
+        Array.Fill(frame2, 0xDEADBEEF);
+        renderer.Render(frame2);
+
+        // Render should not have overwritten the buffer since no pending frame
+        frame2[0].Should().Be(0xDEADBEEF);
+    }
+
+    [SkippableFact]
+    public void BeginFrame_MemoryDirty_Renders() {
+        EnsureSupported();
+        VideoState state = ConfigureGraphics256Color(1);
+        (Renderer renderer, VideoMemory vram) = CreateRenderer(state);
+        SetIdentityPaletteMap(state);
+
+        // Initial frame
+        state.IsRenderingDirty = true;
+        RenderFullFrame(renderer, state);
+        uint[] discard = new uint[renderer.Width * renderer.Height];
+        renderer.Render(discard);
+
+        // Write to VRAM to make memory dirty
+        WriteVramByte(vram, state, 0, 99);
+
+        RenderFullFrame(renderer, state);
+        uint[] frame = new uint[renderer.Width * renderer.Height];
+        renderer.Render(frame);
+
+        frame[0].Should().Be(state.DacRegisters.PaletteMap[99]);
+    }
+
+    [SkippableFact]
+    public void BeginFrame_RegisterDirty_Renders() {
+        EnsureSupported();
+        VideoState state = ConfigureGraphics256Color(1);
+        (Renderer renderer, VideoMemory vram) = CreateRenderer(state);
+        SetIdentityPaletteMap(state);
+        vram.Planes[0, 0] = 55;
+
+        state.IsRenderingDirty = true;
+        RenderFullFrame(renderer, state);
+        uint[] frame = new uint[renderer.Width * renderer.Height];
+        renderer.Render(frame);
+
+        frame[0].Should().Be(state.DacRegisters.PaletteMap[55]);
+    }
+
+    [SkippableFact]
+    public void BeginFrame_BlinkDirty_Renders() {
+        EnsureSupported();
+        VideoState state = ConfigureGraphics256Color(1);
+        VgaBlinkState blinkState = new();
+        (Renderer renderer, VideoMemory vram) = CreateRenderer(state, blinkState);
+        SetIdentityPaletteMap(state);
+        vram.Planes[0, 0] = 77;
+
+        blinkState.MarkChanged();
+        RenderFullFrame(renderer, state);
+        uint[] frame = new uint[renderer.Width * renderer.Height];
+        renderer.Render(frame);
+
+        frame[0].Should().Be(state.DacRegisters.PaletteMap[77]);
+    }
+
+    [SkippableFact]
+    public void CompleteFrame_SkippedFrame_NoPendingFrame() {
+        EnsureSupported();
+        VideoState state = ConfigureGraphics256Color(1);
+        (Renderer renderer, _) = CreateRenderer(state);
+
+        // Frame with no dirty â†’ skip
+        renderer.BeginFrame();
+        for (int i = 0; i < 10; i++) {
+            renderer.RenderScanline();
+        }
+        renderer.CompleteFrame();
+
+        uint[] output = new uint[renderer.Width * renderer.Height];
+        Array.Fill(output, 0xDEADBEEF);
+        renderer.Render(output);
+
+        output[0].Should().Be(0xDEADBEEF, "skipped frame should not publish");
+    }
+
+    [SkippableFact]
+    public void MidFrameDirty_ResumesRenderingFromDirtyPoint() {
+        EnsureSupported();
+        VideoState state = ConfigureGraphics256Color(4);
+        (Renderer renderer, VideoMemory vram) = CreateRenderer(state);
+        SetIdentityPaletteMap(state);
+
+        // First frame: render normally, publish
+        // Fill all plane data with value 1 (covering all lines)
+        for (int addr = 0; addr < 320; addr++) {
+            vram.Planes[0, addr] = 1;
+        }
+        state.IsRenderingDirty = true;
+        RenderFullFrame(renderer, state);
+        uint[] first = new uint[renderer.Width * renderer.Height];
+        renderer.Render(first);
+
+        // Second frame: starts clean (no dirty)
+        // Line 2 row address = 2 * (Offset << 1) = 2 * 80 = 160
+        vram.Planes[0, 160] = 99;
+
+        // Begin frame (clean) â†’ _skipThisFrame = true
+        renderer.BeginFrame();
+
+        int width = renderer.Width;
+        int totalScanlines = state.CrtControllerRegisters.VerticalTotalValue + 10;
+
+        // Render scanlines 0 and 1 (lines 0 and 1 are in skip mode)
+        renderer.RenderScanline();
+        renderer.RenderScanline();
+
+        // Now mark dirty mid-frame via register change
+        state.IsRenderingDirty = true;
+
+        // Render remaining scanlines
+        for (int i = 2; i < totalScanlines; i++) {
+            renderer.RenderScanline();
+        }
+        renderer.CompleteFrame();
+
+        uint[] frame = new uint[renderer.Width * renderer.Height];
+        renderer.Render(frame);
+
+        // Line 2 should show the new value (dirty triggered before line 2 rendered)
+        frame[2 * width].Should().Be(state.DacRegisters.PaletteMap[99], "mid-frame dirty should render updated data");
+    }
+
+    [SkippableFact]
+    public void MidFrameDirty_CopiesPreviousFrameForAlreadySkippedLines() {
+        EnsureSupported();
+        VideoState state = ConfigureGraphics256Color(4);
+        (Renderer renderer, VideoMemory vram) = CreateRenderer(state);
+        SetIdentityPaletteMap(state);
+
+        // First frame: fill line 0 with value 50
+        for (int addr = 0; addr < 40; addr++) {
+            vram.Planes[0, addr] = 50;
+        }
+        state.IsRenderingDirty = true;
+        RenderFullFrame(renderer, state);
+        uint[] discard = new uint[renderer.Width * renderer.Height];
+        renderer.Render(discard);
+
+        // Second frame: starts clean
+        renderer.BeginFrame();
+        // Render some scanlines in skip mode
+        renderer.RenderScanline();
+        renderer.RenderScanline();
+        // Trigger dirty mid-frame
+        state.IsRenderingDirty = true;
+        // Render remaining
+        int totalScanlines = state.CrtControllerRegisters.VerticalTotalValue + 2;
+        for (int i = 2; i < totalScanlines + 5; i++) {
+            renderer.RenderScanline();
+        }
+        renderer.CompleteFrame();
+
+        uint[] frame = new uint[renderer.Width * renderer.Height];
+        renderer.Render(frame);
+
+        // Line 0 should still show value 50 (copied from last published frame)
+        frame[0].Should().Be(state.DacRegisters.PaletteMap[50],
+            "skipped lines should be restored from last published frame");
+    }
+
+    // -------------------------------------------------- Memory Width Modes --------------------------------------------------
+
+    [SkippableFact]
+    public void MemoryWidth_Byte_DirectAddressing() {
+        EnsureSupported();
+        VideoState state = ConfigureGraphicsEga(1);
+        (Renderer renderer, VideoMemory vram) = CreateRenderer(state);
+        SetIdentityAttributeMap(state);
+
+        // Byte mode is the default for the EGA config helper
+        state.CrtControllerRegisters.UnderlineRowScanlineRegister.DoubleWordMode = false;
+        state.CrtControllerRegisters.CrtModeControlRegister.ByteWordMode = ByteWordMode.Byte;
+
+        // Address 5 should be read directly
+        vram.Planes[0, 5] = 0x80;
+
+        state.CrtControllerRegisters.ScreenStartAddress = 5;
+        state.IsRenderingDirty = true;
+        uint[] frame = RenderAndCapture(renderer, state);
+
+        frame[0].Should().Be(state.DacRegisters.AttributeMap[1], "byte mode reads address directly");
+    }
+
+    [SkippableFact]
+    public void MemoryWidth_DoubleWord_ShiftsAddressLeft2() {
+        EnsureSupported();
+        VideoState state = ConfigureGraphicsEga(1);
+        (Renderer renderer, VideoMemory vram) = CreateRenderer(state);
+        SetIdentityAttributeMap(state);
+
+        state.CrtControllerRegisters.UnderlineRowScanlineRegister.DoubleWordMode = true;
+
+        // In DWord mode: physical = (counter << 2) | ((counter >> 14) & 3)
+        // counter=0 â†’ physical=0
+        vram.Planes[0, 0] = 0x80;
+
+        state.IsRenderingDirty = true;
+        uint[] frame = RenderAndCapture(renderer, state);
+
+        frame[0].Should().Be(state.DacRegisters.AttributeMap[1]);
+    }
+
+    [SkippableFact]
+    public void MemoryWidth_Word13_ShiftsAndUseBit13() {
+        EnsureSupported();
+        VideoState state = ConfigureGraphicsEga(1);
+        (Renderer renderer, VideoMemory vram) = CreateRenderer(state);
+        SetIdentityAttributeMap(state);
+
+        state.CrtControllerRegisters.UnderlineRowScanlineRegister.DoubleWordMode = false;
+        state.CrtControllerRegisters.CrtModeControlRegister.ByteWordMode = ByteWordMode.Word;
+        state.CrtControllerRegisters.CrtModeControlRegister.AddressWrap = false;
+
+        // Word13 mode: physical = (counter << 1) | ((counter >> 13) & 1)
+        // counter=0 â†’ physical=0
+        vram.Planes[0, 0] = 0x80;
+
+        state.IsRenderingDirty = true;
+        uint[] frame = RenderAndCapture(renderer, state);
+
+        frame[0].Should().Be(state.DacRegisters.AttributeMap[1]);
+    }
+
+    [SkippableFact]
+    public void MemoryWidth_Word15_ShiftsAndUseBit15() {
+        EnsureSupported();
+        VideoState state = ConfigureGraphicsEga(1);
+        (Renderer renderer, VideoMemory vram) = CreateRenderer(state);
+        SetIdentityAttributeMap(state);
+
+        state.CrtControllerRegisters.UnderlineRowScanlineRegister.DoubleWordMode = false;
+        state.CrtControllerRegisters.CrtModeControlRegister.ByteWordMode = ByteWordMode.Word;
+        state.CrtControllerRegisters.CrtModeControlRegister.AddressWrap = true;
+
+        // Word15 mode: physical = (counter << 1) | ((counter >> 15) & 1)
+        // counter=0 â†’ physical=0
+        vram.Planes[0, 0] = 0x80;
+
+        state.IsRenderingDirty = true;
+        uint[] frame = RenderAndCapture(renderer, state);
+
+        frame[0].Should().Be(state.DacRegisters.AttributeMap[1]);
+    }
+
+    // -------------------------------------------------- Character Clock Mask --------------------------------------------------
+
+    [SkippableFact]
+    public void CharacterClockMask_CountByFour_IncrementsEvery4thChar() {
+        EnsureSupported();
+        VideoState state = ConfigureGraphicsEga(1);
+        (Renderer renderer, VideoMemory vram) = CreateRenderer(state);
+        SetIdentityAttributeMap(state);
+
+        state.CrtControllerRegisters.UnderlineRowScanlineRegister.CountByFour = true;
+        state.CrtControllerRegisters.CrtModeControlRegister.CountByTwo = false;
+
+        // With mask=3, address increments when (charCounter & 3) == 0, AFTER rendering.
+        // char 0 reads addr 0 then increments â†’ addr becomes 1
+        // chars 1-3 read addr 1 (no increment since (charCounter & 3) != 0)
+        // char 4 reads addr 1 then increments â†’ addr becomes 2
+        vram.Planes[0, 0] = 0x80; // bit 7 set at address 0
+        vram.Planes[0, 1] = 0x40; // bit 6 set at address 1
+
+        state.IsRenderingDirty = true;
+        uint[] frame = RenderAndCapture(renderer, state);
+
+        // Char 0 reads address 0 â†’ plane0=0x80, bit 7 = 1 â†’ index 1
+        frame[0].Should().Be(state.DacRegisters.AttributeMap[1], "char 0 reads address 0");
+        // Char 1 reads address 1 (after char 0 incremented) â†’ plane0=0x40, bit 7 = 0
+        frame[8].Should().Be(state.DacRegisters.AttributeMap[0], "char 1 reads address 1, bit 7 = 0");
+        // Char 1, pixel 1 = bit 6 of addr 1 = 1 â†’ index 1
+        frame[9].Should().Be(state.DacRegisters.AttributeMap[1], "char 1 reads address 1, bit 6 = 1");
+
+        // Char 4 still reads address 1 (chars 1-3 did not increment)
+        frame[32].Should().Be(state.DacRegisters.AttributeMap[0], "char 4 reads address 1, bit 7 = 0");
+        frame[33].Should().Be(state.DacRegisters.AttributeMap[1], "char 4 reads address 1, bit 6 = 1");
+    }
+
+    [SkippableFact]
+    public void CharacterClockMask_CountByTwo_IncrementsEveryOtherChar() {
+        EnsureSupported();
+        VideoState state = ConfigureGraphicsEga(1);
+        (Renderer renderer, VideoMemory vram) = CreateRenderer(state);
+        SetIdentityAttributeMap(state);
+
+        state.CrtControllerRegisters.UnderlineRowScanlineRegister.CountByFour = false;
+        state.CrtControllerRegisters.CrtModeControlRegister.CountByTwo = true;
+
+        // With mask=1, address increments when (charCounter & 1) == 0, AFTER rendering.
+        // char 0 reads addr 0, then increments â†’ addr becomes 1
+        // char 1 reads addr 1 (no increment since (1 & 1) != 0)
+        // char 2 reads addr 1, then increments â†’ addr becomes 2
+        vram.Planes[0, 0] = 0x80; // bit 7 set at address 0
+        vram.Planes[0, 1] = 0x00; // nothing at address 1
+
+        state.IsRenderingDirty = true;
+        uint[] frame = RenderAndCapture(renderer, state);
+
+        frame[0].Should().Be(state.DacRegisters.AttributeMap[1], "char 0 reads address 0");
+        // Char 1 reads address 1 (after char 0 incremented) â†’ all zeros â†’ index 0
+        frame[8].Should().Be(state.DacRegisters.AttributeMap[0], "char 1 reads address 1");
+        // Char 2 also reads address 1 (char 1 didn't increment)
+        frame[16].Should().Be(state.DacRegisters.AttributeMap[0], "char 2 reads address 1");
+    }
+
+    // -------------------------------------------------- Scanline Bit 0 for Address --------------------------------------------------
+
+    [SkippableFact]
+    public void ScanlineBit0ForAddressBit13_SubstitutesOnOddScanlines() {
+        EnsureSupported();
+        // 2 lines tall with MaximumScanline=1 â†’ char row has scanlines 0 and 1
+        VideoState state = ConfigureGraphicsEga(2);
+        (Renderer renderer, VideoMemory vram) = CreateRenderer(state);
+        SetIdentityAttributeMap(state);
+
+        state.CrtControllerRegisters.MaximumScanlineRegister.MaximumScanline = 1;
+        state.CrtControllerRegisters.CrtModeControlRegister.CompatibilityModeSupport = false;
+
+        // On scanline 0: bit13 cleared â†’ address stays low
+        // On scanline 1: bit13 set â†’ address gets 0x2000 OR'd in
+        vram.Planes[0, 0] = 0x80; // index=1 at address 0
+        vram.Planes[0, 0x2000] = 0x40; // index=1 at bit 6, address 0x2000
+
+        state.IsRenderingDirty = true;
+        uint[] frame = RenderAndCapture(renderer, state);
+
+        int width = renderer.Width;
+        frame[0].Should().Be(state.DacRegisters.AttributeMap[1], "scanline 0 reads address 0");
+        // Line 1 (scanline 1 of char row) reads from 0x2000
+        frame[width].Should().Be(state.DacRegisters.AttributeMap[0], "scanline 1 bit 7 of addr 0x2000 (=0x40) is 0");
+        frame[width + 1].Should().Be(state.DacRegisters.AttributeMap[1], "scanline 1 bit 6 of addr 0x2000 (=0x40) is 1");
+    }
+
+    [SkippableFact]
+    public void ScanlineBit0ForAddressBit14_SubstitutesOnOddScanlines() {
+        EnsureSupported();
+        VideoState state = ConfigureGraphicsEga(2);
+        (Renderer renderer, VideoMemory vram) = CreateRenderer(state);
+        SetIdentityAttributeMap(state);
+
+        state.CrtControllerRegisters.MaximumScanlineRegister.MaximumScanline = 1;
+        state.CrtControllerRegisters.CrtModeControlRegister.SelectRowScanCounter = false;
+
+        vram.Planes[0, 0] = 0x80;
+        vram.Planes[0, 0x4000] = 0x80; // bit 7 set at address 0x4000
+
+        state.IsRenderingDirty = true;
+        uint[] frame = RenderAndCapture(renderer, state);
+
+        int width = renderer.Width;
+        frame[0].Should().Be(state.DacRegisters.AttributeMap[1], "scanline 0 reads address 0");
+        frame[width].Should().Be(state.DacRegisters.AttributeMap[1], "scanline 1 reads from 0x4000 with bit14 set");
+    }
+
+    // -------------------------------------------------- Line Compare (Split Screen) --------------------------------------------------
+
+    [SkippableFact]
+    public void LineCompare_ResetsMemoryAddressAtCompareValue() {
+        EnsureSupported();
+        VideoState state = ConfigureGraphicsEga(4);
+        (Renderer renderer, VideoMemory vram) = CreateRenderer(state);
+        SetIdentityAttributeMap(state);
+
+        int offset = state.CrtControllerRegisters.Offset;
+        // Set line compare to line 2
+        state.CrtControllerRegisters.LineCompare = 2;
+
+        // Line 0 at address 0
+        vram.Planes[0, 0] = 0x80; // index 1
+
+        // Line 2 normally reads from address 2*offset*2 = 2*40*2=160
+        // But line compare resets address to 0 at line 2
+        // So after reset, line 3 reads from address 0 + offset*2 = 80
+        vram.Planes[0, offset * 2] = 0x40; // index 1 at bit 6, at address offset*2
+
+        state.IsRenderingDirty = true;
+        uint[] frame = RenderAndCapture(renderer, state);
+
+        int width = renderer.Width;
+        // Line 0: reads from address 0, bit 7 = 1 â†’ index 1
+        frame[0].Should().Be(state.DacRegisters.AttributeMap[1], "line 0");
+
+        // Line 3 should read from address offset*2 (after line compare reset at line 2)
+        // Line 2 reset address to 0, line 3 = 0 + offset*2
+        frame[3 * width + 1].Should().Be(state.DacRegisters.AttributeMap[1],
+            "line 3 reads from address offset*2 after line compare reset, bit 6 set");
+    }
+
+    // -------------------------------------------------- Color Plane Enable --------------------------------------------------
+
+    [SkippableFact]
+    public void ColorPlaneEnable_DisabledPlaneOutputsZero() {
+        EnsureSupported();
+        VideoState state = ConfigureGraphicsEga(1);
+        (Renderer renderer, VideoMemory vram) = CreateRenderer(state);
+        SetIdentityAttributeMap(state);
+
+        // Disable plane 0
+        state.AttributeControllerRegisters.ColorPlaneEnableRegister.Value = 0b1110;
+
+        vram.Planes[0, 0] = 0xFF; // all bits set, but plane is disabled
+        vram.Planes[1, 0] = 0x80; // bit 7 set
+
+        state.IsRenderingDirty = true;
+        uint[] frame = RenderAndCapture(renderer, state);
+
+        // Without plane 0, index = (0 << 3 | 0 << 2 | 1 << 1 | 0) = 2
+        frame[0].Should().Be(state.DacRegisters.AttributeMap[2], "plane 0 disabled â†’ contributes 0");
+    }
+
+    [SkippableFact]
+    public void ColorPlaneEnable_AllDisabled_AllZero() {
+        EnsureSupported();
+        VideoState state = ConfigureGraphicsEga(1);
+        (Renderer renderer, VideoMemory vram) = CreateRenderer(state);
+        SetIdentityAttributeMap(state);
+
+        state.AttributeControllerRegisters.ColorPlaneEnableRegister.Value = 0b0000;
+
+        vram.Planes[0, 0] = 0xFF;
+        vram.Planes[1, 0] = 0xFF;
+        vram.Planes[2, 0] = 0xFF;
+        vram.Planes[3, 0] = 0xFF;
+
+        state.IsRenderingDirty = true;
+        uint[] frame = RenderAndCapture(renderer, state);
+
+        frame[0].Should().Be(state.DacRegisters.AttributeMap[0], "all planes disabled â†’ index 0");
+    }
+
+    // -------------------------------------------------- Screen Start Address --------------------------------------------------
+
+    [SkippableFact]
+    public void ScreenStartAddress_OffsetsRendering() {
+        EnsureSupported();
+        VideoState state = ConfigureGraphicsEga(1);
+        (Renderer renderer, VideoMemory vram) = CreateRenderer(state);
+        SetIdentityAttributeMap(state);
+
+        // Move screen start to address 10
+        state.CrtControllerRegisters.ScreenStartAddress = 10;
+        vram.Planes[0, 10] = 0x80; // bit 7 set at address 10
+
+        state.IsRenderingDirty = true;
+        uint[] frame = RenderAndCapture(renderer, state);
+
+        frame[0].Should().Be(state.DacRegisters.AttributeMap[1], "rendering starts from ScreenStartAddress");
+    }
+
+    // -------------------------------------------------- Vertical Timing Halved --------------------------------------------------
+
+    [SkippableFact]
+    public void VerticalTimingHalved_BothCharsRowScanlinesShareSameAddress() {
+        EnsureSupported();
+        // With MaximumScanline=1, each character row has 2 scanlines (0 and 1).
+        // With VerticalTimingHalved, the line counter only increments on odd
+        // charRowScanline values. With CompatibilityModeSupport=true and
+        // SelectRowScanCounter=true (set in ConfigureBase), no scanline-based
+        // address modification occurs, so both scanlines read from the same address.
+        VideoState state = ConfigureGraphicsEga(2);
+        state.CrtControllerRegisters.MaximumScanlineRegister.MaximumScanline = 1;
+        state.CrtControllerRegisters.CrtModeControlRegister.VerticalTimingHalved = true;
+
+        (Renderer renderer, VideoMemory vram) = CreateRenderer(state);
+        SetIdentityAttributeMap(state);
+
+        vram.Planes[0, 0] = 0x80; // bit 7 at address 0
+
+        state.IsRenderingDirty = true;
+        uint[] frame = RenderAndCapture(renderer, state);
+
+        int width = renderer.Width;
+        // Both output lines come from the same character row address
+        frame[0].Should().Be(state.DacRegisters.AttributeMap[1], "scanline 0 of char row");
+        frame[width].Should().Be(state.DacRegisters.AttributeMap[1], "scanline 1 of char row, same address");
+    }
+
+    // -------------------------------------------------- CrtcScanDouble --------------------------------------------------
+
+    [SkippableFact]
+    public void CrtcScanDouble_DoublesEachScanline() {
+        EnsureSupported();
+        VideoState state = ConfigureGraphicsEga(1);
+        (Renderer renderer, _) = CreateRenderer(state);
+
+        // With scan double, each scanline is displayed twice
+        // This halves the effective height
+        state.CrtControllerRegisters.VerticalDisplayEnd = 3;
+        state.CrtControllerRegisters.MaximumScanlineRegister.CrtcScanDouble = true;
+
+        renderer.Height.Should().Be(2, "scan double should halve the height");
+    }
+
+    // -------------------------------------------------- DotsPerClock in Text Mode --------------------------------------------------
+
+    [SkippableFact]
+    public void TextMode_9DotsPerClock_Outputs9Pixels() {
+        EnsureSupported();
+        VideoState state = ConfigureTextMode(1);
+        (Renderer renderer, VideoMemory vram) = CreateRenderer(state);
+        SetIdentityAttributeMap(state);
+
+        // Set 9-dot mode
+        state.SequencerRegisters.ClockingModeRegister.DotsPerClock = 9;
+
+        byte charCode = 0;
+        byte attribute = 0x07;
+        vram.Planes[0, 0] = charCode;
+        vram.Planes[1, 0] = attribute;
+        vram.Planes[2, 0] = 0xFF;
+
+        state.IsRenderingDirty = true;
+        uint[] frame = RenderAndCapture(renderer, state);
+
+        // First 8 pixels should be foreground (font bits), 9th too (mask 0x80>>8 = 0 â†’ background)
+        // Actually, the mask goes mask >>= 1 for DotsPerClock iterations
+        // mask starts at 0x80: pixels 0-6 use bits 7-1, pixel 7 uses bit 0
+        // With DotsPerClock=9, there are 9 iterations but mask reaches 0 at iteration 8
+        // So pixel 8 (9th dot) has mask=0 â†’ always background color
+        for (int i = 0; i < 8; i++) {
+            frame[i].Should().Be(state.DacRegisters.AttributeMap[7], $"pixel {i} = foreground");
+        }
+        // 9th pixel should be background (mask became 0)
+        frame[8].Should().Be(state.DacRegisters.AttributeMap[0], "9th pixel = background (no font bit)");
+    }
+
+    // -------------------------------------------------- Extended Memory (Font Select) --------------------------------------------------
+
+    [SkippableFact]
+    public void TextMode_ExtendedMemory_UsesCharacterMapA() {
+        EnsureSupported();
+        VideoState state = ConfigureTextMode(1);
+        (Renderer renderer, VideoMemory vram) = CreateRenderer(state);
+        SetIdentityAttributeMap(state);
+
+        state.SequencerRegisters.MemoryModeRegister.ExtendedMemory = true;
+        // When bit 3 of attribute is set, use CharacterMapA
+        int charMapAOffset = state.SequencerRegisters.CharacterMapSelectRegister.CharacterMapA;
+
+        byte charCode = 1;
+        byte attribute = 0x0F; // bit 3 set â†’ use CharacterMapA, fg = 0x7 (bits 0-2)
+
+        vram.Planes[0, 0] = charCode;
+        vram.Planes[1, 0] = attribute;
+        // Font data at charMapA + 32*charCode + scanline
+        vram.Planes[2, charMapAOffset + 32 * charCode] = 0x80;
+
+        state.IsRenderingDirty = true;
+        uint[] frame = RenderAndCapture(renderer, state);
+
+        // With extended memory, fg index = attribute & 0x7 = 7
+        frame[0].Should().Be(state.DacRegisters.AttributeMap[7], "first pixel = foreground from charMapA font");
+    }
+
+    // -------------------------------------------------- Zero Buffer Size Guard --------------------------------------------------
+
+    [SkippableFact]
+    public void BeginFrame_ZeroSize_DeactivatesFrame() {
+        EnsureSupported();
+        VideoState state = ConfigureBase(ClockSelect.Use25175Khz, halfDot: true);
+        // VerticalDisplayEnd = 0 with ScanDouble = true â†’ Height = (0+1)/2 = 0
+        state.CrtControllerRegisters.VerticalDisplayEnd = 0;
+        state.CrtControllerRegisters.MaximumScanlineRegister.CrtcScanDouble = true;
+
+        (Renderer renderer, _) = CreateRenderer(state);
+
+        state.IsRenderingDirty = true;
+        renderer.BeginFrame();
+
+        // Width=320, Height=0, BufferSize=0
+        renderer.BufferSize.Should().Be(0);
+
+        // Scanlines should be no-ops
+        renderer.RenderScanline();
+        renderer.CompleteFrame();
+
+        uint[] output = new uint[1];
+        Array.Fill(output, 0xDEADBEEF);
+        renderer.Render(output);
+        output[0].Should().Be(0xDEADBEEF, "no frame should be published for zero-size buffer");
+    }
+
+    // -------------------------------------------------- Multiple Consecutive Frames --------------------------------------------------
+
+    [SkippableFact]
+    public void MultipleFrames_OnlyLastPendingIsDelivered() {
+        EnsureSupported();
+        VideoState state = ConfigureGraphics256Color(1);
+        (Renderer renderer, VideoMemory vram) = CreateRenderer(state);
+        SetIdentityPaletteMap(state);
+
+        // Frame 1
+        vram.Planes[0, 0] = 10;
+        state.IsRenderingDirty = true;
+        RenderFullFrame(renderer, state);
+
+        // Frame 2 (without calling Render in between)
+        vram.Planes[0, 0] = 20;
+        state.IsRenderingDirty = true;
+        RenderFullFrame(renderer, state);
+
+        uint[] frame = new uint[renderer.Width * renderer.Height];
+        renderer.Render(frame);
+
+        // Should get the most recent frame's data
+        frame[0].Should().Be(state.DacRegisters.PaletteMap[20]);
+    }
+
+    // -------------------------------------------------- Byte Panning --------------------------------------------------
+
+    [SkippableFact]
+    public void BytePanning_OffsetsStartAddress() {
+        EnsureSupported();
+        VideoState state = ConfigureGraphicsEga(1);
+        (Renderer renderer, VideoMemory vram) = CreateRenderer(state);
+        SetIdentityAttributeMap(state);
+
+        state.CrtControllerRegisters.PresetRowScanRegister.BytePanning = 3;
+        state.CrtControllerRegisters.ScreenStartAddress = 0;
+
+        // With byte panning = 3, start address becomes 0 + 3 = 3
+        vram.Planes[0, 3] = 0x80;
+
+        state.IsRenderingDirty = true;
+        uint[] frame = RenderAndCapture(renderer, state);
+
+        frame[0].Should().Be(state.DacRegisters.AttributeMap[1], "byte panning offsets start address");
+    }
+
+    // -------------------------------------------------- Display Enable Skew --------------------------------------------------
+
+    [SkippableFact]
+    public void DisplayEnableSkew_DelaysVisibleStart() {
+        EnsureSupported();
+        VideoState state = ConfigureGraphicsEga(1);
+        (Renderer renderer, VideoMemory vram) = CreateRenderer(state);
+        SetIdentityAttributeMap(state);
+
+        state.CrtControllerRegisters.HorizontalBlankingEndRegister.DisplayEnableSkew = 1;
+        // Need to adjust HorizontalDisplayEnd to account for skew
+        // _frameHorizontalDisplayEnd = HorizontalDisplayEnd + 1 + skew
+        // With skew=1, blanking ends at character 1 instead of 0
+
+        vram.Planes[0, 0] = 0x80; // data at address 0
+
+        state.IsRenderingDirty = true;
+        RenderAndCapture(renderer, state);
+
+        // With skew=1, the first visible character starts at characterCounter=1
+        // But memoryAddressCounter starts at 0 and increments at char 0 (since mask=0)
+        // So char 1 reads from address 1
+        // We put data at address 0, so char 0 is blanked and char 1 reads address 1
+        // The test verifies that skew delays the visible area
+        // First visible pixel (pixel 0 in output) comes from char 1, address 1
+        vram.Planes[0, 1] = 0x80;
+        state.IsRenderingDirty = true;
+        uint[] frame = RenderAndCapture(renderer, state);
+
+        frame[0].Should().Be(state.DacRegisters.AttributeMap[1], "skew=1 means first visible char reads address 1");
+    }
+
+    // -------------------------------------------------- Helper Methods --------------------------------------------------
+
+    /// <summary>
+    ///     Creates a Renderer and captures the internal VideoMemory instance.
+    /// </summary>
+    protected (Renderer renderer, VideoMemory videoMemory) CreateRenderer(VideoState state) {
+        return CreateRenderer(state, new VgaBlinkState());
+    }
+
+    protected (Renderer renderer, VideoMemory videoMemory) CreateRenderer(VideoState state, VgaBlinkState blinkState) {
+        IMemory mockMemory = Substitute.For<IMemory>();
+        VideoMemory? captured = null;
+        mockMemory.When(m => m.RegisterMapping(Arg.Any<uint>(), Arg.Any<uint>(), Arg.Any<IMemoryDevice>()))
+            .Do(callInfo => captured = (VideoMemory)callInfo.ArgAt<IMemoryDevice>(2));
+
+        LoggerService loggerService = new();
+        IVgaRenderer256Color renderer256Color = Create256ColorRenderer();
+        Renderer renderer = new(mockMemory, state, blinkState, loggerService, renderer256Color);
+
+        if (captured is null) {
+            throw new InvalidOperationException("VideoMemory was not captured from RegisterMapping call.");
+        }
+
+        return (renderer, captured);
+    }
+
+    /// <summary>
+    ///     Writes a byte to VRAM through the VideoMemory.Write method, which also sets HasChanged.
+    /// </summary>
+    private static void WriteVramByte(VideoMemory vram, VideoState state, uint address, byte value) {
+        // Configure write mode 0 with no set/reset for a direct write
+        state.SequencerRegisters.PlaneMaskRegister.Value = 0b0001; // write to plane 0 only
+        state.SequencerRegisters.MemoryModeRegister.OddEvenMode = false;
+        state.GraphicsControllerRegisters.GraphicsModeRegister.WriteMode = WriteMode.WriteMode0;
+        state.GraphicsControllerRegisters.EnableSetReset.Value = 0;
+        state.GraphicsControllerRegisters.BitMask = 0xFF;
+        state.GraphicsControllerRegisters.DataRotateRegister.FunctionSelect = FunctionSelect.None;
+        state.GraphicsControllerRegisters.DataRotateRegister.RotateCount = 0;
+
+        uint baseAddress = state.GraphicsControllerRegisters.MiscellaneousGraphicsRegister.BaseAddress;
+        vram.Write(baseAddress + address, value);
+    }
+
+    /// <summary>
+    ///     Runs a full frame cycle: BeginFrame, enough RenderScanline calls, CompleteFrame.
+    /// </summary>
+    private static void RenderFullFrame(Renderer renderer, VideoState state) {
+        renderer.BeginFrame();
+        int totalLines = state.CrtControllerRegisters.VerticalTotalValue + 10;
+        for (int i = 0; i < totalLines; i++) {
+            renderer.RenderScanline();
+        }
+        renderer.CompleteFrame();
+    }
+
+    /// <summary>
+    ///     Renders a full frame and captures the output.
+    /// </summary>
+    private static uint[] RenderAndCapture(Renderer renderer, VideoState state) {
+        RenderFullFrame(renderer, state);
+        uint[] output = new uint[renderer.Width * renderer.Height];
+        renderer.Render(output);
+        return output;
+    }
+
+    /// <summary>
+    ///     Base register configuration: clock, dot clock, and minimal CRT settings.
+    /// </summary>
+    private static VideoState ConfigureBase(ClockSelect clock, bool halfDot) {
+        VideoState state = new();
+        state.GeneralRegisters.MiscellaneousOutput.ClockSelect = clock;
+        state.SequencerRegisters.ClockingModeRegister.HalfDotClock = halfDot;
+        state.SequencerRegisters.ClockingModeRegister.DotsPerClock = 8;
+        state.AttributeControllerRegisters.ColorPlaneEnableRegister.Value = 0x0F;
+        state.CrtControllerRegisters.VerticalDisplayEnd = 0;
+        state.CrtControllerRegisters.VerticalTotal = 0;
+        state.CrtControllerRegisters.MaximumScanlineRegister.MaximumScanline = 0;
+        state.CrtControllerRegisters.MaximumScanlineRegister.CrtcScanDouble = false;
+        state.CrtControllerRegisters.HorizontalTotal = 99;
+        state.CrtControllerRegisters.HorizontalDisplayEnd = 79;
+        state.CrtControllerRegisters.Offset = 40;
+        state.CrtControllerRegisters.CrtModeControlRegister.ByteWordMode = ByteWordMode.Byte;
+        state.CrtControllerRegisters.CrtModeControlRegister.CompatibilityModeSupport = true;
+        state.CrtControllerRegisters.CrtModeControlRegister.SelectRowScanCounter = true;
+        return state;
+    }
+
+    /// <summary>
+    ///     Configure for 256-color mode (Mode 13h style), given number of visible lines.
+    /// </summary>
+    private static VideoState ConfigureGraphics256Color(int lines) {
+        VideoState state = ConfigureBase(ClockSelect.Use25175Khz, halfDot: true);
+        state.CrtControllerRegisters.VerticalDisplayEnd = (byte)(lines - 1);
+        state.CrtControllerRegisters.VerticalTotal = (byte)(lines - 1);
+        state.CrtControllerRegisters.HorizontalDisplayEnd = 39;
+        state.CrtControllerRegisters.HorizontalTotal = 49;
+        state.CrtControllerRegisters.Offset = 40;
+        state.GraphicsControllerRegisters.GraphicsModeRegister.In256ColorMode = true;
+        state.GraphicsControllerRegisters.MiscellaneousGraphicsRegister.GraphicsMode = true;
+        return state;
+    }
+
+    /// <summary>
+    ///     Configure for EGA graphics mode, given number of visible lines.
+    /// </summary>
+    private static VideoState ConfigureGraphicsEga(int lines) {
+        VideoState state = ConfigureBase(ClockSelect.Use25175Khz, halfDot: false);
+        state.CrtControllerRegisters.VerticalDisplayEnd = (byte)(lines - 1);
+        state.CrtControllerRegisters.VerticalTotal = (byte)(lines - 1);
+        state.GraphicsControllerRegisters.MiscellaneousGraphicsRegister.GraphicsMode = true;
+        state.GraphicsControllerRegisters.GraphicsModeRegister.In256ColorMode = false;
+        state.GraphicsControllerRegisters.GraphicsModeRegister.ShiftRegisterMode = ShiftRegisterMode.Ega;
+        return state;
+    }
+
+    /// <summary>
+    ///     Configure for CGA graphics mode, given number of visible lines.
+    /// </summary>
+    private static VideoState ConfigureGraphicsCga(int lines) {
+        VideoState state = ConfigureBase(ClockSelect.Use25175Khz, halfDot: false);
+        state.CrtControllerRegisters.VerticalDisplayEnd = (byte)(lines - 1);
+        state.CrtControllerRegisters.VerticalTotal = (byte)(lines - 1);
+        state.GraphicsControllerRegisters.MiscellaneousGraphicsRegister.GraphicsMode = true;
+        state.GraphicsControllerRegisters.GraphicsModeRegister.In256ColorMode = false;
+        state.GraphicsControllerRegisters.GraphicsModeRegister.ShiftRegisterMode = ShiftRegisterMode.Cga;
+        return state;
+    }
+
+    /// <summary>
+    ///     Configure for text mode (80Ã—lines), given number of visible lines.
+    /// </summary>
+    private static VideoState ConfigureTextMode(int lines) {
+        VideoState state = ConfigureBase(ClockSelect.Use25175Khz, halfDot: false);
+        state.CrtControllerRegisters.VerticalDisplayEnd = (byte)(lines - 1);
+        state.CrtControllerRegisters.VerticalTotal = (byte)(lines - 1);
+        state.CrtControllerRegisters.HorizontalDisplayEnd = 79;
+        state.CrtControllerRegisters.HorizontalTotal = 99;
+        state.CrtControllerRegisters.Offset = 80;
+        state.GraphicsControllerRegisters.MiscellaneousGraphicsRegister.GraphicsMode = false;
+        state.GraphicsControllerRegisters.GraphicsModeRegister.In256ColorMode = false;
+        state.SequencerRegisters.MemoryModeRegister.ExtendedMemory = false;
+        return state;
+    }
+
+    /// <summary>
+    ///     Sets PaletteMap so that index N maps to a unique distinguishable color.
+    /// </summary>
+    private static void SetIdentityPaletteMap(VideoState state) {
+        for (int i = 0; i < 256; i++) {
+            state.DacRegisters.PaletteMap[i] = 0xFF000000u | ((uint)i << 16) | ((uint)i << 8) | (uint)i;
+        }
+    }
+
+    /// <summary>
+    ///     Sets AttributeMap so that index N maps to a unique distinguishable color.
+    /// </summary>
+    private static void SetIdentityAttributeMap(VideoState state) {
+        for (int i = 0; i < 16; i++) {
+            state.DacRegisters.AttributeMap[i] = 0xFF000000u | ((uint)i << 20) | ((uint)i << 12) | ((uint)i << 4);
+        }
+    }
+}
+

--- a/tests/Spice86.Tests/Video/VRamLayoutTests.cs
+++ b/tests/Spice86.Tests/Video/VRamLayoutTests.cs
@@ -1,0 +1,159 @@
+namespace Spice86.Tests.Video;
+
+using FluentAssertions;
+
+using NSubstitute;
+
+using Spice86.Core.Emulator.Devices.Video;
+using Spice86.Core.Emulator.Devices.Video.Registers.Graphics;
+using Spice86.Shared.Interfaces;
+
+using Xunit;
+
+/// <summary>
+///     Tests for the <see cref="PlaneAccessor"/> and <see cref="VideoMemory"/> flat interleaved VRam layout.
+/// </summary>
+public class VRamLayoutTests {
+    [Fact]
+    public void PlaneAccessor_WriteThenRead_RoundTrips() {
+        byte[] vram = new byte[4 * 64 * 1024];
+        PlaneAccessor planes = new PlaneAccessor(vram);
+
+        planes[0, 0] = 0xAA;
+        planes[1, 0] = 0xBB;
+        planes[2, 0] = 0xCC;
+        planes[3, 0] = 0xDD;
+
+        planes[0, 0].Should().Be(0xAA);
+        planes[1, 0].Should().Be(0xBB);
+        planes[2, 0].Should().Be(0xCC);
+        planes[3, 0].Should().Be(0xDD);
+    }
+
+    [Fact]
+    public void PlaneAccessor_MapsToInterleavedLayout() {
+        byte[] vram = new byte[4 * 64 * 1024];
+        PlaneAccessor planes = new PlaneAccessor(vram);
+
+        planes[2, 5] = 0x42;
+
+        // Interleaved layout: address * 4 + plane
+        vram[5 * 4 + 2].Should().Be(0x42);
+    }
+
+    [Fact]
+    public void PlaneAccessor_DifferentAddresses_AreIndependent() {
+        byte[] vram = new byte[4 * 64 * 1024];
+        PlaneAccessor planes = new PlaneAccessor(vram);
+
+        planes[0, 100] = 0x11;
+        planes[0, 200] = 0x22;
+
+        planes[0, 100].Should().Be(0x11);
+        planes[0, 200].Should().Be(0x22);
+    }
+
+    [Fact]
+    public void VRam_Mode13hChain4_PixelNAtIndexN() {
+        // In the interleaved layout, mode 13h chain-4 pixel N maps to VRam[N]:
+        // plane = N & 3, offset = N >> 2, index = (N >> 2) * 4 + (N & 3) = N
+        byte[] vram = new byte[4 * 64 * 1024];
+        PlaneAccessor planes = new PlaneAccessor(vram);
+
+        // Write pixels via plane accessor (as the CPU write path does)
+        planes[0, 0] = 10; // pixel 0: plane=0, offset=0 → index 0
+        planes[1, 0] = 20; // pixel 1: plane=1, offset=0 → index 1
+        planes[2, 0] = 30; // pixel 2: plane=2, offset=0 → index 2
+        planes[3, 0] = 40; // pixel 3: plane=3, offset=0 → index 3
+        planes[0, 1] = 50; // pixel 4: plane=0, offset=1 → index 4
+        planes[1, 1] = 60; // pixel 5: plane=1, offset=1 → index 5
+
+        vram[0].Should().Be(10, "pixel 0 at VRam[0]");
+        vram[1].Should().Be(20, "pixel 1 at VRam[1]");
+        vram[2].Should().Be(30, "pixel 2 at VRam[2]");
+        vram[3].Should().Be(40, "pixel 3 at VRam[3]");
+        vram[4].Should().Be(50, "pixel 4 at VRam[4]");
+        vram[5].Should().Be(60, "pixel 5 at VRam[5]");
+    }
+
+    [Fact]
+    public void VideoMemory_VRamAndPlanes_ShareSameStorage() {
+        VideoState state = new();
+        ILoggerService logger = Substitute.For<ILoggerService>();
+        VideoMemory mem = new VideoMemory(state, logger);
+
+        mem.Planes[1, 10] = 0x77;
+
+        mem.VRam[10 * 4 + 1].Should().Be(0x77, "Planes and VRam share the same underlying buffer");
+    }
+
+    [Fact]
+    public void VideoMemory_GetLinearSpan_ReturnsCorrectSlice() {
+        VideoState state = new();
+        ILoggerService logger = Substitute.For<ILoggerService>();
+        VideoMemory mem = new VideoMemory(state, logger);
+
+        mem.VRam[100] = 0xAA;
+        mem.VRam[101] = 0xBB;
+        mem.VRam[102] = 0xCC;
+
+        System.ReadOnlySpan<byte> span = mem.GetLinearSpan(100, 3);
+
+        span[0].Should().Be(0xAA);
+        span[1].Should().Be(0xBB);
+        span[2].Should().Be(0xCC);
+    }
+
+    [Fact]
+    public void VideoMemory_HasChanged_SetOnWrite() {
+        VideoState state = new();
+        ILoggerService logger = Substitute.For<ILoggerService>();
+        VideoMemory mem = new VideoMemory(state, logger);
+
+        mem.ResetChanged();
+        mem.HasChanged.Should().BeFalse();
+
+        // Write a different value via Planes (which writes to VRam)
+        mem.Planes[0, 0] = 0;
+        mem.ResetChanged();
+
+        // Direct VRam write doesn't go through WriteValue, so HasChanged is the WriteValue path.
+        // Use the Write method to test HasChanged properly
+        state.SequencerRegisters.PlaneMaskRegister.Value = 0b1111;
+        state.SequencerRegisters.MemoryModeRegister.OddEvenMode = false;
+        state.GraphicsControllerRegisters.GraphicsModeRegister.WriteMode = WriteMode.WriteMode0;
+        state.GraphicsControllerRegisters.EnableSetReset.Value = 0;
+        state.GraphicsControllerRegisters.BitMask = 0xFF;
+        state.GraphicsControllerRegisters.DataRotateRegister.FunctionSelect = FunctionSelect.None;
+        state.GraphicsControllerRegisters.DataRotateRegister.RotateCount = 0;
+
+        uint baseAddr = state.GraphicsControllerRegisters.MiscellaneousGraphicsRegister.BaseAddress;
+        mem.Write(baseAddr, 0x42);
+
+        mem.HasChanged.Should().BeTrue();
+    }
+
+    [Fact]
+    public void VideoMemory_LatchLoad_Uses32BitInterleavedRead() {
+        VideoState state = new();
+        ILoggerService logger = Substitute.For<ILoggerService>();
+        VideoMemory mem = new VideoMemory(state, logger);
+
+        // Set up chain4 mode for read
+        state.SequencerRegisters.MemoryModeRegister.Chain4Mode = true;
+        state.GraphicsControllerRegisters.GraphicsModeRegister.ReadMode = ReadMode.ReadMode0;
+
+        // Write known values to all 4 planes at offset 0
+        mem.Planes[0, 0] = 0x11;
+        mem.Planes[1, 0] = 0x22;
+        mem.Planes[2, 0] = 0x33;
+        mem.Planes[3, 0] = 0x44;
+
+        uint baseAddr = state.GraphicsControllerRegisters.MiscellaneousGraphicsRegister.BaseAddress;
+
+        // Reading should load all 4 latches from the interleaved buffer
+        byte result = mem.Read(baseAddr); // chain4: plane=0, offset=0
+
+        result.Should().Be(0x11, "Read returns plane 0 in ReadMode0 with Chain4");
+    }
+}

--- a/tests/Spice86.Tests/Video/VgaRenderer256ColorAvx2Tests.cs
+++ b/tests/Spice86.Tests/Video/VgaRenderer256ColorAvx2Tests.cs
@@ -1,0 +1,15 @@
+namespace Spice86.Tests.Video;
+
+using Spice86.Core.Emulator.Devices.Video;
+
+using System.Runtime.Intrinsics.X86;
+
+/// <summary>
+///     Runs the 256-color renderer test suite with the AVX2 implementation.
+///     Tests are skipped automatically on machines that do not support AVX2.
+/// </summary>
+public sealed class VgaRenderer256ColorAvx2Tests : VgaRenderer256ColorTestsBase {
+    protected override bool IsSupported => Avx2.IsSupported;
+
+    protected override IVgaRenderer256Color Create256ColorRenderer() => new VgaRenderer256ColorAvx2();
+}

--- a/tests/Spice86.Tests/Video/VgaRenderer256ColorSse41Tests.cs
+++ b/tests/Spice86.Tests/Video/VgaRenderer256ColorSse41Tests.cs
@@ -1,0 +1,15 @@
+namespace Spice86.Tests.Video;
+
+using Spice86.Core.Emulator.Devices.Video;
+
+using System.Runtime.Intrinsics.X86;
+
+/// <summary>
+///     Runs the 256-color renderer test suite with the SSE4.1 implementation.
+///     Tests are skipped automatically on machines that do not support SSE4.1.
+/// </summary>
+public sealed class VgaRenderer256ColorSse41Tests : VgaRenderer256ColorTestsBase {
+    protected override bool IsSupported => Sse41.IsSupported;
+
+    protected override IVgaRenderer256Color Create256ColorRenderer() => new VgaRenderer256ColorSse41();
+}

--- a/tests/Spice86.Tests/Video/VgaRenderer256ColorTests.cs
+++ b/tests/Spice86.Tests/Video/VgaRenderer256ColorTests.cs
@@ -1,0 +1,22 @@
+﻿namespace Spice86.Tests.Video;
+
+using FluentAssertions;
+
+using NSubstitute;
+
+using Spice86.Core.Emulator.Devices.Video;
+using Spice86.Core.Emulator.Memory;
+using Spice86.Logging;
+using Spice86.Shared.Interfaces;
+
+using Xunit;
+
+/// <summary>
+///     Runs the 256-color renderer test suite with the scalar (non-SIMD) implementation.
+///     Also hosts <see cref="VideoMemory"/> span tests that are renderer-independent.
+/// </summary>
+public sealed class VgaRenderer256ColorTests : VgaRenderer256ColorTestsBase {
+    protected override bool IsSupported => true;
+
+    protected override IVgaRenderer256Color Create256ColorRenderer() => new VgaRenderer256ColorScalar();
+}

--- a/tests/Spice86.Tests/Video/VgaRenderer256ColorTestsBase.cs
+++ b/tests/Spice86.Tests/Video/VgaRenderer256ColorTestsBase.cs
@@ -1,0 +1,485 @@
+namespace Spice86.Tests.Video;
+
+using FluentAssertions;
+
+using NSubstitute;
+
+using Spice86.Core.Emulator.Devices.Video;
+using Spice86.Core.Emulator.Devices.Video.Registers.CrtController;
+using Spice86.Core.Emulator.Memory;
+using Spice86.Logging;
+using Spice86.Shared.Interfaces;
+
+using Xunit;
+
+using ClockSelect = Spice86.Core.Emulator.Devices.Video.Registers.General.MiscellaneousOutput.ClockSelectValue;
+
+/// <summary>
+///     Base class for 256-color renderer tests, parameterized by renderer implementation.
+///     Concrete subclasses supply a specific <see cref="IVgaRenderer256Color"/> and report
+///     whether the required CPU instruction set is available.
+/// </summary>
+public abstract class VgaRenderer256ColorTestsBase {
+    /// <summary>
+    ///     Returns true when the renderer under test is runnable on the current machine.
+    /// </summary>
+    protected abstract bool IsSupported { get; }
+
+    /// <summary>
+    ///     Creates the renderer implementation under test.
+    /// </summary>
+    protected abstract IVgaRenderer256Color Create256ColorRenderer();
+
+    /// <summary>
+    ///     Skips the current test when the required instruction set is not supported.
+    /// </summary>
+    protected void EnsureSupported() =>
+        Skip.IfNot(IsSupported, "The required CPU instruction set is not supported on this machine.");
+
+    protected (Renderer renderer, VideoMemory videoMemory) CreateRenderer(VideoState state) {
+        IMemory mockMemory = Substitute.For<IMemory>();
+        VideoMemory? captured = null;
+        mockMemory.When(m => m.RegisterMapping(Arg.Any<uint>(), Arg.Any<uint>(), Arg.Any<IMemoryDevice>()))
+            .Do(callInfo => captured = (VideoMemory)callInfo.ArgAt<IMemoryDevice>(2));
+
+        LoggerService loggerService = new();
+        VgaBlinkState blinkState = new();
+        IVgaRenderer256Color renderer256Color = Create256ColorRenderer();
+        Renderer renderer = new(mockMemory, state, blinkState, loggerService, renderer256Color);
+
+        if (captured is null) {
+            throw new InvalidOperationException("VideoMemory was not captured from RegisterMapping call.");
+        }
+
+        return (renderer, captured);
+    }
+
+    // ─────────── Scalar doubled rendering ───────────
+
+    [SkippableFact]
+    public void Render256Color_ScalarDoubled_SinglePixel() {
+        EnsureSupported();
+        VideoState state = ConfigureGraphics256Color(1);
+        (Renderer renderer, VideoMemory vram) = CreateRenderer(state);
+        SetIdentityPaletteMap(state);
+
+        vram.Planes[0, 0] = 42;
+
+        state.IsRenderingDirty = true;
+        uint[] frame = RenderAndCapture(renderer, state);
+
+        // Each plane byte → 2 identical pixels
+        frame[0].Should().Be(state.DacRegisters.PaletteMap[42]);
+        frame[1].Should().Be(state.DacRegisters.PaletteMap[42]);
+    }
+
+    [SkippableFact]
+    public void Render256Color_AllFourPlanes_ProduceEightPixels() {
+        EnsureSupported();
+        VideoState state = ConfigureGraphics256Color(1);
+        (Renderer renderer, VideoMemory vram) = CreateRenderer(state);
+        SetIdentityPaletteMap(state);
+
+        vram.Planes[0, 0] = 10;
+        vram.Planes[1, 0] = 20;
+        vram.Planes[2, 0] = 30;
+        vram.Planes[3, 0] = 40;
+
+        state.IsRenderingDirty = true;
+        uint[] frame = RenderAndCapture(renderer, state);
+
+        frame[0].Should().Be(state.DacRegisters.PaletteMap[10]);
+        frame[1].Should().Be(state.DacRegisters.PaletteMap[10]);
+        frame[2].Should().Be(state.DacRegisters.PaletteMap[20]);
+        frame[3].Should().Be(state.DacRegisters.PaletteMap[20]);
+        frame[4].Should().Be(state.DacRegisters.PaletteMap[30]);
+        frame[5].Should().Be(state.DacRegisters.PaletteMap[30]);
+        frame[6].Should().Be(state.DacRegisters.PaletteMap[40]);
+        frame[7].Should().Be(state.DacRegisters.PaletteMap[40]);
+    }
+
+    [SkippableFact]
+    public void Render256Color_MultipleCharacters_Contiguous() {
+        EnsureSupported();
+        VideoState state = ConfigureGraphics256Color(1);
+        (Renderer renderer, VideoMemory vram) = CreateRenderer(state);
+        SetIdentityPaletteMap(state);
+
+        // Two character positions
+        vram.Planes[0, 0] = 1;
+        vram.Planes[1, 0] = 2;
+        vram.Planes[2, 0] = 3;
+        vram.Planes[3, 0] = 4;
+
+        vram.Planes[0, 1] = 5;
+        vram.Planes[1, 1] = 6;
+        vram.Planes[2, 1] = 7;
+        vram.Planes[3, 1] = 8;
+
+        state.IsRenderingDirty = true;
+        uint[] frame = RenderAndCapture(renderer, state);
+
+        // First character: 8 pixels
+        frame[0].Should().Be(state.DacRegisters.PaletteMap[1]);
+        frame[1].Should().Be(state.DacRegisters.PaletteMap[1]);
+        frame[6].Should().Be(state.DacRegisters.PaletteMap[4]);
+        frame[7].Should().Be(state.DacRegisters.PaletteMap[4]);
+
+        // Second character: starts at pixel 8
+        frame[8].Should().Be(state.DacRegisters.PaletteMap[5]);
+        frame[9].Should().Be(state.DacRegisters.PaletteMap[5]);
+        frame[14].Should().Be(state.DacRegisters.PaletteMap[8]);
+        frame[15].Should().Be(state.DacRegisters.PaletteMap[8]);
+    }
+
+    [SkippableFact]
+    public void Render256Color_FullScanline_AllPixelsCorrect() {
+        EnsureSupported();
+        VideoState state = ConfigureGraphics256Color(1);
+        (Renderer renderer, VideoMemory vram) = CreateRenderer(state);
+        SetIdentityPaletteMap(state);
+
+        // Fill all 40 characters (160 VRAM bytes) with sequential values
+        for (int charPos = 0; charPos < 40; charPos++) {
+            for (int plane = 0; plane < 4; plane++) {
+                vram.Planes[plane, charPos] = (byte)(charPos * 4 + plane);
+            }
+        }
+
+        state.IsRenderingDirty = true;
+        uint[] frame = RenderAndCapture(renderer, state);
+
+        // Verify all 320 pixels
+        for (int charPos = 0; charPos < 40; charPos++) {
+            for (int plane = 0; plane < 4; plane++) {
+                int pixelIndex = charPos * 8 + plane * 2;
+                byte expectedPaletteIndex = (byte)(charPos * 4 + plane);
+                uint expectedColor = state.DacRegisters.PaletteMap[expectedPaletteIndex];
+
+                frame[pixelIndex].Should().Be(expectedColor,
+                    $"pixel {pixelIndex} (char {charPos}, plane {plane}) should map to palette index {expectedPaletteIndex}");
+                frame[pixelIndex + 1].Should().Be(expectedColor,
+                    $"pixel {pixelIndex + 1} (doubled) should match");
+            }
+        }
+    }
+
+    [SkippableFact]
+    public void Render256Color_MultipleScanlines_RowAddressAdvances() {
+        EnsureSupported();
+        VideoState state = ConfigureGraphics256Color(3);
+        (Renderer renderer, VideoMemory vram) = CreateRenderer(state);
+        SetIdentityPaletteMap(state);
+
+        // Line 0 at address 0
+        vram.Planes[0, 0] = 10;
+        // Line 1: row address advances by Offset<<1 = 80
+        vram.Planes[0, 80] = 20;
+        // Line 2: address = 160
+        vram.Planes[0, 160] = 30;
+
+        state.IsRenderingDirty = true;
+        uint[] frame = RenderAndCapture(renderer, state);
+
+        int width = renderer.Width; // 320
+        frame[0].Should().Be(state.DacRegisters.PaletteMap[10], "line 0");
+        frame[width].Should().Be(state.DacRegisters.PaletteMap[20], "line 1");
+        frame[2 * width].Should().Be(state.DacRegisters.PaletteMap[30], "line 2");
+    }
+
+    [SkippableFact]
+    public void Render256Color_WithScreenStartAddress_OffsetsCorrectly() {
+        EnsureSupported();
+        VideoState state = ConfigureGraphics256Color(1);
+        (Renderer renderer, VideoMemory vram) = CreateRenderer(state);
+        SetIdentityPaletteMap(state);
+
+        state.CrtControllerRegisters.ScreenStartAddress = 5;
+        vram.Planes[0, 5] = 99;
+
+        state.IsRenderingDirty = true;
+        uint[] frame = RenderAndCapture(renderer, state);
+
+        frame[0].Should().Be(state.DacRegisters.PaletteMap[99], "should start from ScreenStartAddress");
+    }
+
+    [SkippableFact]
+    public void Render256Color_PaletteMapApplied() {
+        EnsureSupported();
+        VideoState state = ConfigureGraphics256Color(1);
+        (Renderer renderer, VideoMemory vram) = CreateRenderer(state);
+
+        uint specificColor = 0xFF_AA_BB_CC;
+        state.DacRegisters.PaletteMap[77] = specificColor;
+        vram.Planes[0, 0] = 77;
+
+        state.IsRenderingDirty = true;
+        uint[] frame = RenderAndCapture(renderer, state);
+
+        frame[0].Should().Be(specificColor);
+        frame[1].Should().Be(specificColor);
+    }
+
+    [SkippableFact]
+    public void Render256Color_ZeroValuePixels_UsesPaletteZero() {
+        EnsureSupported();
+        VideoState state = ConfigureGraphics256Color(1);
+        (Renderer renderer, VideoMemory _) = CreateRenderer(state);
+
+        uint backgroundColor = 0xFF_00_00_00;
+        state.DacRegisters.PaletteMap[0] = backgroundColor;
+
+        state.IsRenderingDirty = true;
+        uint[] frame = RenderAndCapture(renderer, state);
+
+        frame[0].Should().Be(backgroundColor, "zero VRAM values should use palette index 0");
+    }
+
+    [SkippableFact]
+    public void Render256Color_MaxPaletteIndex_Works() {
+        EnsureSupported();
+        VideoState state = ConfigureGraphics256Color(1);
+        (Renderer renderer, VideoMemory vram) = CreateRenderer(state);
+
+        uint maxColor = 0xFF_FF_FF_FF;
+        state.DacRegisters.PaletteMap[255] = maxColor;
+        vram.Planes[0, 0] = 255;
+
+        state.IsRenderingDirty = true;
+        uint[] frame = RenderAndCapture(renderer, state);
+
+        frame[0].Should().Be(maxColor);
+    }
+
+    [SkippableFact]
+    public void Render256Color_DirtySkip_StillWorks() {
+        EnsureSupported();
+        VideoState state = ConfigureGraphics256Color(1);
+        (Renderer renderer, VideoMemory vram) = CreateRenderer(state);
+        SetIdentityPaletteMap(state);
+
+        vram.Planes[0, 0] = 42;
+        state.IsRenderingDirty = true;
+        RenderFullFrame(renderer, state);
+        uint[] first = new uint[renderer.Width * renderer.Height];
+        renderer.Render(first);
+        first[0].Should().Be(state.DacRegisters.PaletteMap[42]);
+
+        // Second frame with no changes → skip
+        RenderFullFrame(renderer, state);
+        uint[] second = new uint[renderer.Width * renderer.Height];
+        System.Array.Fill(second, 0xDEADBEEF);
+        renderer.Render(second);
+        second[0].Should().Be(0xDEADBEEF, "skipped frame should not overwrite");
+    }
+
+    [SkippableFact]
+    public void Render256Color_BytePanning_OffsetsStart() {
+        EnsureSupported();
+        VideoState state = ConfigureGraphics256Color(1);
+        (Renderer renderer, VideoMemory vram) = CreateRenderer(state);
+        SetIdentityPaletteMap(state);
+
+        state.CrtControllerRegisters.PresetRowScanRegister.BytePanning = 2;
+        state.CrtControllerRegisters.ScreenStartAddress = 0;
+
+        // With panning=2, start address becomes 0+2=2
+        vram.Planes[0, 2] = 88;
+
+        state.IsRenderingDirty = true;
+        uint[] frame = RenderAndCapture(renderer, state);
+
+        frame[0].Should().Be(state.DacRegisters.PaletteMap[88], "byte panning offsets 256-color start");
+    }
+
+    [SkippableFact]
+    public void Render256Color_ConsecutiveFrames_UpdateCorrectly() {
+        EnsureSupported();
+        VideoState state = ConfigureGraphics256Color(1);
+        (Renderer renderer, VideoMemory vram) = CreateRenderer(state);
+        SetIdentityPaletteMap(state);
+
+        // Frame 1
+        vram.Planes[0, 0] = 10;
+        state.IsRenderingDirty = true;
+        uint[] f1 = RenderAndCapture(renderer, state);
+        f1[0].Should().Be(state.DacRegisters.PaletteMap[10]);
+
+        // Frame 2: different data
+        vram.Planes[0, 0] = 200;
+        state.IsRenderingDirty = true;
+        uint[] f2 = RenderAndCapture(renderer, state);
+        f2[0].Should().Be(state.DacRegisters.PaletteMap[200]);
+    }
+
+    // ─────────── DoubleWord / Word addressing modes ───────────
+
+    [SkippableFact]
+    public void Render256Color_DoubleWordMode_ReadsCorrectPhysicalAddresses() {
+        EnsureSupported();
+        VideoState state = ConfigureGraphics256Color(1);
+        // Enable DoubleWord addressing: physical = counter << 2.
+        // Counter 0 → physical 0, counter 1 → physical 4, counter 2 → physical 8.
+        // VRam layout: physical P → VRam[P*4 .. P*4+3].
+        state.CrtControllerRegisters.UnderlineRowScanlineRegister.DoubleWordMode = true;
+        (Renderer renderer, VideoMemory vram) = CreateRenderer(state);
+        SetIdentityPaletteMap(state);
+
+        // Char 0 reads counter=0 → physical=0 → VRam[0..3]
+        vram.Planes[0, 0] = 10;
+        vram.Planes[1, 0] = 20;
+        vram.Planes[2, 0] = 30;
+        vram.Planes[3, 0] = 40;
+
+        // Char 1 reads counter=1 → physical=4 → VRam[16..19]
+        vram.Planes[0, 4] = 50;
+        vram.Planes[1, 4] = 60;
+        vram.Planes[2, 4] = 70;
+        vram.Planes[3, 4] = 80;
+
+        // Poison the contiguous location that would be read by
+        // a buggy implementation assuming stride-1 physical addressing.
+        // Physical address 1 → VRam[4..7] (wrong for char 1).
+        vram.Planes[0, 1] = 0xAA;
+        vram.Planes[1, 1] = 0xBB;
+
+        state.IsRenderingDirty = true;
+        uint[] frame = RenderAndCapture(renderer, state);
+
+        // Char 0 pixels
+        frame[0].Should().Be(state.DacRegisters.PaletteMap[10], "char 0, plane 0");
+        frame[2].Should().Be(state.DacRegisters.PaletteMap[20], "char 0, plane 1");
+        frame[4].Should().Be(state.DacRegisters.PaletteMap[30], "char 0, plane 2");
+        frame[6].Should().Be(state.DacRegisters.PaletteMap[40], "char 0, plane 3");
+
+        // Char 1 pixels — must use physical address 4, NOT physical address 1
+        frame[8].Should().Be(state.DacRegisters.PaletteMap[50], "char 1, plane 0 — DoubleWord addressing");
+        frame[10].Should().Be(state.DacRegisters.PaletteMap[60], "char 1, plane 1 — DoubleWord addressing");
+        frame[12].Should().Be(state.DacRegisters.PaletteMap[70], "char 1, plane 2 — DoubleWord addressing");
+        frame[14].Should().Be(state.DacRegisters.PaletteMap[80], "char 1, plane 3 — DoubleWord addressing");
+    }
+
+    [SkippableFact]
+    public void Render256Color_Word13Mode_ReadsCorrectPhysicalAddresses() {
+        EnsureSupported();
+        VideoState state = ConfigureGraphics256Color(1);
+        // Word13 mode: physical = (counter << 1) | (counter >> 13 & 1).
+        // Counter 0 → physical 0, counter 1 → physical 2, counter 2 → physical 4.
+        state.CrtControllerRegisters.CrtModeControlRegister.ByteWordMode = ByteWordMode.Word;
+        state.CrtControllerRegisters.CrtModeControlRegister.AddressWrap = false;
+        state.CrtControllerRegisters.UnderlineRowScanlineRegister.DoubleWordMode = false;
+        (Renderer renderer, VideoMemory vram) = CreateRenderer(state);
+        SetIdentityPaletteMap(state);
+
+        // Char 0 reads counter=0 → physical=0 → VRam[0..3]
+        vram.Planes[0, 0] = 11;
+        vram.Planes[1, 0] = 22;
+        vram.Planes[2, 0] = 33;
+        vram.Planes[3, 0] = 44;
+
+        // Char 1 reads counter=1 → physical=2 → VRam[8..11]
+        vram.Planes[0, 2] = 55;
+        vram.Planes[1, 2] = 66;
+        vram.Planes[2, 2] = 77;
+        vram.Planes[3, 2] = 88;
+
+        // Poison location that a contiguous reader would pick up:
+        // physical 1 → VRam[4..7]
+        vram.Planes[0, 1] = 0xCC;
+        vram.Planes[1, 1] = 0xDD;
+
+        state.IsRenderingDirty = true;
+        uint[] frame = RenderAndCapture(renderer, state);
+
+        frame[0].Should().Be(state.DacRegisters.PaletteMap[11], "char 0, plane 0");
+        frame[2].Should().Be(state.DacRegisters.PaletteMap[22], "char 0, plane 1");
+
+        frame[8].Should().Be(state.DacRegisters.PaletteMap[55], "char 1, plane 0 — Word13 addressing");
+        frame[10].Should().Be(state.DacRegisters.PaletteMap[66], "char 1, plane 1 — Word13 addressing");
+        frame[12].Should().Be(state.DacRegisters.PaletteMap[77], "char 1, plane 2 — Word13 addressing");
+        frame[14].Should().Be(state.DacRegisters.PaletteMap[88], "char 1, plane 3 — Word13 addressing");
+    }
+
+    [SkippableFact]
+    public void Render256Color_CountByFour_RepeatsAddressForGroupedCharacters() {
+        EnsureSupported();
+        // With CountByFour (mask=3), the memory address counter advances only
+        // every 4th character clock.  Groups of characters share the same
+        // VRAM address and must produce identical pixel data.
+        VideoState state = ConfigureGraphics256Color(1);
+        state.CrtControllerRegisters.UnderlineRowScanlineRegister.CountByFour = true;
+        state.CrtControllerRegisters.HorizontalDisplayEnd = 7;
+        state.CrtControllerRegisters.HorizontalTotal = 10;
+        (Renderer renderer, VideoMemory vram) = CreateRenderer(state);
+        SetIdentityPaletteMap(state);
+
+        // Counter advances: char 0 reads C=0, advance → C=1.
+        // Chars 1-3 read C=1 (no advance). Char 4 reads C=1, advance → C=2.
+        // Chars 5-7 read C=2 (no advance).
+        vram.Planes[0, 0] = 10;  // read by char 0
+        vram.Planes[0, 1] = 50;  // read by chars 1–4
+        vram.Planes[0, 2] = 90;  // read by chars 5–7
+
+        state.IsRenderingDirty = true;
+        uint[] frame = RenderAndCapture(renderer, state);
+
+        // Char 0: unique address (counter=0)
+        frame[0].Should().Be(state.DacRegisters.PaletteMap[10], "char 0 uses counter 0");
+
+        // Chars 1–4: all share counter=1
+        frame[8].Should().Be(state.DacRegisters.PaletteMap[50], "char 1 uses counter 1");
+        frame[16].Should().Be(state.DacRegisters.PaletteMap[50], "char 2 uses counter 1");
+        frame[24].Should().Be(state.DacRegisters.PaletteMap[50], "char 3 uses counter 1");
+        frame[32].Should().Be(state.DacRegisters.PaletteMap[50], "char 4 uses counter 1");
+
+        // Chars 5–7: all share counter=2
+        frame[40].Should().Be(state.DacRegisters.PaletteMap[90], "char 5 uses counter 2");
+        frame[48].Should().Be(state.DacRegisters.PaletteMap[90], "char 6 uses counter 2");
+        frame[56].Should().Be(state.DacRegisters.PaletteMap[90], "char 7 uses counter 2");
+    }
+
+    // ─────────── Helpers ───────────
+
+    protected static void RenderFullFrame(Renderer renderer, VideoState state) {
+        renderer.BeginFrame();
+        int totalLines = state.CrtControllerRegisters.VerticalTotalValue + 10;
+        for (int i = 0; i < totalLines; i++) {
+            renderer.RenderScanline();
+        }
+        renderer.CompleteFrame();
+    }
+
+    protected static uint[] RenderAndCapture(Renderer renderer, VideoState state) {
+        RenderFullFrame(renderer, state);
+        uint[] output = new uint[renderer.Width * renderer.Height];
+        renderer.Render(output);
+        return output;
+    }
+
+    protected static VideoState ConfigureGraphics256Color(int lines) {
+        VideoState state = new();
+        state.GeneralRegisters.MiscellaneousOutput.ClockSelect = ClockSelect.Use25175Khz;
+        state.SequencerRegisters.ClockingModeRegister.HalfDotClock = true;
+        state.SequencerRegisters.ClockingModeRegister.DotsPerClock = 8;
+        state.AttributeControllerRegisters.ColorPlaneEnableRegister.Value = 0x0F;
+        state.CrtControllerRegisters.VerticalDisplayEnd = (byte)(lines - 1);
+        state.CrtControllerRegisters.VerticalTotal = (byte)(lines - 1);
+        state.CrtControllerRegisters.MaximumScanlineRegister.MaximumScanline = 0;
+        state.CrtControllerRegisters.MaximumScanlineRegister.CrtcScanDouble = false;
+        state.CrtControllerRegisters.HorizontalDisplayEnd = 39;
+        state.CrtControllerRegisters.HorizontalTotal = 49;
+        state.CrtControllerRegisters.Offset = 40;
+        state.CrtControllerRegisters.CrtModeControlRegister.ByteWordMode = ByteWordMode.Byte;
+        state.CrtControllerRegisters.CrtModeControlRegister.CompatibilityModeSupport = true;
+        state.CrtControllerRegisters.CrtModeControlRegister.SelectRowScanCounter = true;
+        state.GraphicsControllerRegisters.GraphicsModeRegister.In256ColorMode = true;
+        state.GraphicsControllerRegisters.MiscellaneousGraphicsRegister.GraphicsMode = true;
+        return state;
+    }
+
+    protected static void SetIdentityPaletteMap(VideoState state) {
+        for (int i = 0; i < 256; i++) {
+            state.DacRegisters.PaletteMap[i] = 0xFF000000u | ((uint)i << 16) | ((uint)i << 8) | (uint)i;
+        }
+    }
+}

--- a/tests/Spice86.Tests/Video/VideoMemoryTests.cs
+++ b/tests/Spice86.Tests/Video/VideoMemoryTests.cs
@@ -7,6 +7,7 @@ using Spice86.Core.Emulator.Devices.Video.Registers.Graphics;
 using Spice86.Shared.Interfaces;
 
 using Xunit;
+using FluentAssertions;
 
 public class VideoMemoryTests {
     [Fact]
@@ -69,4 +70,36 @@ public class VideoMemoryTests {
         ILoggerService logger = Substitute.For<ILoggerService>();
         return new VideoMemory(state, logger);
     }
+
+        [Fact]
+        public void GetLinearSpan_ReturnsContiguousPixelData() {
+            VideoState state = new();
+            ILoggerService logger = Substitute.For<ILoggerService>();
+            VideoMemory mem = new VideoMemory(state, logger);
+
+            for (int i = 0; i < 16; i++) {
+                mem.VRam[i] = (byte)(i + 1);
+            }
+
+            System.ReadOnlySpan<byte> span = mem.GetLinearSpan(0, 16);
+
+            for (int i = 0; i < 16; i++) {
+                span[i].Should().Be((byte)(i + 1));
+            }
+        }
+
+        [Fact]
+        public void GetLinearSpan_WithOffset_ReturnsCorrectData() {
+            VideoState state = new();
+            ILoggerService logger = Substitute.For<ILoggerService>();
+            VideoMemory mem = new VideoMemory(state, logger);
+
+            mem.VRam[100] = 0xAA;
+            mem.VRam[101] = 0xBB;
+
+            System.ReadOnlySpan<byte> span = mem.GetLinearSpan(100, 2);
+
+            span[0].Should().Be(0xAA);
+            span[1].Should().Be(0xBB);
+        }
 }


### PR DESCRIPTION
### Description of Changes
Implement event-driven VGA timing and rendering on the emulation loop.

### Rationale behind Changes
Move VGA rendering from ad-hoc/polling to an event-based model to make VGA register behavior deterministic, fix timing-dependent visual issues (blink/refresh), reduce race conditions between emulation and rendering, and improve testability and correctness of video emulation and UI presentation.


### Suggested Testing Steps
Tested with:
- Dune
- Dune 2
- Dune 2 setup
- Krondor
- Transartica
- Civ1
- Prince of persia
- Grand prix circuit
