### PR TITLE
fix: INT21H 0x4B LOAD or LOAD AND EXEC corrupted the stack frame

### DIFF
--- a/src/Spice86.Core/Emulator/OperatingSystem/DosProcessManager.cs
+++ b/src/Spice86.Core/Emulator/OperatingSystem/DosProcessManager.cs
@@ -80,7 +80,11 @@ public class DosProcessManager {
     private readonly InterruptVectorTable _interruptVectorTable;
     private readonly Stack _stack;
     private readonly DosSwappableDataArea _sda;
-    private const int IregsFrameSize = 18;
+    // In FreeDOS this is 18 (sizeof(iregs) = 9 GP registers pushed by PUSH$ALL).
+    // Spice86's CfgCpu INT only pushes FLAGS+CS+IP (6 bytes) with no GP register frame,
+    // so no subtraction is needed. A non-zero value corrupts the parent's saved SP,
+    // causing IRET to pop garbage FLAGS (e.g. carry flag set → SUMMON.COM error path).
+    private const int IregsFrameSize = 0;
 
     /// <summary>
     /// The master environment block that all DOS PSPs inherit.
@@ -252,7 +256,8 @@ public class DosProcessManager {
 
         ushort parentSS = _state.SS;
         ushort parentSP = _state.SP;
-        // FreeDOS stores (SP - sizeof(iregs)) in the child PSP's stack field.
+        // FreeDOS stores (SP - sizeof(iregs)) in the parent PSP's stack field.
+        // In Spice86, IregsFrameSize is 0 because CfgCpu has no GP register frame.
         ushort parentReservedSP = (ushort)(parentSP - IregsFrameSize);
 
         // Allocate environment block FIRST before allocating program memory, as we might decide to take ALL the remaining free memory

--- a/tests/Spice86.Tests/Dos/DosProcessManagerTests.cs
+++ b/tests/Spice86.Tests/Dos/DosProcessManagerTests.cs
@@ -153,9 +153,10 @@ public class DosProcessManagerTests {
 
             context.CurrentPspSegment.Should().Be(parentSegment);
             context.State.SS.Should().Be(0xFFFD);
-            // SP is restored to the iregs frame location (parent SP minus IregsFrameSize of 18 bytes).
-            // FreeDOS stores ps_stack = SS:(SP - sizeof(iregs)) during EXEC.
-            context.State.SP.Should().Be((ushort)(0xFFFE - 18));
+            // SP is restored to the exact value it had before the EXEC call.
+            // Spice86's CfgCpu has no GP register frame (unlike FreeDOS's PUSH$ALL),
+            // so no IregsFrameSize subtraction is applied.
+            context.State.SP.Should().Be(0xFFFE);
         } finally {
             DeleteIfExists(comFilePath);
         }


### PR DESCRIPTION
### Description of Changes

```
    // In FreeDOS this is 18 (sizeof(iregs) = 9 GP registers pushed by PUSH$ALL).
    // Spice86's CfgCpu INT only pushes FLAGS+CS+IP (6 bytes) with no GP register frame,
    // so no subtraction is needed. A non-zero value corrupts the parent's saved SP,
    // causing IRET to pop garbage FLAGS (e.g. carry flag set → SUMMON.COM error path).
    private const int IregsFrameSize = 0;
```
    
Previously the value was from FreeDOS, which expects 18 from from the CPU.

The regression was coming from commit  de98e05fc02c215b3d1184442f3a222070d1ef5c
### Rationale behind Changes

Fixes The Summonning. Avoids corrupting the Stack Frame in INT21H 0x4B helper function  LoadOrLoadAndExecuteInternal 

```
        // FreeDOS stores (SP - sizeof(iregs)) in the parent PSP's stack field.
        // In Spice86, IregsFrameSize is 0 because CfgCpu has no GP register frame.
        ushort parentReservedSP = (ushort)(parentSP - IregsFrameSize);
```

### Suggested Testing Steps

Tested with The Summonning. It works again now. Integration tests updated first to reveal the bug.