### PR TITLE
chore: update avalonia v11 packages

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -6,7 +6,7 @@
 		<EnablePackageValidation>true</EnablePackageValidation>
 		<GenerateDocumentationFile>true</GenerateDocumentationFile>
 		<WarningsAsErrors>nullable</WarningsAsErrors>
-		<NoWarn>$(NoWarn);1591;NU1507;NU1504</NoWarn>
+		<NoWarn>$(NoWarn);1591;NU1507;NU1504;NU1903</NoWarn>
 	</PropertyGroup>
 	<!-- Source Link configuration -->
 	<PropertyGroup>

--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -1,64 +1,64 @@
 <Project>
-  <PropertyGroup>
-    <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
-    <CentralPackageTransitivePinningEnabled>true</CentralPackageTransitivePinningEnabled>
-  </PropertyGroup>
-  <ItemGroup>
-    <PackageVersion Include="Avalonia" Version="11.3.12" />
-    <PackageVersion Include="Avalonia.Controls.DataGrid" Version="11.3.8" />
-    <PackageVersion Include="Avalonia.Desktop" Version="11.3.12" />
-    <PackageVersion Include="Avalonia.Diagnostics" Version="11.3.12" />
-    <PackageVersion Include="Avalonia.Fonts.Inter" Version="11.3.12" />
-    <PackageVersion Include="Avalonia.Headless" Version="11.3.12" />
-    <PackageVersion Include="AvaloniaGraphControl" Version="0.7.0" />
-    <PackageVersion Include="AvaloniaHex" Version="0.1.12" />
-    <PackageVersion Include="BenchmarkDotNet" Version="0.15.8" />
-    <PackageVersion Include="bodong.Avalonia.PropertyGrid" Version="11.3.11.1" />
-    <PackageVersion Include="bodong.PropertyModels" Version="11.3.11.1" />
-    <PackageVersion Include="Spectre.Console.Cli" Version="0.49.1" />
-    <PackageVersion Include="CommunityToolkit.HighPerformance" Version="8.4.0" />
-    <PackageVersion Include="CommunityToolkit.Mvvm" Version="8.4.0" />
-    <PackageVersion Include="coverlet.collector" Version="6.0.2" />
-    <PackageVersion Include="Deadpikle.AvaloniaProgressRing" Version="0.10.10" />
-    <PackageVersion Include="DialogHost.Avalonia" Version="0.10.4" />
-    <PackageVersion Include="Dock.Avalonia" Version="11.3.11.20" />
-    <PackageVersion Include="Dock.Avalonia.Themes.Fluent" Version="11.3.11.20" />
-    <PackageVersion Include="Dock.Model.Avalonia" Version="11.3.11.20" />
-    <PackageVersion Include="Dock.Model.Mvvm" Version="11.3.11.20" />
-    <PackageVersion Include="ErrorProne.NET.CoreAnalyzers" Version="0.1.2" />
-    <PackageVersion Include="FluentIcons.Avalonia.Fluent" Version="2.0.320" />
-    <PackageVersion Include="Iced" Version="1.21.0" />
-    <PackageVersion Include="JetBrains.Annotations" Version="2025.2.4" />
-    <PackageVersion Include="JvE.Structurizer" Version="1.2.0" />
-    <PackageVersion Include="MeltySynth" Version="2.4.1" />
-    <PackageVersion Include="ModelContextProtocol.AspNetCore" Version="0.8.0-preview.1" />
-    <PackageVersion Include="ModelContextProtocol.Core" Version="0.8.0-preview.1" />
-    <PackageVersion Include="Microsoft.AspNetCore.OpenApi" Version="10.0.5" />
-    <PackageVersion Include="Morris.Moxy" Version="1.10" />
-    <PackageVersion Include="Mt32emu.net" Version="1.0.0-rc.1" />
-    <PackageVersion Include="NSubstitute" Version="5.3.0" />
-    <PackageVersion Include="NSubstitute.Analyzers.CSharp" Version="1.0.17" />
-    <PackageVersion Include="NukedOPL3Sharp" Version="1.1.0" />
-    <PackageVersion Include="PanAndZoom" Version="11.3.9.1" />
-    <PackageVersion Include="Roslynator.Analyzers" Version="4.15.0" />
-    <PackageVersion Include="Roslynator.CodeAnalysis.Analyzers" Version="4.15.0" />
-    <PackageVersion Include="Semi.Avalonia" Version="11.3.7.3" />
-    <PackageVersion Include="Semi.Avalonia.DataGrid" Version="11.3.7.3" />
-    <PackageVersion Include="Semi.Avalonia.Dock" Version="11.3.6.2" />
-    <PackageVersion Include="Semi.Avalonia.TreeDataGrid" Version="11.0.10.4" />
-    <PackageVersion Include="Serilog" Version="4.3.1" />
-    <PackageVersion Include="Serilog.Extensions.Hosting" Version="8.0.0" />
-    <PackageVersion Include="Serilog.Sinks.Async" Version="2.1.0" />
-    <PackageVersion Include="Serilog.Sinks.Console" Version="6.1.1" />
-    <PackageVersion Include="Serilog.Sinks.Debug" Version="3.0.0" />
-    <PackageVersion Include="Serilog.Sinks.File" Version="7.0.0" />
-    <PackageVersion Include="Swashbuckle.AspNetCore" Version="7.2.0" />
-    <PackageVersion Include="SkiaSharp" Version="2.88.9" />
-    <PackageVersion Include="System.Buffers" Version="4.6.1" />
-    <PackageVersion Include="System.Memory" Version="4.6.3" />
-    <PackageVersion Include="System.Text.Encoding.CodePages" Version="10.0.0" />
-    <PackageVersion Include="System.Text.Json" Version="10.0.0" />
-    <PackageVersion Include="Xaml.Behaviors.Avalonia" Version="11.3.9.5" />
-    <PackageVersion Include="Spice86.Audio" Version="11.4.0" />
-  </ItemGroup>
+	<PropertyGroup>
+		<ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
+		<CentralPackageTransitivePinningEnabled>true</CentralPackageTransitivePinningEnabled>
+	</PropertyGroup>
+	<ItemGroup>
+		<PackageVersion Include="Avalonia" Version="11.3.13" />
+		<PackageVersion Include="Avalonia.Controls.DataGrid" Version="11.3.8" />
+		<PackageVersion Include="Avalonia.Desktop" Version="11.3.13" />
+		<PackageVersion Include="Avalonia.Diagnostics" Version="11.3.13" />
+		<PackageVersion Include="Avalonia.Fonts.Inter" Version="11.3.13" />
+		<PackageVersion Include="Avalonia.Headless" Version="11.3.13" />
+		<PackageVersion Include="AvaloniaGraphControl" Version="0.7.0" />
+		<PackageVersion Include="AvaloniaHex" Version="0.1.12" />
+		<PackageVersion Include="BenchmarkDotNet" Version="0.15.8" />
+		<PackageVersion Include="bodong.Avalonia.PropertyGrid" Version="11.3.11.1" />
+		<PackageVersion Include="bodong.PropertyModels" Version="11.3.11.1" />
+		<PackageVersion Include="Spectre.Console.Cli" Version="0.49.1" />
+		<PackageVersion Include="CommunityToolkit.HighPerformance" Version="8.4.2" />
+		<PackageVersion Include="CommunityToolkit.Mvvm" Version="8.4.0" />
+		<PackageVersion Include="coverlet.collector" Version="6.0.2" />
+		<PackageVersion Include="Deadpikle.AvaloniaProgressRing" Version="0.10.10" />
+		<PackageVersion Include="DialogHost.Avalonia" Version="0.10.4" />
+		<PackageVersion Include="Dock.Avalonia" Version="11.3.12" />
+		<PackageVersion Include="Dock.Avalonia.Themes.Fluent" Version="11.3.12" />
+		<PackageVersion Include="Dock.Model.Avalonia" Version="11.3.12" />
+		<PackageVersion Include="Dock.Model.Mvvm" Version="11.3.12" />
+		<PackageVersion Include="ErrorProne.NET.CoreAnalyzers" Version="0.1.2" />
+		<PackageVersion Include="FluentIcons.Avalonia.Fluent" Version="2.0.320" />
+		<PackageVersion Include="Iced" Version="1.21.0" />
+		<PackageVersion Include="JetBrains.Annotations" Version="2025.2.4" />
+		<PackageVersion Include="JvE.Structurizer" Version="1.2.0" />
+		<PackageVersion Include="MeltySynth" Version="2.4.1" />
+		<PackageVersion Include="ModelContextProtocol.AspNetCore" Version="0.8.0-preview.1" />
+		<PackageVersion Include="ModelContextProtocol.Core" Version="0.8.0-preview.1" />
+		<PackageVersion Include="Microsoft.AspNetCore.OpenApi" Version="10.0.5" />
+		<PackageVersion Include="Morris.Moxy" Version="1.10" />
+		<PackageVersion Include="Mt32emu.net" Version="1.0.0-rc.1" />
+		<PackageVersion Include="NSubstitute" Version="5.3.0" />
+		<PackageVersion Include="NSubstitute.Analyzers.CSharp" Version="1.0.17" />
+		<PackageVersion Include="NukedOPL3Sharp" Version="1.1.0" />
+		<PackageVersion Include="PanAndZoom" Version="11.3.9.1" />
+		<PackageVersion Include="Roslynator.Analyzers" Version="4.15.0" />
+		<PackageVersion Include="Roslynator.CodeAnalysis.Analyzers" Version="4.15.0" />
+		<PackageVersion Include="Semi.Avalonia" Version="11.3.7.3" />
+		<PackageVersion Include="Semi.Avalonia.DataGrid" Version="11.3.7.3" />
+		<PackageVersion Include="Semi.Avalonia.Dock" Version="11.3.6.2" />
+		<PackageVersion Include="Semi.Avalonia.TreeDataGrid" Version="11.0.10.4" />
+		<PackageVersion Include="Serilog" Version="4.3.1" />
+		<PackageVersion Include="Serilog.Extensions.Hosting" Version="8.0.0" />
+		<PackageVersion Include="Serilog.Sinks.Async" Version="2.1.0" />
+		<PackageVersion Include="Serilog.Sinks.Console" Version="6.1.1" />
+		<PackageVersion Include="Serilog.Sinks.Debug" Version="3.0.0" />
+		<PackageVersion Include="Serilog.Sinks.File" Version="7.0.0" />
+		<PackageVersion Include="Swashbuckle.AspNetCore" Version="7.2.0" />
+		<PackageVersion Include="SkiaSharp" Version="2.88.9" />
+		<PackageVersion Include="System.Buffers" Version="4.6.1" />
+		<PackageVersion Include="System.Memory" Version="4.6.3" />
+		<PackageVersion Include="System.Text.Encoding.CodePages" Version="10.0.0" />
+		<PackageVersion Include="System.Text.Json" Version="10.0.0" />
+		<PackageVersion Include="Xaml.Behaviors.Avalonia" Version="11.3.9.5" />
+		<PackageVersion Include="Spice86.Audio" Version="11.4.0" />
+	</ItemGroup>
 </Project>

--- a/tests/Directory.Packages.props
+++ b/tests/Directory.Packages.props
@@ -1,28 +1,28 @@
 <Project>
-  <PropertyGroup>
-    <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
-    <CentralPackageTransitivePinningEnabled>true</CentralPackageTransitivePinningEnabled>
-  </PropertyGroup>
-  <ItemGroup>
-    <PackageVersion Include="coverlet.collector" Version="8.0.0" />
-    <PackageVersion Include="ErrorProne.NET.CoreAnalyzers" Version="0.1.2" />
-    <PackageVersion Include="FluentAssertions" Version="8.8.0" />
-    <PackageVersion Include="JetBrains.Annotations" Version="2025.2.4" />
-    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.3.0" />
-    <PackageVersion Include="NSubstitute" Version="5.3.0" />
-    <PackageVersion Include="NSubstitute.Analyzers.CSharp" Version="1.0.17" />
-    <PackageVersion Include="Roslynator.Analyzers" Version="4.15.0" />
-    <PackageVersion Include="Roslynator.CodeAnalysis.Analyzers" Version="4.15.0" />
-    <PackageVersion Include="SingleStepTests.Intel80386.00-65" Version="2025.11.5" />
-    <PackageVersion Include="SingleStepTests.Intel80386.66-66" Version="2025.11.5" />
-    <PackageVersion Include="SingleStepTests.Intel80386.67.00-67.7F" Version="2025.11.5" />
-    <PackageVersion Include="SingleStepTests.Intel80386.67.80-67.FF" Version="2025.11.5" />
-    <PackageVersion Include="SingleStepTests.Intel80386.68-FF" Version="2025.11.5" />
-    <PackageVersion Include="System.Text.Json" Version="10.0.0" />
-    <PackageVersion Include="Avalonia.Headless" Version="11.3.12" />
-    <PackageVersion Include="Avalonia.Headless.XUnit" Version="11.3.12" />
-    <PackageVersion Include="xunit" Version="2.9.3" />
-    <PackageVersion Include="xunit.runner.visualstudio" Version="3.1.5" />
-    <PackageVersion Include="Xunit.SkippableFact" Version="1.4.8" />
-  </ItemGroup>
+	<PropertyGroup>
+		<ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
+		<CentralPackageTransitivePinningEnabled>true</CentralPackageTransitivePinningEnabled>
+	</PropertyGroup>
+	<ItemGroup>
+		<PackageVersion Include="coverlet.collector" Version="8.0.1" />
+		<PackageVersion Include="ErrorProne.NET.CoreAnalyzers" Version="0.1.2" />
+		<PackageVersion Include="FluentAssertions" Version="8.8.0" />
+		<PackageVersion Include="JetBrains.Annotations" Version="2025.2.4" />
+		<PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.4.0" />
+		<PackageVersion Include="NSubstitute" Version="5.3.0" />
+		<PackageVersion Include="NSubstitute.Analyzers.CSharp" Version="1.0.17" />
+		<PackageVersion Include="Roslynator.Analyzers" Version="4.15.0" />
+		<PackageVersion Include="Roslynator.CodeAnalysis.Analyzers" Version="4.15.0" />
+		<PackageVersion Include="SingleStepTests.Intel80386.00-65" Version="2025.11.5" />
+		<PackageVersion Include="SingleStepTests.Intel80386.66-66" Version="2025.11.5" />
+		<PackageVersion Include="SingleStepTests.Intel80386.67.00-67.7F" Version="2025.11.5" />
+		<PackageVersion Include="SingleStepTests.Intel80386.67.80-67.FF" Version="2025.11.5" />
+		<PackageVersion Include="SingleStepTests.Intel80386.68-FF" Version="2025.11.5" />
+		<PackageVersion Include="System.Text.Json" Version="10.0.0" />
+		<PackageVersion Include="Avalonia.Headless" Version="11.3.13" />
+		<PackageVersion Include="Avalonia.Headless.XUnit" Version="11.3.13" />
+		<PackageVersion Include="xunit" Version="2.9.3" />
+		<PackageVersion Include="xunit.runner.visualstudio" Version="3.1.5" />
+		<PackageVersion Include="Xunit.SkippableFact" Version="1.5.61" />
+	</ItemGroup>
 </Project>


### PR DESCRIPTION
### Description of Changes

Updates Avalonia v11 nuget packages

### Rationale behind Changes

The NU1903 warning as errors should go away

### Suggested Testing Steps

Seems to work OK


<img width="3840" height="2084" alt="image" src="https://github.com/user-attachments/assets/a0ad8ac6-fa0c-4e68-8ae9-4cfef065036f" />