### PR TITLE
feat: Add deterministic, low‑overhead clock jitter (--ClockJitterSeed)

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -241,7 +241,7 @@ Variants: `MemoryBasedDataStructureWithCsBaseAddress`, `MemoryBasedDataStructure
 - **Segmented addressing**: Use `SegmentedAddress` not raw offsets; linear address = segment * 16 + offset
 - **A20 Gate**: Memory wrapping at 1MB boundary controlled by `A20Gate` (toggle via `--A20Gate` flag)
 - **EMS/XMS**: Enabled by default; disable with `--Xms false` / `--Ems false`
-- **Time handling**: Real-time vs instruction-based via `--InstructionsPerSecond` or `--TimeMultiplier`
+- **Time handling**: Real-time vs instruction-based via `--InstructionTimeScale` or `--TimeMultiplier`
 - **Internal visibility**: `Spice86.Tests` has `InternalsVisibleTo` for testing internal APIs
 
 ## Reference Examples

--- a/README.md
+++ b/README.md
@@ -111,7 +111,8 @@ Spice86 -e program.exe --CpuHeavyLog --CpuHeavyLogDumpFile "C:\logs\cpu.log"
   -o, --OverrideSupplierClassName    Name of a class that will generate the initial function information. See documentation for more information.
   -p, --ProgramEntryPointSegment     (Default: 4096) Segment where to load the program. DOS PSP and MCB will be created before it.
   -u, --UseCodeOverride              (Default: true) <true or false> if false it will use the names provided by overrideSupplierClassName but not the code
-  -i, --InstructionsPerSecond        <number of instructions that have to be executed by the emulator to consider a second passed> if blank will use time based timer.
+  -i, --InstructionTimeScale        <number of instructions that have to be executed by the emulator to consider a second passed> if blank will use time based timer.
+  --ClockJitterSeed <CLOCKJITTERSEED> Optional integer seed enabling small deterministic clock jitter (±0.01 ms). Omit to disable.
   -t, --TimeMultiplier               (Default: 1) <time multiplier> if >1 will go faster, if <1 will go slower.
   -h, --HeadlessMode [Mode]          (Default: false) Headless mode. The mode 'Minimal' does not use any UI components, 'Avalonia' uses the full UI and consumes a bit more memory.
   -l, --VerboseLogs                  (Default: false) Enable verbose level logs
@@ -280,7 +281,7 @@ Also, while in Seer, set Settings/Configuration/Assembly/Disassembly Mode to
 |---------|---------|
 | **C Drive** | Configurable with `--CDrive`, defaults to current folder |
 | **Program Arguments** | Pass up to 127 chars with `--ExeArgs` |
-| **Time Handling** | Real elapsed time (adjustable with `--TimeMultiplier`) or instruction-based timing with `--InstructionsPerSecond` |
+| **Time Handling** | Real elapsed time (adjustable with `--TimeMultiplier`) or instruction-based timing with `--InstructionTimeScale` |
 | **Screen Refresh** | 30 FPS and on VGA retrace wait detection |
 | **Structure Viewer** | Requires C header file (`--StructureFile`) to display memory structures |
 
@@ -439,7 +440,7 @@ You can pass arguments (max 127 chars!) to the emulated program with the option 
 The emulated Timer hardware of the PC (Intel 8259) supports measuring time from either:
 
 - The real elapsed time. Speed can be altered with parameter **--TimeMultiplier**.
-- The number of instructions the emulated CPU executed. This is the behaviour that is activated with parameter **--InstructionsPerSecond** and is forced when in GDB mode so that you can debug with peace of mind without the timer triggering.
+- The number of instructions the emulated CPU executed. This is the behaviour that is activated with parameter **--InstructionTimeScale** and is forced when in GDB mode so that you can debug with peace of mind without the timer triggering.
 
 Compatibility list available [here](COMPATIBILITY.md).
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -635,8 +635,9 @@ Spice86 -e game.exe</code></pre>
           <tr><th>Option</th><th>Default</th><th>Description</th></tr>
         </thead>
         <tbody>
-          <tr><td><code>--Cycles</code></td><td>—</td><td>Target CPU cycles per ms (unset = no limit). Overrides <code>--InstructionsPerSecond</code> when set.</td></tr>
-          <tr><td><code>-i, --InstructionsPerSecond</code></td><td>—</td><td>Instruction-based timer; blank = real-time timer</td></tr>
+          <tr><td><code>--Cycles</code></td><td>—</td><td>Target CPU cycles per ms (unset = no limit). Overrides <code>--InstructionTimeScale</code> when set.</td></tr>
+          <tr><td><code>-i, --InstructionTimeScale</code></td><td>—</td><td>Instruction-based timer; blank = real-time timer</td></tr>
+          <tr><td><code>--ClockJitterSeed</code></td><td>—</td><td>Optional integer seed enabling small deterministic clock jitter (±0.01 ms). Omit to disable.</td></tr>
           <tr><td><code>-t, --TimeMultiplier</code></td><td>1</td><td>Real-time speed multiplier (&gt;1 faster, &lt;1 slower)</td></tr>
         </tbody>
       </table>

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -6,7 +6,7 @@
 		<EnablePackageValidation>true</EnablePackageValidation>
 		<GenerateDocumentationFile>true</GenerateDocumentationFile>
 		<WarningsAsErrors>nullable</WarningsAsErrors>
-		<NoWarn>$(NoWarn);1591;NU1507;NU1504;NU1903</NoWarn>
+		<NoWarn>$(NoWarn);1591;NU1507;NU1504</NoWarn>
 	</PropertyGroup>
 	<!-- Source Link configuration -->
 	<PropertyGroup>

--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -60,5 +60,6 @@
 		<PackageVersion Include="System.Text.Json" Version="10.0.0" />
 		<PackageVersion Include="Xaml.Behaviors.Avalonia" Version="11.3.9.5" />
 		<PackageVersion Include="Spice86.Audio" Version="11.4.0" />
+		<PackageVersion Include="Tmds.DBus.Protocol" Version="0.21.3" />
 	</ItemGroup>
 </Project>

--- a/src/Spice86.Core/CLI/CommandLineParser.cs
+++ b/src/Spice86.Core/CLI/CommandLineParser.cs
@@ -43,7 +43,7 @@ public class CommandLineParser {
         initialConfig.OverrideSupplier = ParseFunctionInformationSupplierClassName(initialConfig.OverrideSupplierClassName);
         initialConfig.ExeArgs = exeArgs;
         if (initialConfig.Cycles != null) {
-            initialConfig.InstructionsPerSecond = null;
+            initialConfig.InstructionTimeScale = null;
         }
         if (initialConfig.CpuHeavyLogDumpFile != null) {
             initialConfig.CpuHeavyLog = true;

--- a/src/Spice86.Core/CLI/Configuration.cs
+++ b/src/Spice86.Core/CLI/Configuration.cs
@@ -113,8 +113,16 @@ public sealed class Configuration : CommandSettings {
     /// <summary>
     /// Only for <see cref="PitTimer"/>
     /// </summary>
-    [CommandOption("-i|--InstructionsPerSecond <INSTRUCTIONSPERSECOND>")]
-    public long? InstructionsPerSecond { get; set; }
+    [CommandOption("-i|--InstructionTimeScale <INSTRUCTIONTIMESCALE>")]
+    public long? InstructionTimeScale { get; set; }
+
+    /// <summary>
+    /// Optional seed for deterministic clock jitter. When set, both the cycles-driven clock and the
+    /// real-time stopwatch clock add a small, reproducible signed offset (bounded to ±0.01 ms) to
+    /// <c>ElapsedTimeMs</c>. When <c>null</c> (the default), clocks behave exactly as before.
+    /// </summary>
+    [CommandOption("--ClockJitterSeed <CLOCKJITTERSEED>")]
+    public int? ClockJitterSeed { get; init; }
 
     /// <summary>
     /// The time multiplier used for speeding up or slowing down the execution of the program.

--- a/src/Spice86.Core/Emulator/VM/Clock/ClockBase.cs
+++ b/src/Spice86.Core/Emulator/VM/Clock/ClockBase.cs
@@ -7,6 +7,18 @@ public abstract class ClockBase : IEmulatedClock {
     private volatile bool _isPaused;
     private volatile bool _isDisposed;
 
+    /// <summary>The jitter source for this clock instance.</summary>
+    private protected readonly ClockJitter _jitter;
+
+    /// <summary>
+    /// Initialises the clock with the given jitter source and sets <see cref="StartTime"/> to
+    /// <see cref="DateTime.UtcNow"/>.
+    /// </summary>
+    private protected ClockBase(ClockJitter jitter) {
+        _jitter = jitter;
+        StartTime = DateTime.UtcNow;
+    }
+
     /// <inheritdoc/>
     public abstract double ElapsedTimeMs { get; }
 

--- a/src/Spice86.Core/Emulator/VM/Clock/ClockJitter.cs
+++ b/src/Spice86.Core/Emulator/VM/Clock/ClockJitter.cs
@@ -1,0 +1,64 @@
+namespace Spice86.Core.Emulator.VM.Clock;
+
+/// <summary>
+/// Base class for clock jitter sources.
+/// The dotnet JIT can devirtualize calls to sealed subclasses, making the no-op path and branch-free at runtime.
+/// Use <see cref="Create"/> to obtain the appropriate instance.
+/// </summary>
+internal abstract class ClockJitter {
+    /// <summary>
+    /// Returns a <see cref="NoOpClockJitter"/> when <paramref name="seed"/> is <c>null</c>,
+    /// or a deterministic <see cref="RandomClockJitter"/> otherwise.
+    /// </summary>
+    internal static ClockJitter Create(int? seed) =>
+        seed.HasValue ? new RandomClockJitter(seed.Value) : new NoOpClockJitter();
+
+    /// <summary>
+    /// Returns a signed jitter offset in milliseconds to add to the clock's elapsed time.
+    /// </summary>
+    internal abstract double Advance();
+
+    /// <summary>Jitter implementation that always returns zero; used when no seed is configured.</summary>
+    private sealed class NoOpClockJitter : ClockJitter {
+        internal override double Advance() => 0.0;
+    }
+
+    /// <summary>
+    /// Jitter implementation that uses a fast xorshift64 PRNG to produce a bounded,
+    /// deterministic offset in [<c>0</c>, <c>MaxJitterMs</c>].
+    /// </summary>
+    private sealed class RandomClockJitter : ClockJitter {
+        private const double MaxJitterMs = 0.01;
+
+        private const ulong GoldenRatio64 = 0x9E3779B97F4A7C15UL;
+
+        private const double High53BitsToDoubleFactor = 1.0 / (1UL << 53);
+
+        private ulong _state;
+
+        internal RandomClockJitter(int seed) {
+            // Initialize PRNG state from the 32-bit seed and spread entropy into 64 bits.
+            // Combining with the golden-ratio constant reduces correlation for small seeds.
+            ulong s = (uint)seed;
+            _state = s ^ (s << 32) ^ GoldenRatio64;
+            // xorshift algorithms require a non-zero state; avoid the degenerate zero value.
+            if (_state == 0) {
+                _state = GoldenRatio64;
+            }
+        }
+
+        internal override double Advance() {
+            // xorshift64 PRNG step: quick bit-mixing to produce the next pseudo-random state.
+            _state ^= _state << 13;
+            _state ^= _state >> 7;
+            _state ^= _state << 17;
+            // Convert the top 53 bits of the 64-bit PRNG state into a `double` in [0,1).
+            // We shift right by 11 (64 - 53) to select those high 53 bits.
+            // 53 matches the IEEE-754 `double` significand (52 fraction bits + implicit leading 1).
+            // Then we divide byt 2^53 to normalize to [0,1).
+            // Using the high-order bits yields better statistical quality for xorshift.
+            double normalized = (_state >> 11) * High53BitsToDoubleFactor;
+            return normalized * MaxJitterMs;
+        }
+    }
+}

--- a/src/Spice86.Core/Emulator/VM/Clock/CyclesClock.cs
+++ b/src/Spice86.Core/Emulator/VM/Clock/CyclesClock.cs
@@ -8,15 +8,16 @@ using Spice86.Core.Emulator.CPU;
 public class CyclesClock : ClockBase {
     private readonly State _cpuState;
 
-    public CyclesClock(State cpuState, long cyclesPerSecond, DateTime? startTime = null) {
+    public CyclesClock(State cpuState, long cyclesPerSecond, int? jitterSeed)
+        : base(ClockJitter.Create(jitterSeed)) {
         _cpuState = cpuState;
         CyclesPerSecond = cyclesPerSecond;
-        StartTime = startTime ?? DateTime.UtcNow;
     }
 
     /// <summary>Gets or sets the number of CPU cycles per second used to calculate elapsed time.</summary>
     public long CyclesPerSecond { get; set; }
 
     /// <inheritdoc/>
-    public override double ElapsedTimeMs => (double)_cpuState.Cycles * 1000 / CyclesPerSecond;
+    public override double ElapsedTimeMs =>
+        (double)_cpuState.Cycles * 1000 / CyclesPerSecond + _jitter.Advance();
 }

--- a/src/Spice86.Core/Emulator/VM/Clock/EmulatedClock.cs
+++ b/src/Spice86.Core/Emulator/VM/Clock/EmulatedClock.cs
@@ -8,10 +8,9 @@ using System.Diagnostics;
 public class EmulatedClock : ClockBase {
     private int _ticks;
     private readonly Stopwatch _stopwatch = new();
-    private double _cachedTime;
 
-    public EmulatedClock(DateTime? startTime = null) {
-        StartTime = startTime ?? DateTime.UtcNow;
+    public EmulatedClock(int? jitterSeed)
+        : base(ClockJitter.Create(jitterSeed)) {
         _stopwatch.Start();
     }
 
@@ -20,11 +19,10 @@ public class EmulatedClock : ClockBase {
         get {
             // Stopwatch.GetTimestamp can be slow, so we only query it periodically.
             if (_ticks++ % 100 != 0) {
-                return _cachedTime;
+                return field;
             }
-
-            _cachedTime = _stopwatch.Elapsed.TotalMilliseconds;
-            return _cachedTime;
+            field = _stopwatch.Elapsed.TotalMilliseconds + _jitter.Advance();
+            return field;
         }
     }
 

--- a/src/Spice86/Spice86DependencyInjection.cs
+++ b/src/Spice86/Spice86DependencyInjection.cs
@@ -193,9 +193,9 @@ public class Spice86DependencyInjection : IDisposable {
             loggerService.Information("BIOS data area created...");
         }
 
-        _emulatedClock = configuration.InstructionsPerSecond != null
-            ? new CyclesClock(state, configuration.InstructionsPerSecond.Value)
-            : new EmulatedClock();
+        _emulatedClock = configuration.InstructionTimeScale != null
+            ? new CyclesClock(state, configuration.InstructionTimeScale.Value, configuration.ClockJitterSeed)
+            : new EmulatedClock(configuration.ClockJitterSeed);
         // Register clock and limiter to pause/resume events
         pauseHandler.Pausing += () => _emulatedClock.OnPause();
         pauseHandler.Resumed += () => _emulatedClock.OnResume();

--- a/tests/Directory.Packages.props
+++ b/tests/Directory.Packages.props
@@ -24,5 +24,6 @@
 		<PackageVersion Include="xunit" Version="2.9.3" />
 		<PackageVersion Include="xunit.runner.visualstudio" Version="3.1.5" />
 		<PackageVersion Include="Xunit.SkippableFact" Version="1.5.61" />
+		<PackageVersion Include="Tmds.DBus.Protocol" Version="0.21.3" />
 	</ItemGroup>
 </Project>

--- a/tests/Spice86.Tests/ClockTests.cs
+++ b/tests/Spice86.Tests/ClockTests.cs
@@ -18,7 +18,7 @@ public class ClockTests {
     public void CyclesClock_CurrentDateTime_ShouldReflectStartTimePlusElapsed() {
         // Arrange
         State state = new State(CpuModel.INTEL_80286);
-        CyclesClock clock = new CyclesClock(state, 1000); // 1000 cycles per second
+        CyclesClock clock = new CyclesClock(state, 1000, null); // 1000 cycles per second
         DateTime startTime = new DateTime(2000, 1, 1, 12, 0, 0, DateTimeKind.Utc);
         clock.StartTime = startTime;
 
@@ -40,7 +40,7 @@ public class ClockTests {
     public void EmulatedClock_StartTime_CanBeSetAndCurrentDateTimeCalculated() {
         // Arrange
         DateTime startTime = new DateTime(2000, 1, 1, 12, 0, 0, DateTimeKind.Utc);
-        EmulatedClock clock = new EmulatedClock();
+        EmulatedClock clock = new EmulatedClock(null);
         
         // Act
         clock.StartTime = startTime;
@@ -58,7 +58,7 @@ public class ClockTests {
     public void Clock_StartTime_CanBeSetAndRetrieved() {
         // Arrange
         State state = new State(CpuModel.INTEL_80286);
-        CyclesClock clock = new CyclesClock(state, 1000);
+        CyclesClock clock = new CyclesClock(state, 1000, null);
         DateTime expectedStartTime = new DateTime(2000, 1, 1, 12, 0, 0, DateTimeKind.Utc);
 
         // Act
@@ -76,7 +76,7 @@ public class ClockTests {
     public void Clock_OnPauseAndOnResume_ShouldNotThrow() {
         // Arrange
         State state = new State(CpuModel.INTEL_80286);
-        CyclesClock clock = new CyclesClock(state, 1000);
+        CyclesClock clock = new CyclesClock(state, 1000, null);
 
         // Act
         Action act = () => {
@@ -86,5 +86,101 @@ public class ClockTests {
 
         // Assert
         act.Should().NotThrow();
+    }
+
+    /// <summary>
+    /// Tests that CyclesClock with no jitter seed returns an exact baseline value.
+    /// </summary>
+    [Fact]
+    public void CyclesClock_WithNullSeed_ReturnsExactBaselineTime() {
+        State state = new State(CpuModel.INTEL_80286);
+        CyclesClock clock = new CyclesClock(state, 1000, null);
+        for (int i = 0; i < 1000; i++) {
+            state.IncCycles();
+        }
+
+        clock.ElapsedTimeMs.Should().Be(1000.0);
+    }
+
+    /// <summary>
+    /// Tests that CyclesClock with a seed produces a value that differs from the no-seed baseline
+    /// but remains within the ±0.01 ms jitter bound.
+    /// </summary>
+    [Fact]
+    public void CyclesClock_WithSeed_AddsBoundedJitterToBaselineTime() {
+        State stateBase = new State(CpuModel.INTEL_80286);
+        State stateJitter = new State(CpuModel.INTEL_80286);
+        CyclesClock clockBase = new CyclesClock(stateBase, 1000, null);
+        CyclesClock clockJitter = new CyclesClock(stateJitter, 1000, 42);
+
+        for (int i = 0; i < 1000; i++) {
+            stateBase.IncCycles();
+            stateJitter.IncCycles();
+        }
+
+        double baseTime = clockBase.ElapsedTimeMs;
+        double jitteredTime = clockJitter.ElapsedTimeMs;
+
+        Math.Abs(jitteredTime - baseTime).Should().BeLessThanOrEqualTo(0.01);
+    }
+
+    /// <summary>
+    /// Tests that CyclesClock with the same seed produces identical ElapsedTimeMs across runs.
+    /// </summary>
+    [Fact]
+    public void CyclesClock_WithSameSeed_ProducesReproducibleJitter() {
+        State state1 = new State(CpuModel.INTEL_80286);
+        CyclesClock clock1 = new CyclesClock(state1, 1000, 12345);
+        for (int i = 0; i < 1000; i++) {
+            state1.IncCycles();
+        }
+        double time1 = clock1.ElapsedTimeMs;
+
+        State state2 = new State(CpuModel.INTEL_80286);
+        CyclesClock clock2 = new CyclesClock(state2, 1000, 12345);
+        for (int i = 0; i < 1000; i++) {
+            state2.IncCycles();
+        }
+        double time2 = clock2.ElapsedTimeMs;
+
+        time1.Should().Be(time2);
+    }
+
+    /// <summary>
+    /// Tests that CyclesClock instances with different seeds stay within the expected jitter bounds.
+    /// </summary>
+    [Fact]
+    public void CyclesClock_WithDifferentSeeds_JitterIsBounded() {
+        State baseState = new State(CpuModel.INTEL_80286);
+        State state1 = new State(CpuModel.INTEL_80286);
+        State state2 = new State(CpuModel.INTEL_80286);
+        CyclesClock baseClock = new CyclesClock(baseState, 1000, null);
+        CyclesClock clock1 = new CyclesClock(state1, 1000, 1);
+        CyclesClock clock2 = new CyclesClock(state2, 1000, 2);
+
+        for (int i = 0; i < 1000; i++) {
+            baseState.IncCycles();
+            state1.IncCycles();
+            state2.IncCycles();
+        }
+
+        double baseTime = baseClock.ElapsedTimeMs;
+        Math.Abs(clock1.ElapsedTimeMs - baseTime).Should().BeLessThanOrEqualTo(0.01);
+        Math.Abs(clock2.ElapsedTimeMs - baseTime).Should().BeLessThanOrEqualTo(0.01);
+    }
+
+    /// <summary>
+    /// Tests that EmulatedClock with a seed produces a non-negative elapsed time;
+    /// jitter must not push the value below zero. Tight bound testing requires a fake time
+    /// source and is not reliable with a real Stopwatch.
+    /// </summary>
+    [Fact]
+    public void EmulatedClock_WithSeed_ElapsedTimeMsIsNonNegative() {
+        EmulatedClock clock = new EmulatedClock(99);
+
+        // Force multiple cache refreshes to exercise the jitter code path.
+        for (int i = 0; i < 300; i++) {
+            clock.ElapsedTimeMs.Should().BeGreaterThanOrEqualTo(0.0);
+        }
     }
 }

--- a/tests/Spice86.Tests/CommandLineParserTests.cs
+++ b/tests/Spice86.Tests/CommandLineParserTests.cs
@@ -76,7 +76,7 @@ public class CommandLineParserTests {
             [
                 "-e", executablePath,
                 "--Cycles", "123",
-                "--InstructionsPerSecond", "456",
+                "--InstructionTimeScale", "456",
                 "--CpuHeavyLogDumpFile", "cpu-heavy.log"
             ];
 
@@ -87,7 +87,7 @@ public class CommandLineParserTests {
             configuration.Should().NotBeNull();
             Configuration nonNullConfiguration = configuration ?? throw new InvalidOperationException("Configuration should not be null.");
             nonNullConfiguration.Cycles.Should().Be(123);
-            nonNullConfiguration.InstructionsPerSecond.Should().BeNull();
+            nonNullConfiguration.InstructionTimeScale.Should().BeNull();
             nonNullConfiguration.CpuHeavyLog.Should().BeTrue();
             nonNullConfiguration.CpuHeavyLogDumpFile.Should().Be("cpu-heavy.log");
         } finally {

--- a/tests/Spice86.Tests/Dos/DosTestFixture.cs
+++ b/tests/Spice86.Tests/Dos/DosTestFixture.cs
@@ -56,7 +56,7 @@ public class DosTestFixture {
         A20Gate a20Gate = new(configuration.A20Gate);
         Memory = new(memoryBreakpoints, ram, a20Gate,
             initializeResetVector: configuration.InitializeDOS is true);
-        IEmulatedClock emulatedClock = new EmulatedClock();
+        IEmulatedClock emulatedClock = new EmulatedClock(null);
         DeviceScheduler emulationLoopScheduler = new(emulatedClock, LoggerService, "Emulation loop");
         EmulatorBreakpointsManager emulatorBreakpointsManager = new(pauseHandler, state, Memory, memoryBreakpoints, ioBreakpoints);
 

--- a/tests/Spice86.Tests/Emulator/Devices/ExternalInput/DeviceSchedulerTests.cs
+++ b/tests/Spice86.Tests/Emulator/Devices/ExternalInput/DeviceSchedulerTests.cs
@@ -21,7 +21,7 @@ public sealed class DeviceSchedulerTests {
         _logger = Substitute.For<ILoggerService>();
         _state = new State(CpuModel.INTEL_8086);
         // 1000 cycles = 1 second for simplicity in tests
-        _cyclesClock = new CyclesClock(_state, 1000);
+        _cyclesClock = new CyclesClock(_state, 1000, null);
         _scheduler = new DeviceScheduler(_cyclesClock, _logger, "Emulation loop");
     }
 

--- a/tests/Spice86.Tests/Emulator/Devices/ExternalInput/Pit8254Tests.cs
+++ b/tests/Spice86.Tests/Emulator/Devices/ExternalInput/Pit8254Tests.cs
@@ -32,7 +32,7 @@ public class Pit8254Tests {
         State state = new(CpuModel.INTEL_80286);
         _ioPortDispatcher = new IOPortDispatcher(new AddressReadWriteBreakpoints(), state, logger, false);
         var pic = new DualPic(_ioPortDispatcher, state, logger, false);
-        var emulatedClock = new EmulatedClock();
+        var emulatedClock = new EmulatedClock(null);
         var emulationLoopScheduler = new DeviceScheduler(emulatedClock, logger, "Emulation loop");
         _pit = new PitTimer(_ioPortDispatcher, state, pic, _speaker, emulationLoopScheduler, emulatedClock, logger, false);
     }

--- a/tests/Spice86.Tests/Emulator/Devices/ExternalInput/PitModeTests.cs
+++ b/tests/Spice86.Tests/Emulator/Devices/ExternalInput/PitModeTests.cs
@@ -31,7 +31,7 @@ public class PitModeTests {
         _speaker = Substitute.For<IPitSpeaker>();
         State state = new(CpuModel.INTEL_80286);
         _ioPortDispatcher = new IOPortDispatcher(new AddressReadWriteBreakpoints(), state, logger, false);
-        _clock = new EmulatedClock();
+        _clock = new EmulatedClock(null);
         var emulationLoopScheduler = new DeviceScheduler(_clock, logger, "Emulation loop");
         _pic = new DualPic(_ioPortDispatcher, state, logger, false);
         _pit = new PitTimer(_ioPortDispatcher, state, _pic, _speaker, emulationLoopScheduler, _clock, logger, false);

--- a/tests/Spice86.Tests/Emulator/Devices/ExternalInput/PitTimerTests.cs
+++ b/tests/Spice86.Tests/Emulator/Devices/ExternalInput/PitTimerTests.cs
@@ -57,7 +57,7 @@ public sealed class PitTimerTests {
             Dispatcher = new IOPortDispatcher(breakpoints, State, Logger, false);
             DualPic = new DualPic(Dispatcher, State, Logger, false);
             Speaker = new StubPitSpeaker();
-            var emulatedClock = new EmulatedClock();
+            var emulatedClock = new EmulatedClock(null);
             var emulationLoopScheduler = new DeviceScheduler(emulatedClock, Logger, "Emulation loop");
             PitTimer = new PitTimer(Dispatcher, State, DualPic, Speaker, emulationLoopScheduler, emulatedClock, Logger, false);
         }


### PR DESCRIPTION
### Description of Changes
Rename the CLI InstructionsPerSecond to InstructionTimeScale

Add small optional jitter to the emulated clock.

This allow deterministic clock like CycleClock to not let some programs get stuck in loops because for example timer interrupt never fires for the only instruction it can like here:
```
// imagine this is in a tight loop
1EFD:005B sti
1EFD:005C jmp short 0x005E
1EFD:005E cli
```