### PR TITLE
feat: Configurable emulator start time

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,7 @@ Spice86 -e program.exe --CpuHeavyLog --CpuHeavyLogDumpFile "C:\logs\cpu.log"
   -u, --UseCodeOverride              (Default: true) <true or false> if false it will use the names provided by overrideSupplierClassName but not the code
   -i, --InstructionTimeScale        <number of instructions that have to be executed by the emulator to consider a second passed> if blank will use time based timer.
   --ClockJitterSeed <CLOCKJITTERSEED> Optional integer seed enabling small deterministic clock jitter (±0.01 ms). Omit to disable.
+  --ClockStartTime <CLOCKSTARTTIME> Optional UTC start date/time for the emulated clock (parseable by DateTime.Parse, e.g. 1993-06-01T00:00:00Z). When omitted defaults to the current UTC time.
   -t, --TimeMultiplier               (Default: 1) <time multiplier> if >1 will go faster, if <1 will go slower.
   -h, --HeadlessMode [Mode]          (Default: false) Headless mode. The mode 'Minimal' does not use any UI components, 'Avalonia' uses the full UI and consumes a bit more memory.
   -l, --VerboseLogs                  (Default: false) Enable verbose level logs

--- a/docs/index.html
+++ b/docs/index.html
@@ -638,6 +638,7 @@ Spice86 -e game.exe</code></pre>
           <tr><td><code>--Cycles</code></td><td>—</td><td>Target CPU cycles per ms (unset = no limit). Overrides <code>--InstructionTimeScale</code> when set.</td></tr>
           <tr><td><code>-i, --InstructionTimeScale</code></td><td>—</td><td>Instruction-based timer; blank = real-time timer</td></tr>
           <tr><td><code>--ClockJitterSeed</code></td><td>—</td><td>Optional integer seed enabling small deterministic clock jitter (±0.01 ms). Omit to disable.</td></tr>
+          <tr><td><code>--ClockStartTime</code></td><td>—</td><td>Optional UTC start date/time for the emulated clock (parseable by <code>DateTime.Parse</code>, e.g. <code>1993-06-01T00:00:00Z</code>). When omitted defaults to current UTC time.</td></tr>
           <tr><td><code>-t, --TimeMultiplier</code></td><td>1</td><td>Real-time speed multiplier (&gt;1 faster, &lt;1 slower)</td></tr>
         </tbody>
       </table>

--- a/src/Spice86.Core/CLI/Configuration.cs
+++ b/src/Spice86.Core/CLI/Configuration.cs
@@ -125,6 +125,15 @@ public sealed class Configuration : CommandSettings {
     public int? ClockJitterSeed { get; init; }
 
     /// <summary>
+    /// Optional fixed start date/time for the emulated clock. Accepts any value parseable by
+    /// <see cref="DateTimeOffset.Parse(string)"/> (e.g. an ISO 8601 string like
+    /// <c>1993-06-01T00:00:00Z</c>). When <c>null</c> (the default), the emulated clock starts
+    /// from <see cref="DateTimeOffset.UtcNow"/> at launch time.
+    /// </summary>
+    [CommandOption("--ClockStartTime <CLOCKSTARTTIME>")]
+    public DateTimeOffset? ClockStartTime { get; init; }
+
+    /// <summary>
     /// The time multiplier used for speeding up or slowing down the execution of the program.
     /// </summary>
     [CommandOption("-t|--TimeMultiplier <TIMEMULTIPLIER>")]

--- a/src/Spice86.Core/Emulator/Devices/Cmos/RealTimeClock.cs
+++ b/src/Spice86.Core/Emulator/Devices/Cmos/RealTimeClock.cs
@@ -212,7 +212,7 @@ public sealed class RealTimeClock : DefaultIOPortHandler, IDisposable {
             return 0xFF;
         }
 
-        DateTime now = _clock.CurrentDateTime;
+        DateTimeOffset now = _clock.CurrentDateTime;
         switch (reg) {
             case CmosRegisterAddresses.Seconds: return EncodeTimeComponent(now.Second);
             case CmosRegisterAddresses.Minutes: return EncodeTimeComponent(now.Minute);
@@ -387,7 +387,7 @@ public sealed class RealTimeClock : DefaultIOPortHandler, IDisposable {
     /// within 2ms of the next second boundary.
     /// </para>
     /// </summary>
-    private bool IsUpdateInProgress(DateTime now) {
+    private bool IsUpdateInProgress(DateTimeOffset now) {
         double msInSecond = now.TimeOfDay.TotalMilliseconds % 1000.0;
         return msInSecond >= 998.0 || msInSecond < 2.0;
     }

--- a/src/Spice86.Core/Emulator/InterruptHandlers/SystemClock/SystemClockInt1AHandler.cs
+++ b/src/Spice86.Core/Emulator/InterruptHandlers/SystemClock/SystemClockInt1AHandler.cs
@@ -90,7 +90,7 @@ public class SystemClockInt1AHandler : InterruptHandler {
             LoggerService.Verbose("INT 1A, AH=02h - Read Time from RTC");
         }
 
-        DateTime now = _realTimeClock.Clock.CurrentDateTime;
+        DateTimeOffset now = _realTimeClock.Clock.CurrentDateTime;
         State.CH = BcdConverter.ToBcd((byte)now.Hour);
         State.CL = BcdConverter.ToBcd((byte)now.Minute);
         State.DH = BcdConverter.ToBcd((byte)now.Second);
@@ -119,7 +119,7 @@ public class SystemClockInt1AHandler : InterruptHandler {
             LoggerService.Verbose("INT 1A, AH=04h - Read Date from RTC");
         }
 
-        DateTime now = _realTimeClock.Clock.CurrentDateTime;
+        DateTimeOffset now = _realTimeClock.Clock.CurrentDateTime;
         State.CH = BcdConverter.ToBcd((byte)(now.Year / 100));
         State.CL = BcdConverter.ToBcd((byte)(now.Year % 100));
         State.DH = BcdConverter.ToBcd((byte)now.Month);

--- a/src/Spice86.Core/Emulator/VM/Clock/ClockBase.cs
+++ b/src/Spice86.Core/Emulator/VM/Clock/ClockBase.cs
@@ -11,22 +11,21 @@ public abstract class ClockBase : IEmulatedClock {
     private protected readonly ClockJitter _jitter;
 
     /// <summary>
-    /// Initialises the clock with the given jitter source and sets <see cref="StartTime"/> to
-    /// <see cref="DateTime.UtcNow"/>.
+    /// Initialises the clock with the given jitter source and start time.
     /// </summary>
-    private protected ClockBase(ClockJitter jitter) {
+    private protected ClockBase(ClockJitter jitter, DateTimeOffset startTime) {
         _jitter = jitter;
-        StartTime = DateTime.UtcNow;
+        StartTime = startTime;
     }
 
     /// <inheritdoc/>
     public abstract double ElapsedTimeMs { get; }
 
     /// <inheritdoc/>
-    public DateTime StartTime { get; set; }
+    public DateTimeOffset StartTime { get; set; }
 
     /// <inheritdoc/>
-    public DateTime CurrentDateTime => StartTime.AddMilliseconds(ElapsedTimeMs);
+    public DateTimeOffset CurrentDateTime => StartTime.AddMilliseconds(ElapsedTimeMs);
 
     /// <inheritdoc/>
     public bool IsPaused => _isPaused || _isDisposed;

--- a/src/Spice86.Core/Emulator/VM/Clock/CyclesClock.cs
+++ b/src/Spice86.Core/Emulator/VM/Clock/CyclesClock.cs
@@ -8,8 +8,8 @@ using Spice86.Core.Emulator.CPU;
 public class CyclesClock : ClockBase {
     private readonly State _cpuState;
 
-    public CyclesClock(State cpuState, long cyclesPerSecond, int? jitterSeed)
-        : base(ClockJitter.Create(jitterSeed)) {
+    public CyclesClock(State cpuState, long cyclesPerSecond, int? jitterSeed, DateTimeOffset startTime)
+        : base(ClockJitter.Create(jitterSeed), startTime) {
         _cpuState = cpuState;
         CyclesPerSecond = cyclesPerSecond;
     }

--- a/src/Spice86.Core/Emulator/VM/Clock/EmulatedClock.cs
+++ b/src/Spice86.Core/Emulator/VM/Clock/EmulatedClock.cs
@@ -9,8 +9,8 @@ public class EmulatedClock : ClockBase {
     private int _ticks;
     private readonly Stopwatch _stopwatch = new();
 
-    public EmulatedClock(int? jitterSeed)
-        : base(ClockJitter.Create(jitterSeed)) {
+    public EmulatedClock(int? jitterSeed, DateTimeOffset startTime)
+        : base(ClockJitter.Create(jitterSeed), startTime) {
         _stopwatch.Start();
     }
 

--- a/src/Spice86.Core/Emulator/VM/Clock/IEmulatedClock.cs
+++ b/src/Spice86.Core/Emulator/VM/Clock/IEmulatedClock.cs
@@ -13,12 +13,12 @@ public interface IEmulatedClock : IDisposable {
     /// Gets or sets the start time for the emulated clock.
     /// This represents the initial date/time from which CurrentDateTime is calculated.
     /// </summary>
-    DateTime StartTime { get; set; }
+    DateTimeOffset StartTime { get; set; }
 
     /// <summary>
     /// Gets the current date and time, calculated as StartTime + TimeSpan.FromMilliseconds(ElapsedTimeMs).
     /// </summary>
-    DateTime CurrentDateTime { get; }
+    DateTimeOffset CurrentDateTime { get; }
 
     /// <summary>
     /// Gets a value indicating whether the clock is currently paused or has been disposed.

--- a/src/Spice86/Spice86DependencyInjection.cs
+++ b/src/Spice86/Spice86DependencyInjection.cs
@@ -193,9 +193,10 @@ public class Spice86DependencyInjection : IDisposable {
             loggerService.Information("BIOS data area created...");
         }
 
+        DateTimeOffset clockStartTime = configuration.ClockStartTime ?? DateTimeOffset.UtcNow;
         _emulatedClock = configuration.InstructionTimeScale != null
-            ? new CyclesClock(state, configuration.InstructionTimeScale.Value, configuration.ClockJitterSeed)
-            : new EmulatedClock(configuration.ClockJitterSeed);
+            ? new CyclesClock(state, configuration.InstructionTimeScale.Value, configuration.ClockJitterSeed, clockStartTime)
+            : new EmulatedClock(configuration.ClockJitterSeed, clockStartTime);
         // Register clock and limiter to pause/resume events
         pauseHandler.Pausing += () => _emulatedClock.OnPause();
         pauseHandler.Resumed += () => _emulatedClock.OnResume();

--- a/tests/Spice86.Tests/ClockTests.cs
+++ b/tests/Spice86.Tests/ClockTests.cs
@@ -18,33 +18,31 @@ public class ClockTests {
     public void CyclesClock_CurrentDateTime_ShouldReflectStartTimePlusElapsed() {
         // Arrange
         State state = new State(CpuModel.INTEL_80286);
-        CyclesClock clock = new CyclesClock(state, 1000, null); // 1000 cycles per second
-        DateTime startTime = new DateTime(2000, 1, 1, 12, 0, 0, DateTimeKind.Utc);
-        clock.StartTime = startTime;
+        DateTimeOffset startTime = new DateTimeOffset(2000, 1, 1, 12, 0, 0, TimeSpan.Zero);
+        CyclesClock clock = new CyclesClock(state, 1000, null, startTime); // 1000 cycles per second
 
         // Act - simulate 2000 cycles (2 seconds)
         for (int i = 0; i < 2000; i++) {
             state.IncCycles();
         }
-        DateTime currentDateTime = clock.CurrentDateTime;
+        DateTimeOffset currentDateTime = clock.CurrentDateTime;
 
         // Assert
-        DateTime expectedDateTime = startTime.AddSeconds(2);
+        DateTimeOffset expectedDateTime = startTime.AddSeconds(2);
         currentDateTime.Should().BeCloseTo(expectedDateTime, TimeSpan.FromMilliseconds(100));
     }
 
     /// <summary>
-    /// Tests that EmulatedClock StartTime can be set and CurrentDateTime is calculated correctly.
+    /// Tests that EmulatedClock constructed with a start time correctly reports CurrentDateTime.
     /// </summary>
     [Fact]
     public void EmulatedClock_StartTime_CanBeSetAndCurrentDateTimeCalculated() {
         // Arrange
-        DateTime startTime = new DateTime(2000, 1, 1, 12, 0, 0, DateTimeKind.Utc);
-        EmulatedClock clock = new EmulatedClock(null);
+        DateTimeOffset startTime = new DateTimeOffset(2000, 1, 1, 12, 0, 0, TimeSpan.Zero);
+        EmulatedClock clock = new EmulatedClock(null, startTime);
         
         // Act
-        clock.StartTime = startTime;
-        DateTime currentDateTime = clock.CurrentDateTime;
+        DateTimeOffset currentDateTime = clock.CurrentDateTime;
 
         // Assert - CurrentDateTime should be StartTime plus elapsed time
         // Since the stopwatch has been running, it should be after StartTime
@@ -52,18 +50,17 @@ public class ClockTests {
     }
 
     /// <summary>
-    /// Tests that StartTime can be set and retrieved correctly.
+    /// Tests that CyclesClock constructed with a start time stores and retrieves it correctly.
     /// </summary>
     [Fact]
     public void Clock_StartTime_CanBeSetAndRetrieved() {
         // Arrange
         State state = new State(CpuModel.INTEL_80286);
-        CyclesClock clock = new CyclesClock(state, 1000, null);
-        DateTime expectedStartTime = new DateTime(2000, 1, 1, 12, 0, 0, DateTimeKind.Utc);
+        DateTimeOffset expectedStartTime = new DateTimeOffset(2000, 1, 1, 12, 0, 0, TimeSpan.Zero);
+        CyclesClock clock = new CyclesClock(state, 1000, null, expectedStartTime);
 
         // Act
-        clock.StartTime = expectedStartTime;
-        DateTime actualStartTime = clock.StartTime;
+        DateTimeOffset actualStartTime = clock.StartTime;
 
         // Assert
         actualStartTime.Should().Be(expectedStartTime);
@@ -76,7 +73,7 @@ public class ClockTests {
     public void Clock_OnPauseAndOnResume_ShouldNotThrow() {
         // Arrange
         State state = new State(CpuModel.INTEL_80286);
-        CyclesClock clock = new CyclesClock(state, 1000, null);
+        CyclesClock clock = new CyclesClock(state, 1000, null, DateTimeOffset.UnixEpoch);
 
         // Act
         Action act = () => {
@@ -94,7 +91,7 @@ public class ClockTests {
     [Fact]
     public void CyclesClock_WithNullSeed_ReturnsExactBaselineTime() {
         State state = new State(CpuModel.INTEL_80286);
-        CyclesClock clock = new CyclesClock(state, 1000, null);
+        CyclesClock clock = new CyclesClock(state, 1000, null, DateTimeOffset.UnixEpoch);
         for (int i = 0; i < 1000; i++) {
             state.IncCycles();
         }
@@ -110,8 +107,8 @@ public class ClockTests {
     public void CyclesClock_WithSeed_AddsBoundedJitterToBaselineTime() {
         State stateBase = new State(CpuModel.INTEL_80286);
         State stateJitter = new State(CpuModel.INTEL_80286);
-        CyclesClock clockBase = new CyclesClock(stateBase, 1000, null);
-        CyclesClock clockJitter = new CyclesClock(stateJitter, 1000, 42);
+        CyclesClock clockBase = new CyclesClock(stateBase, 1000, null, DateTimeOffset.UnixEpoch);
+        CyclesClock clockJitter = new CyclesClock(stateJitter, 1000, 42, DateTimeOffset.UnixEpoch);
 
         for (int i = 0; i < 1000; i++) {
             stateBase.IncCycles();
@@ -130,14 +127,14 @@ public class ClockTests {
     [Fact]
     public void CyclesClock_WithSameSeed_ProducesReproducibleJitter() {
         State state1 = new State(CpuModel.INTEL_80286);
-        CyclesClock clock1 = new CyclesClock(state1, 1000, 12345);
+        CyclesClock clock1 = new CyclesClock(state1, 1000, 12345, DateTimeOffset.UnixEpoch);
         for (int i = 0; i < 1000; i++) {
             state1.IncCycles();
         }
         double time1 = clock1.ElapsedTimeMs;
 
         State state2 = new State(CpuModel.INTEL_80286);
-        CyclesClock clock2 = new CyclesClock(state2, 1000, 12345);
+        CyclesClock clock2 = new CyclesClock(state2, 1000, 12345, DateTimeOffset.UnixEpoch);
         for (int i = 0; i < 1000; i++) {
             state2.IncCycles();
         }
@@ -154,9 +151,9 @@ public class ClockTests {
         State baseState = new State(CpuModel.INTEL_80286);
         State state1 = new State(CpuModel.INTEL_80286);
         State state2 = new State(CpuModel.INTEL_80286);
-        CyclesClock baseClock = new CyclesClock(baseState, 1000, null);
-        CyclesClock clock1 = new CyclesClock(state1, 1000, 1);
-        CyclesClock clock2 = new CyclesClock(state2, 1000, 2);
+        CyclesClock baseClock = new CyclesClock(baseState, 1000, null, DateTimeOffset.UnixEpoch);
+        CyclesClock clock1 = new CyclesClock(state1, 1000, 1, DateTimeOffset.UnixEpoch);
+        CyclesClock clock2 = new CyclesClock(state2, 1000, 2, DateTimeOffset.UnixEpoch);
 
         for (int i = 0; i < 1000; i++) {
             baseState.IncCycles();
@@ -176,7 +173,7 @@ public class ClockTests {
     /// </summary>
     [Fact]
     public void EmulatedClock_WithSeed_ElapsedTimeMsIsNonNegative() {
-        EmulatedClock clock = new EmulatedClock(99);
+        EmulatedClock clock = new EmulatedClock(99, DateTimeOffset.UnixEpoch);
 
         // Force multiple cache refreshes to exercise the jitter code path.
         for (int i = 0; i < 300; i++) {

--- a/tests/Spice86.Tests/CommandLineParserTests.cs
+++ b/tests/Spice86.Tests/CommandLineParserTests.cs
@@ -107,6 +107,31 @@ public class CommandLineParserTests {
         configuration.Should().BeNull();
     }
 
+    [Fact]
+    public void ParseCommandLine_ClockStartTime_IsoUtcString_ParsedAsUtcOffset() {
+        // Arrange
+        string executablePath = CreateTemporaryExecutablePath();
+        try {
+            string[] args =
+            [
+                "-e", executablePath,
+                "--ClockStartTime", "1993-06-01T00:00:00Z"
+            ];
+
+            // Act
+            Configuration? configuration = Parse(args);
+
+            // Assert
+            configuration.Should().NotBeNull();
+            Configuration nonNullConfiguration = configuration ?? throw new InvalidOperationException("Configuration should not be null.");
+            nonNullConfiguration.ClockStartTime.Should().NotBeNull();
+            DateTimeOffset clockStartTime = nonNullConfiguration.ClockStartTime ?? throw new InvalidOperationException("ClockStartTime should not be null.");
+            clockStartTime.Should().Be(new DateTimeOffset(1993, 6, 1, 0, 0, 0, TimeSpan.Zero));
+        } finally {
+            File.Delete(executablePath);
+        }
+    }
+
     private static Configuration? Parse(string[] args) {
         CommandLineParser parser = new();
         return parser.ParseCommandLine(args);

--- a/tests/Spice86.Tests/Dos/DosTestFixture.cs
+++ b/tests/Spice86.Tests/Dos/DosTestFixture.cs
@@ -56,7 +56,7 @@ public class DosTestFixture {
         A20Gate a20Gate = new(configuration.A20Gate);
         Memory = new(memoryBreakpoints, ram, a20Gate,
             initializeResetVector: configuration.InitializeDOS is true);
-        IEmulatedClock emulatedClock = new EmulatedClock(null);
+        IEmulatedClock emulatedClock = new EmulatedClock(null, DateTimeOffset.UnixEpoch);
         DeviceScheduler emulationLoopScheduler = new(emulatedClock, LoggerService, "Emulation loop");
         EmulatorBreakpointsManager emulatorBreakpointsManager = new(pauseHandler, state, Memory, memoryBreakpoints, ioBreakpoints);
 

--- a/tests/Spice86.Tests/Emulator/Devices/ExternalInput/DeviceSchedulerTests.cs
+++ b/tests/Spice86.Tests/Emulator/Devices/ExternalInput/DeviceSchedulerTests.cs
@@ -21,7 +21,7 @@ public sealed class DeviceSchedulerTests {
         _logger = Substitute.For<ILoggerService>();
         _state = new State(CpuModel.INTEL_8086);
         // 1000 cycles = 1 second for simplicity in tests
-        _cyclesClock = new CyclesClock(_state, 1000, null);
+        _cyclesClock = new CyclesClock(_state, 1000, null, DateTimeOffset.UnixEpoch);
         _scheduler = new DeviceScheduler(_cyclesClock, _logger, "Emulation loop");
     }
 

--- a/tests/Spice86.Tests/Emulator/Devices/ExternalInput/Pit8254Tests.cs
+++ b/tests/Spice86.Tests/Emulator/Devices/ExternalInput/Pit8254Tests.cs
@@ -32,7 +32,7 @@ public class Pit8254Tests {
         State state = new(CpuModel.INTEL_80286);
         _ioPortDispatcher = new IOPortDispatcher(new AddressReadWriteBreakpoints(), state, logger, false);
         var pic = new DualPic(_ioPortDispatcher, state, logger, false);
-        var emulatedClock = new EmulatedClock(null);
+        EmulatedClock emulatedClock = new EmulatedClock(null, DateTimeOffset.UnixEpoch);
         var emulationLoopScheduler = new DeviceScheduler(emulatedClock, logger, "Emulation loop");
         _pit = new PitTimer(_ioPortDispatcher, state, pic, _speaker, emulationLoopScheduler, emulatedClock, logger, false);
     }

--- a/tests/Spice86.Tests/Emulator/Devices/ExternalInput/PitModeTests.cs
+++ b/tests/Spice86.Tests/Emulator/Devices/ExternalInput/PitModeTests.cs
@@ -31,7 +31,7 @@ public class PitModeTests {
         _speaker = Substitute.For<IPitSpeaker>();
         State state = new(CpuModel.INTEL_80286);
         _ioPortDispatcher = new IOPortDispatcher(new AddressReadWriteBreakpoints(), state, logger, false);
-        _clock = new EmulatedClock(null);
+        _clock = new EmulatedClock(null, DateTimeOffset.UnixEpoch);
         var emulationLoopScheduler = new DeviceScheduler(_clock, logger, "Emulation loop");
         _pic = new DualPic(_ioPortDispatcher, state, logger, false);
         _pit = new PitTimer(_ioPortDispatcher, state, _pic, _speaker, emulationLoopScheduler, _clock, logger, false);

--- a/tests/Spice86.Tests/Emulator/Devices/ExternalInput/PitTimerTests.cs
+++ b/tests/Spice86.Tests/Emulator/Devices/ExternalInput/PitTimerTests.cs
@@ -57,7 +57,7 @@ public sealed class PitTimerTests {
             Dispatcher = new IOPortDispatcher(breakpoints, State, Logger, false);
             DualPic = new DualPic(Dispatcher, State, Logger, false);
             Speaker = new StubPitSpeaker();
-            var emulatedClock = new EmulatedClock(null);
+            EmulatedClock emulatedClock = new EmulatedClock(null, DateTimeOffset.UnixEpoch);
             var emulationLoopScheduler = new DeviceScheduler(emulatedClock, Logger, "Emulation loop");
             PitTimer = new PitTimer(Dispatcher, State, DualPic, Speaker, emulationLoopScheduler, emulatedClock, Logger, false);
         }


### PR DESCRIPTION
### Description of Changes
Allow changing the start date of the emulator. This helps getting reproducible CPU logs.
This also helps if an application didnt expect to be started so far in the future :)