### PR TITLE
Fix/disasm: more inline evaluators (LDS, LES, LEA, CALL FAR)

### DIFF
--- a/src/Spice86/ViewModels/Services/ExpressionEvaluationService.cs
+++ b/src/Spice86/ViewModels/Services/ExpressionEvaluationService.cs
@@ -40,7 +40,7 @@ public class ExpressionEvaluationService {
                 Register reg = instruction.GetOpRegister(i);
                 string? expr = RegisterToExpression(reg);
                 if (expr != null) {
-                    long value = _compiler.CompileValue(expr)();
+                    uint value = _compiler.CompileValue(expr)();
                     if (segments.Count > 0) {
                         AddSeparator(segments);
                     }
@@ -51,7 +51,7 @@ public class ExpressionEvaluationService {
                 if (isLea) {
                     string? addressExpr = BuildAddressExpression(instruction);
                     if (addressExpr != null) {
-                        long value = _compiler.CompileValue(addressExpr)();
+                        uint value = _compiler.CompileValue(addressExpr)();
                         if (segments.Count > 0) {
                             AddSeparator(segments);
                         }
@@ -60,7 +60,7 @@ public class ExpressionEvaluationService {
                 } else {
                     string? expr = BuildMemoryExpression(instruction);
                     if (expr != null) {
-                        long value = _compiler.CompileValue(expr)();
+                        uint value = _compiler.CompileValue(expr)();
                         if (segments.Count > 0) {
                             AddSeparator(segments);
                         }

--- a/src/Spice86/ViewModels/Services/ExpressionEvaluationService.cs
+++ b/src/Spice86/ViewModels/Services/ExpressionEvaluationService.cs
@@ -47,13 +47,25 @@ public class ExpressionEvaluationService {
                     AddRegisterValue(segments, expr.ToUpperInvariant(), value, GetRegisterBitWidth(reg));
                 }
             } else if (kind == OpKind.Memory) {
-                string? expr = BuildMemoryExpression(instruction);
-                if (expr != null) {
-                    long value = _compiler.CompileValue(expr)();
-                    if (segments.Count > 0) {
-                        AddSeparator(segments);
+                bool isLea = instruction.Mnemonic == Mnemonic.Lea;
+                if (isLea) {
+                    string? addressExpr = BuildAddressExpression(instruction);
+                    if (addressExpr != null) {
+                        long value = _compiler.CompileValue(addressExpr)();
+                        if (segments.Count > 0) {
+                            AddSeparator(segments);
+                        }
+                        AddAddressValue(segments, instruction, value, GetRegisterBitWidth(instruction.GetOpRegister(0)));
                     }
-                    AddMemoryValue(segments, instruction, value, GetMemorySizeBitWidth(instruction.MemorySize));
+                } else {
+                    string? expr = BuildMemoryExpression(instruction);
+                    if (expr != null) {
+                        long value = _compiler.CompileValue(expr)();
+                        if (segments.Count > 0) {
+                            AddSeparator(segments);
+                        }
+                        AddMemoryValue(segments, instruction, value, GetMemorySizeBitWidth(instruction.MemorySize));
+                    }
                 }
             }
             // Immediate and branch operands are skipped (already visible in disassembly text)
@@ -68,6 +80,12 @@ public class ExpressionEvaluationService {
 
     private static void AddRegisterValue(List<FormattedTextToken> segments, string name, long value, int bitWidth) {
         segments.Add(new FormattedTextToken { Text = name, Kind = FormatterTextKind.Register });
+        segments.Add(new FormattedTextToken { Text = "=", Kind = FormatterTextKind.Punctuation });
+        segments.Add(new FormattedTextToken { Text = FormatHex(value, bitWidth), Kind = FormatterTextKind.Number });
+    }
+
+    private static void AddAddressValue(List<FormattedTextToken> segments, Instruction instruction, long value, int bitWidth) {
+        segments.Add(new FormattedTextToken { Text = "addr", Kind = FormatterTextKind.Keyword });
         segments.Add(new FormattedTextToken { Text = "=", Kind = FormatterTextKind.Punctuation });
         segments.Add(new FormattedTextToken { Text = FormatHex(value, bitWidth), Kind = FormatterTextKind.Number });
     }
@@ -112,14 +130,36 @@ public class ExpressionEvaluationService {
 
     private static string? RegisterToExpression(Register register) {
         return register switch {
-            Register.AL => "al", Register.CL => "cl", Register.DL => "dl", Register.BL => "bl",
-            Register.AH => "ah", Register.CH => "ch", Register.DH => "dh", Register.BH => "bh",
-            Register.AX => "ax", Register.CX => "cx", Register.DX => "dx", Register.BX => "bx",
-            Register.SP => "sp", Register.BP => "bp", Register.SI => "si", Register.DI => "di",
-            Register.EAX => "eax", Register.ECX => "ecx", Register.EDX => "edx", Register.EBX => "ebx",
-            Register.ESP => "esp", Register.EBP => "ebp", Register.ESI => "esi", Register.EDI => "edi",
-            Register.ES => "es", Register.CS => "cs", Register.SS => "ss", Register.DS => "ds",
-            Register.FS => "fs", Register.GS => "gs",
+            Register.AL => "al",
+            Register.CL => "cl",
+            Register.DL => "dl",
+            Register.BL => "bl",
+            Register.AH => "ah",
+            Register.CH => "ch",
+            Register.DH => "dh",
+            Register.BH => "bh",
+            Register.AX => "ax",
+            Register.CX => "cx",
+            Register.DX => "dx",
+            Register.BX => "bx",
+            Register.SP => "sp",
+            Register.BP => "bp",
+            Register.SI => "si",
+            Register.DI => "di",
+            Register.EAX => "eax",
+            Register.ECX => "ecx",
+            Register.EDX => "edx",
+            Register.EBX => "ebx",
+            Register.ESP => "esp",
+            Register.EBP => "ebp",
+            Register.ESI => "esi",
+            Register.EDI => "edi",
+            Register.ES => "es",
+            Register.CS => "cs",
+            Register.SS => "ss",
+            Register.DS => "ds",
+            Register.FS => "fs",
+            Register.GS => "gs",
             _ => null
         };
     }
@@ -158,7 +198,23 @@ public class ExpressionEvaluationService {
             return null;
         }
 
+        string addressExpr = BuildAddressExpressionCore(instruction);
+
         string? segment = RegisterToExpression(instruction.MemorySegment);
+        return segment != null
+            ? $"{sizePrefix} ptr {segment}:[{addressExpr}]"
+            : $"{sizePrefix} ptr [{addressExpr}]";
+    }
+
+    /// <summary>
+    /// Builds an arithmetic expression for the effective address (offset only, no memory dereference).
+    /// Used by LEA to compute the address without reading memory.
+    /// </summary>
+    private static string? BuildAddressExpression(Instruction instruction) {
+        return BuildAddressExpressionCore(instruction);
+    }
+
+    private static string BuildAddressExpressionCore(Instruction instruction) {
 
         List<string> addressParts = new();
 
@@ -179,9 +235,7 @@ public class ExpressionEvaluationService {
 
         string addressExpr = string.Join(" + ", addressParts);
 
-        return segment != null
-            ? $"{sizePrefix} ptr {segment}:[{addressExpr}]"
-            : $"{sizePrefix} ptr [{addressExpr}]";
+        return addressExpr;
     }
 
     private static string FormatHex(long value, int bitWidth) {

--- a/src/Spice86/ViewModels/Services/ExpressionEvaluationService.cs
+++ b/src/Spice86/ViewModels/Services/ExpressionEvaluationService.cs
@@ -178,7 +178,7 @@ public class ExpressionEvaluationService {
         return size switch {
             MemorySize.UInt8 or MemorySize.Int8 => "byte",
             MemorySize.UInt16 or MemorySize.Int16 => "word",
-            MemorySize.UInt32 or MemorySize.Int32 => "dword",
+            MemorySize.UInt32 or MemorySize.Int32 or MemorySize.SegPtr16 => "dword",
             _ => null
         };
     }
@@ -187,7 +187,7 @@ public class ExpressionEvaluationService {
         return size switch {
             MemorySize.UInt8 or MemorySize.Int8 => 8,
             MemorySize.UInt16 or MemorySize.Int16 => 16,
-            MemorySize.UInt32 or MemorySize.Int32 => 32,
+            MemorySize.UInt32 or MemorySize.Int32 or MemorySize.SegPtr16 => 32,
             _ => 16
         };
     }

--- a/src/Spice86/ViewModels/Services/ExpressionEvaluationService.cs
+++ b/src/Spice86/ViewModels/Services/ExpressionEvaluationService.cs
@@ -55,7 +55,7 @@ public class ExpressionEvaluationService {
                         if (segments.Count > 0) {
                             AddSeparator(segments);
                         }
-                        AddAddressValue(segments, instruction, value, GetRegisterBitWidth(instruction.GetOpRegister(0)));
+                        AddAddressValue(segments, value, GetRegisterBitWidth(instruction.GetOpRegister(0)));
                     }
                 } else {
                     string? expr = BuildMemoryExpression(instruction);
@@ -84,7 +84,7 @@ public class ExpressionEvaluationService {
         segments.Add(new FormattedTextToken { Text = FormatHex(value, bitWidth), Kind = FormatterTextKind.Number });
     }
 
-    private static void AddAddressValue(List<FormattedTextToken> segments, Instruction instruction, long value, int bitWidth) {
+    private static void AddAddressValue(List<FormattedTextToken> segments, long value, int bitWidth) {
         segments.Add(new FormattedTextToken { Text = "addr", Kind = FormatterTextKind.Keyword });
         segments.Add(new FormattedTextToken { Text = "=", Kind = FormatterTextKind.Punctuation });
         segments.Add(new FormattedTextToken { Text = FormatHex(value, bitWidth), Kind = FormatterTextKind.Number });

--- a/tests/Spice86.Tests/UI/ExpressionEvaluatorUITests.cs
+++ b/tests/Spice86.Tests/UI/ExpressionEvaluatorUITests.cs
@@ -194,4 +194,76 @@ public class ExpressionEvaluatorUITests : BreakpointUiTestBase {
         // Verify displacement operator is syntax-colored
         evaluated.Should().Contain(s => s.Text == "+" && s.Kind == FormatterTextKind.Operator);
     }
+
+    /// <summary>
+    /// Verifies that LEA computes the effective address instead of reading memory.
+    /// ASM: lea ax, [bp-8] (opcode 8D 46 F8) — should show computed address, not memory contents.
+    /// </summary>
+    [AvaloniaFact]
+    public void EvaluateOperands_LeaAxBpMinus8_ShowsEffectiveAddress() {
+        // Arrange
+        State state = CreateState();
+        (Memory memory, _, _) = CreateMemory();
+
+        state.AX = 0x1111;
+        state.BP = 0x0100;
+        state.SS = 0x2000;
+
+        // Write decoy data at effective address — LEA must NOT read this
+        uint physicalAddress = (uint)(state.SS * 16 + state.BP - 8);
+        memory.UInt16[physicalAddress] = 0xDEAD;
+
+        // x86 16-bit encoding: lea ax, [bp-8] → 8D 46 F8
+        byte[] machineCode = [0x8D, 0x46, 0xF8];
+        SegmentedAddress address = new(0x1000, 0x0100);
+        DebuggerLineViewModel line = CreateDebuggerLine(machineCode, address);
+
+        ExpressionEvaluationService service = new(state, memory);
+
+        // Act
+        List<FormattedTextToken>? evaluated = service.FormatOperandValues(line.InstructionInfo);
+
+        // Assert
+        evaluated.Should().NotBeNullOrEmpty();
+        string text = SegmentsToText(evaluated!);
+
+        // LEA should show effective address = BP - 8 = 0x0100 - 8 = 0x00F8
+        text.Should().Contain("0x00F8");
+        // LEA must NOT show the memory contents 0xDEAD
+        text.Should().NotContain("DEAD");
+        // AX register value should still be shown
+        text.Should().Contain("AX=0x1111");
+    }
+
+    /// <summary>
+    /// Verifies LEA with base+index computes the effective address.
+    /// ASM: lea ax, [bx+si] (opcode 8D 00)
+    /// </summary>
+    [AvaloniaFact]
+    public void EvaluateOperands_LeaAxBxSi_ShowsEffectiveAddress() {
+        // Arrange
+        State state = CreateState();
+        (Memory memory, _, _) = CreateMemory();
+
+        state.AX = 0x0000;
+        state.BX = 0x0030;
+        state.SI = 0x0010;
+        state.DS = 0x2000;
+
+        // x86 16-bit encoding: lea ax, [bx+si] → 8D 00
+        byte[] machineCode = [0x8D, 0x00];
+        SegmentedAddress address = new(0x1000, 0x0100);
+        DebuggerLineViewModel line = CreateDebuggerLine(machineCode, address);
+
+        ExpressionEvaluationService service = new(state, memory);
+
+        // Act
+        List<FormattedTextToken>? evaluated = service.FormatOperandValues(line.InstructionInfo);
+
+        // Assert
+        evaluated.Should().NotBeNullOrEmpty();
+        string text = SegmentsToText(evaluated!);
+        // Effective address = BX + SI = 0x0030 + 0x0010 = 0x0040
+        text.Should().Contain("0x0040");
+    }
 }

--- a/tests/Spice86.Tests/UI/ExpressionEvaluatorUITests.cs
+++ b/tests/Spice86.Tests/UI/ExpressionEvaluatorUITests.cs
@@ -266,4 +266,78 @@ public class ExpressionEvaluatorUITests : BreakpointUiTestBase {
         // Effective address = BX + SI = 0x0030 + 0x0010 = 0x0040
         text.Should().Contain("0x0040");
     }
+
+    /// <summary>
+    /// Verifies that LDS evaluates the far pointer memory operand (dword containing offset:segment).
+    /// ASM: lds si, ss:[bp+0x10] (opcode C5 76 10) — should show the dword value at memory.
+    /// </summary>
+    [AvaloniaFact]
+    public void EvaluateOperands_LdsSiBpPlus10_ShowsFarPointerValue() {
+        // Arrange
+        State state = CreateState();
+        (Memory memory, _, _) = CreateMemory();
+
+        state.SI = 0x0000;
+        state.BP = 0x0984;
+        state.SS = 0x2F23;
+        state.DS = 0x261F;
+
+        // Write a far pointer (offset:segment) at SS:BP+0x10
+        uint physicalAddress = (uint)(state.SS * 16 + state.BP + 0x10);
+        memory.UInt16[physicalAddress] = 0x1234;       // offset
+        memory.UInt16[physicalAddress + 2] = 0x5678;   // segment
+
+        // x86 16-bit encoding: lds si, [bp+0x10] → C5 76 10
+        byte[] machineCode = [0xC5, 0x76, 0x10];
+        SegmentedAddress address = new(0x1000, 0x0100);
+        DebuggerLineViewModel line = CreateDebuggerLine(machineCode, address);
+
+        ExpressionEvaluationService service = new(state, memory);
+
+        // Act
+        List<FormattedTextToken>? evaluated = service.FormatOperandValues(line.InstructionInfo);
+
+        // Assert
+        evaluated.Should().NotBeNullOrEmpty();
+        string text = SegmentsToText(evaluated!);
+        // Should show the dword value read from memory (segment:offset packed as dword)
+        text.Should().Contain("0x56781234");
+        // SI register value should also be shown
+        text.Should().Contain("SI=0x0000");
+    }
+
+    /// <summary>
+    /// Verifies that CALL dword ptr [mem] evaluates the far pointer memory operand.
+    /// ASM: call dword ptr ss:[bp-4] (opcode FF 5E FC) — should show the target address.
+    /// </summary>
+    [AvaloniaFact]
+    public void EvaluateOperands_CallFarPtrBpMinus4_ShowsFarPointerValue() {
+        // Arrange
+        State state = CreateState();
+        (Memory memory, _, _) = CreateMemory();
+
+        state.BP = 0x0984;
+        state.SS = 0x2F23;
+
+        // Write a far pointer (offset:segment) at SS:BP-4
+        uint physicalAddress = (uint)(state.SS * 16 + state.BP - 4);
+        memory.UInt16[physicalAddress] = 0xABCD;       // offset
+        memory.UInt16[physicalAddress + 2] = 0x1234;   // segment
+
+        // x86 16-bit encoding: call dword ptr [bp-4] → FF 5E FC
+        byte[] machineCode = [0xFF, 0x5E, 0xFC];
+        SegmentedAddress address = new(0x1000, 0x0100);
+        DebuggerLineViewModel line = CreateDebuggerLine(machineCode, address);
+
+        ExpressionEvaluationService service = new(state, memory);
+
+        // Act
+        List<FormattedTextToken>? evaluated = service.FormatOperandValues(line.InstructionInfo);
+
+        // Assert
+        evaluated.Should().NotBeNullOrEmpty();
+        string text = SegmentsToText(evaluated!);
+        // Should show the dword value read from memory
+        text.Should().Contain("0x1234ABCD");
+    }
 }

--- a/tests/Spice86.Tests/UI/ExpressionEvaluatorUITests.cs
+++ b/tests/Spice86.Tests/UI/ExpressionEvaluatorUITests.cs
@@ -68,7 +68,7 @@ public class ExpressionEvaluatorUITests : BreakpointUiTestBase {
         state.AX = 0x1234;
         state.BX = 0x5678;
 
-        // x86 16-bit encoding: mov ax, bx → 89 D8
+        // x86 16-bit encoding: mov ax, bx -> 89 D8
         byte[] machineCode = [0x89, 0xD8];
         SegmentedAddress address = new(0x1000, 0x0100);
         DebuggerLineViewModel line = CreateDebuggerLine(machineCode, address);
@@ -80,7 +80,8 @@ public class ExpressionEvaluatorUITests : BreakpointUiTestBase {
 
         // Assert
         evaluated.Should().NotBeNullOrEmpty();
-        string text = SegmentsToText(evaluated!);
+        List<FormattedTextToken> evaluatedTokens = evaluated ?? [];
+        string text = SegmentsToText(evaluatedTokens);
         text.Should().Contain("AX=0x1234");
         text.Should().Contain("BX=0x5678");
 
@@ -107,7 +108,7 @@ public class ExpressionEvaluatorUITests : BreakpointUiTestBase {
         // Write 0xABCD at physical address DS*16 + BX = 0x20000 + 0x50 = 0x20050
         memory.UInt16[0x20050] = 0xABCD;
 
-        // x86 16-bit encoding: mov ax, word ptr [bx] → 8B 07
+        // x86 16-bit encoding: mov ax, word ptr [bx] -> 8B 07
         byte[] machineCode = [0x8B, 0x07];
         SegmentedAddress address = new(0x1000, 0x0100);
         DebuggerLineViewModel line = CreateDebuggerLine(machineCode, address);
@@ -119,7 +120,8 @@ public class ExpressionEvaluatorUITests : BreakpointUiTestBase {
 
         // Assert
         evaluated.Should().NotBeNullOrEmpty();
-        string text = SegmentsToText(evaluated!);
+        List<FormattedTextToken> evaluatedTokens = evaluated ?? [];
+        string text = SegmentsToText(evaluatedTokens);
         text.Should().Contain("AX=0x0000");
         text.Should().Contain("0xABCD");
 
@@ -130,7 +132,7 @@ public class ExpressionEvaluatorUITests : BreakpointUiTestBase {
 
     /// <summary>
     /// Verifies that immediates are NOT evaluated (they are already visible in disassembly text).
-    /// ASM: mov ax, 0x1234 (opcode B8 34 12) — only AX should appear in evaluation.
+    /// ASM: mov ax, 0x1234 (opcode B8 34 12) - only AX should appear in evaluation.
     /// </summary>
     [AvaloniaFact]
     public void EvaluateOperands_MovAxImm_OnlyShowsDestRegister() {
@@ -140,7 +142,7 @@ public class ExpressionEvaluatorUITests : BreakpointUiTestBase {
 
         state.AX = 0x5555;
 
-        // x86 16-bit encoding: mov ax, 0x1234 → B8 34 12
+        // x86 16-bit encoding: mov ax, 0x1234 -> B8 34 12
         byte[] machineCode = [0xB8, 0x34, 0x12];
         SegmentedAddress address = new(0x1000, 0x0100);
         DebuggerLineViewModel line = CreateDebuggerLine(machineCode, address);
@@ -152,7 +154,8 @@ public class ExpressionEvaluatorUITests : BreakpointUiTestBase {
 
         // Assert
         evaluated.Should().NotBeNullOrEmpty();
-        string text = SegmentsToText(evaluated!);
+        List<FormattedTextToken> evaluatedTokens = evaluated ?? [];
+        string text = SegmentsToText(evaluatedTokens);
         text.Should().Contain("AX=0x5555");
         // The immediate value 0x1234 should NOT appear in evaluation
         text.Should().NotContain("=0x1234");
@@ -175,7 +178,7 @@ public class ExpressionEvaluatorUITests : BreakpointUiTestBase {
         // Write 0xBEEF at physical address DS*16 + BX + 0x10 = 0x20000 + 0x50 + 0x10 = 0x20060
         memory.UInt16[0x20060] = 0xBEEF;
 
-        // x86 16-bit encoding: mov ax, word ptr [bx+0x10] → 8B 47 10
+        // x86 16-bit encoding: mov ax, word ptr [bx+0x10] -> 8B 47 10
         byte[] machineCode = [0x8B, 0x47, 0x10];
         SegmentedAddress address = new(0x1000, 0x0100);
         DebuggerLineViewModel line = CreateDebuggerLine(machineCode, address);
@@ -187,7 +190,8 @@ public class ExpressionEvaluatorUITests : BreakpointUiTestBase {
 
         // Assert
         evaluated.Should().NotBeNullOrEmpty();
-        string text = SegmentsToText(evaluated!);
+        List<FormattedTextToken> evaluatedTokens = evaluated ?? [];
+        string text = SegmentsToText(evaluatedTokens);
         text.Should().Contain("AX=0x0000");
         text.Should().Contain("0xBEEF");
 
@@ -197,7 +201,7 @@ public class ExpressionEvaluatorUITests : BreakpointUiTestBase {
 
     /// <summary>
     /// Verifies that LEA computes the effective address instead of reading memory.
-    /// ASM: lea ax, [bp-8] (opcode 8D 46 F8) — should show computed address, not memory contents.
+    /// ASM: lea ax, [bp-8] (opcode 8D 46 F8) - should show computed address, not memory contents.
     /// </summary>
     [AvaloniaFact]
     public void EvaluateOperands_LeaAxBpMinus8_ShowsEffectiveAddress() {
@@ -209,11 +213,11 @@ public class ExpressionEvaluatorUITests : BreakpointUiTestBase {
         state.BP = 0x0100;
         state.SS = 0x2000;
 
-        // Write decoy data at effective address — LEA must NOT read this
+        // Write decoy data at effective address - LEA must NOT read this
         uint physicalAddress = (uint)(state.SS * 16 + state.BP - 8);
         memory.UInt16[physicalAddress] = 0xDEAD;
 
-        // x86 16-bit encoding: lea ax, [bp-8] → 8D 46 F8
+        // x86 16-bit encoding: lea ax, [bp-8] -> 8D 46 F8
         byte[] machineCode = [0x8D, 0x46, 0xF8];
         SegmentedAddress address = new(0x1000, 0x0100);
         DebuggerLineViewModel line = CreateDebuggerLine(machineCode, address);
@@ -225,7 +229,8 @@ public class ExpressionEvaluatorUITests : BreakpointUiTestBase {
 
         // Assert
         evaluated.Should().NotBeNullOrEmpty();
-        string text = SegmentsToText(evaluated!);
+        List<FormattedTextToken> evaluatedTokens = evaluated ?? [];
+        string text = SegmentsToText(evaluatedTokens);
 
         // LEA should show effective address = BP - 8 = 0x0100 - 8 = 0x00F8
         text.Should().Contain("0x00F8");
@@ -250,7 +255,7 @@ public class ExpressionEvaluatorUITests : BreakpointUiTestBase {
         state.SI = 0x0010;
         state.DS = 0x2000;
 
-        // x86 16-bit encoding: lea ax, [bx+si] → 8D 00
+        // x86 16-bit encoding: lea ax, [bx+si] -> 8D 00
         byte[] machineCode = [0x8D, 0x00];
         SegmentedAddress address = new(0x1000, 0x0100);
         DebuggerLineViewModel line = CreateDebuggerLine(machineCode, address);
@@ -262,14 +267,15 @@ public class ExpressionEvaluatorUITests : BreakpointUiTestBase {
 
         // Assert
         evaluated.Should().NotBeNullOrEmpty();
-        string text = SegmentsToText(evaluated!);
+        List<FormattedTextToken> evaluatedTokens = evaluated ?? [];
+        string text = SegmentsToText(evaluatedTokens);
         // Effective address = BX + SI = 0x0030 + 0x0010 = 0x0040
         text.Should().Contain("0x0040");
     }
 
     /// <summary>
     /// Verifies that LDS evaluates the far pointer memory operand (dword containing offset:segment).
-    /// ASM: lds si, ss:[bp+0x10] (opcode C5 76 10) — should show the dword value at memory.
+    /// ASM: lds si, ss:[bp+0x10] (opcode C5 76 10) - should show the dword value at memory.
     /// </summary>
     [AvaloniaFact]
     public void EvaluateOperands_LdsSiBpPlus10_ShowsFarPointerValue() {
@@ -287,7 +293,7 @@ public class ExpressionEvaluatorUITests : BreakpointUiTestBase {
         memory.UInt16[physicalAddress] = 0x1234;       // offset
         memory.UInt16[physicalAddress + 2] = 0x5678;   // segment
 
-        // x86 16-bit encoding: lds si, [bp+0x10] → C5 76 10
+        // x86 16-bit encoding: lds si, [bp+0x10] -> C5 76 10
         byte[] machineCode = [0xC5, 0x76, 0x10];
         SegmentedAddress address = new(0x1000, 0x0100);
         DebuggerLineViewModel line = CreateDebuggerLine(machineCode, address);
@@ -299,7 +305,8 @@ public class ExpressionEvaluatorUITests : BreakpointUiTestBase {
 
         // Assert
         evaluated.Should().NotBeNullOrEmpty();
-        string text = SegmentsToText(evaluated!);
+        List<FormattedTextToken> evaluatedTokens = evaluated ?? [];
+        string text = SegmentsToText(evaluatedTokens);
         // Should show the dword value read from memory (segment:offset packed as dword)
         text.Should().Contain("0x56781234");
         // SI register value should also be shown
@@ -308,7 +315,7 @@ public class ExpressionEvaluatorUITests : BreakpointUiTestBase {
 
     /// <summary>
     /// Verifies that CALL dword ptr [mem] evaluates the far pointer memory operand.
-    /// ASM: call dword ptr ss:[bp-4] (opcode FF 5E FC) — should show the target address.
+    /// ASM: call dword ptr ss:[bp-4] (opcode FF 5E FC) - should show the target address.
     /// </summary>
     [AvaloniaFact]
     public void EvaluateOperands_CallFarPtrBpMinus4_ShowsFarPointerValue() {
@@ -324,7 +331,7 @@ public class ExpressionEvaluatorUITests : BreakpointUiTestBase {
         memory.UInt16[physicalAddress] = 0xABCD;       // offset
         memory.UInt16[physicalAddress + 2] = 0x1234;   // segment
 
-        // x86 16-bit encoding: call dword ptr [bp-4] → FF 5E FC
+        // x86 16-bit encoding: call dword ptr [bp-4] -> FF 5E FC
         byte[] machineCode = [0xFF, 0x5E, 0xFC];
         SegmentedAddress address = new(0x1000, 0x0100);
         DebuggerLineViewModel line = CreateDebuggerLine(machineCode, address);
@@ -336,7 +343,8 @@ public class ExpressionEvaluatorUITests : BreakpointUiTestBase {
 
         // Assert
         evaluated.Should().NotBeNullOrEmpty();
-        string text = SegmentsToText(evaluated!);
+        List<FormattedTextToken> evaluatedTokens = evaluated ?? [];
+        string text = SegmentsToText(evaluatedTokens);
         // Should show the dword value read from memory
         text.Should().Contain("0x1234ABCD");
     }


### PR DESCRIPTION
### Description of Changes

Fix gaps in the UI disasm expression evaluators for:

* LDS,
* LEA,
* LES,
* CALL FAR

Outside of LEA, changes are generic enough to fix more than those specific cases.

Before:
<img width="2558" height="1420" alt="image" src="https://github.com/user-attachments/assets/d0cdc007-1620-4e87-a206-f0a0a55ea9a6" />

After:

<img width="2545" height="1409" alt="image" src="https://github.com/user-attachments/assets/41e64055-f6a8-4f33-a7be-a4899fe94f55" />


### Rationale behind Changes

Aid in reverse engineering

### Suggested Testing Steps

Tested with manual tests. Covered by new UI integration tests which exercise the entire stack.