### PR TITLE
chore: update Avalonia package from .13 to .14 (fixes security warning as error)

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -6,7 +6,7 @@
 		<EnablePackageValidation>true</EnablePackageValidation>
 		<GenerateDocumentationFile>true</GenerateDocumentationFile>
 		<WarningsAsErrors>nullable</WarningsAsErrors>
-		<NoWarn>$(NoWarn);1591;NU1507;NU1504</NoWarn>
+		<NoWarn>$(NoWarn);1591;NU1507</NoWarn>
 	</PropertyGroup>
 	<!-- Source Link configuration -->
 	<PropertyGroup>

--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -4,12 +4,12 @@
 		<CentralPackageTransitivePinningEnabled>true</CentralPackageTransitivePinningEnabled>
 	</PropertyGroup>
 	<ItemGroup>
-		<PackageVersion Include="Avalonia" Version="11.3.13" />
+		<PackageVersion Include="Avalonia" Version="11.3.14" />
 		<PackageVersion Include="Avalonia.Controls.DataGrid" Version="11.3.8" />
-		<PackageVersion Include="Avalonia.Desktop" Version="11.3.13" />
-		<PackageVersion Include="Avalonia.Diagnostics" Version="11.3.13" />
-		<PackageVersion Include="Avalonia.Fonts.Inter" Version="11.3.13" />
-		<PackageVersion Include="Avalonia.Headless" Version="11.3.13" />
+		<PackageVersion Include="Avalonia.Desktop" Version="11.3.14" />
+		<PackageVersion Include="Avalonia.Diagnostics" Version="11.3.14" />
+		<PackageVersion Include="Avalonia.Fonts.Inter" Version="11.3.14" />
+		<PackageVersion Include="Avalonia.Headless" Version="11.3.14" />
 		<PackageVersion Include="AvaloniaGraphControl" Version="0.7.0" />
 		<PackageVersion Include="AvaloniaHex" Version="0.1.12" />
 		<PackageVersion Include="BenchmarkDotNet" Version="0.15.8" />


### PR DESCRIPTION
### Description of Changes

Updates Avalonia v11 core packages to the next minor version.

### Rationale behind Changes

Fixes the security issue with a transitive dependancy (some package for DBus)

### Suggested Testing Steps

Tested with Dune and DOTT.