### PR TITLE
fix: Expand INT 21h AH=33h with BootDrive and Dos Version support

### DIFF
--- a/src/Spice86.Core/Emulator/InterruptHandlers/Dos/DosInt21Handler.cs
+++ b/src/Spice86.Core/Emulator/InterruptHandlers/Dos/DosInt21Handler.cs
@@ -40,6 +40,7 @@ public class DosInt21Handler : InterruptHandler {
     private readonly DosTables _dosTables;
     private readonly DosSwappableDataArea _sda;
     private readonly DosFcbManager _dosFcbManager;
+    private readonly DosSysVars _dosSysVars;
     private uint _stdinReadyFlagLinearAddress;
     private bool _isCtrlCFlag;
 
@@ -70,7 +71,7 @@ public class DosInt21Handler : InterruptHandler {
         DosStringDecoder dosStringDecoder, DosMemoryManager dosMemoryManager,
         DosFileManager dosFileManager, DosDriveManager dosDriveManager,
         DosProcessManager dosProcessManager,
-        IOPortDispatcher ioPortDispatcher, DosTables dosTables, ILoggerService loggerService, DosFcbManager dosFcbManager)
+        IOPortDispatcher ioPortDispatcher, DosTables dosTables, DosSysVars dosSysVars, ILoggerService loggerService, DosFcbManager dosFcbManager)
             : base(memory, functionHandlerProvider, stack, state, loggerService) {
         _sda = new(memory, MemoryUtils.ToPhysicalAddress(DosSwappableDataArea.BaseSegment, 0));
         _countryInfo = countryInfo;
@@ -82,6 +83,7 @@ public class DosInt21Handler : InterruptHandler {
         _dosProcessManager = dosProcessManager;
         _ioPortDispatcher = ioPortDispatcher;
         _dosTables = dosTables;
+        _dosSysVars = dosSysVars;
         _interruptVectorTable = new InterruptVectorTable(memory);
         _dosFcbManager = dosFcbManager;
         FillDispatchTable();
@@ -1295,26 +1297,38 @@ public class DosInt21Handler : InterruptHandler {
     }
 
     /// <summary>
-    /// Gets or sets the Ctrl-C flag. AL: 0 = get, 1 or 2 = set it from DL.
+    /// Gets or sets the Ctrl-C flag and other DOS variables (INT 21h AH=33h, "DosVars").
     /// </summary>
-    /// <returns>
-    /// The Ctrl-C flag in DL if AL is 0. <br/>
-    /// </returns>
-    /// <exception cref="UnhandledOperationException">If the operation in AL is not supported.</exception>
     public void GetSetControlBreak() {
         if (LoggerService.IsEnabled(LogEventLevel.Verbose)) {
-            LoggerService.Verbose("GET/SET CTRL-C FLAG");
+            LoggerService.Verbose("GET/SET CTRL-C FLAG / DOSVARS");
         }
-        byte op = State.AL;
-        if (op == 0) {
-            // GET
-            State.DL = _isCtrlCFlag ? (byte)1 : (byte)0;
-        } else if (op is 1 or 2) {
-            // SET
-            _isCtrlCFlag = State.DL == 1;
-        } else {
-            throw new UnhandledOperationException(State,
-                "Ctrl-C get/set operation unhandled: " + op);
+        byte subfunction = State.AL;
+        switch (subfunction) {
+            case 0x00: // Get Ctrl-C flag
+                State.DL = _isCtrlCFlag ? (byte)1 : (byte)0;
+                break;
+            case 0x01: // Set Ctrl-C flag
+                _isCtrlCFlag = (State.DL & 1) == 1;
+                State.DL = _isCtrlCFlag ? (byte)1 : (byte)0;
+                break;
+            case 0x02: // Get/Set extended control break
+                byte tmp = _isCtrlCFlag ? (byte)1 : (byte)0;
+                _isCtrlCFlag = (State.DL & 1) == 1;
+                State.DL = tmp;
+                break;
+            case 0x05: // Get Boot Drive
+                State.DL = _dosSysVars.BootDrive;
+                break;
+            case 0x06: // Get (real) DOS version
+                State.BL = 0x05; // Major version (example: 5)
+                State.BH = 0x00; // Minor version (example: 0)
+                State.DL = 0x00; // Revision (lower 3 bits), rest 0
+                State.DH = 0x00; // Version flags (bit3: ROM, bit4: HMA)
+                break;
+            default:
+                State.AL = 0xFF; // Error, do NOT set carry
+                break;
         }
     }
 

--- a/src/Spice86.Core/Emulator/OperatingSystem/Dos.cs
+++ b/src/Spice86.Core/Emulator/OperatingSystem/Dos.cs
@@ -222,7 +222,8 @@ public sealed class Dos {
         DosInt22Handler = new DosInt22Handler(_memory, functionHandlerProvider, stack, state, ProcessManager, _loggerService);
         DosInt21Handler = new DosInt21Handler(_memory, functionHandlerProvider, stack, state,
             keyboardInt16Handler, CountryInfo, dosStringDecoder,
-            MemoryManager, FileManager, DosDriveManager, ProcessManager, ioPortDispatcher, DosTables, _loggerService, FcbManager);
+            MemoryManager, FileManager, DosDriveManager, ProcessManager,
+            ioPortDispatcher, DosTables, DosSysVars, _loggerService, FcbManager);
         DosInt23Handler = new DosInt23Handler(_memory, functionHandlerProvider, stack, state, ProcessManager, _loggerService);
         DosInt24Handler = new DosInt24Handler(_memory, functionHandlerProvider, stack, state, _loggerService);
         DosInt20Handler = new DosInt20Handler(_memory, functionHandlerProvider, stack, state, DosInt21Handler, _loggerService);

--- a/tests/Spice86.Tests/Dos/DosInt21HandlerTests.cs
+++ b/tests/Spice86.Tests/Dos/DosInt21HandlerTests.cs
@@ -68,6 +68,10 @@ public class DosInt21HandlerTests {
             envVars,
             logger);
 
+        var configuration = new Configuration();
+        var nulDevice = new NullDevice(logger, memory, 0xF8000);
+        var dosSysVars = new DosSysVars(configuration, nulDevice, memory, 0x700);
+
         var handler = new DosInt21Handler(
             memory,
             functionHandlerProvider,
@@ -82,6 +86,7 @@ public class DosInt21HandlerTests {
             dosProcessManager,
             ioPortDispatcher,
             dosTables,
+            dosSysVars,
             logger,
             dosFcbManager);
 


### PR DESCRIPTION


### Description of Changes

Extend DosInt21Handler.GetSetControlBreak to handle more INT 21h AH=33h subfunctions (Ctrl-C, boot drive, DOS version). Update constructors and tests to require DosSysVars.

### Rationale behind Changes

Fixes #1222 


### Suggested Testing Steps

Code is from freedos. Tested with the game in the above issue.