### PR TITLE
fix: Fix INT9H not processing in Monkey Island 2 (batch file PR regression)

### DIFF
--- a/src/Spice86.Core/Emulator/InterruptHandlers/Input/Keyboard/BiosKeyboardInt9Handler.cs
+++ b/src/Spice86.Core/Emulator/InterruptHandlers/Input/Keyboard/BiosKeyboardInt9Handler.cs
@@ -75,16 +75,9 @@ public class BiosKeyboardInt9Handler : InterruptHandler {
         // Disable keyboard first - otherwise Prince of Persia reads it before us!
         _ps2Controller.WriteByte(KeyboardPorts.Command, (byte)KeyboardCommand.DisablePortKbd);
 
-        byte status = _ps2Controller.ReadByte(KeyboardPorts.StatusRegister);
-        if ((status & 0x01) == 0) {
-            // Nothing pending in the 8042 output buffer: don't consume stale data bytes.
-            _ps2Controller.WriteByte(KeyboardPorts.Command, (byte)KeyboardCommand.EnableKeyboardPort);
-            _dualPic.AcknowledgeInterrupt(1);
-            return;
-        }
-
         if (LoggerService.IsEnabled(LogEventLevel.Debug)) {
-            LoggerService.Debug("INT09: entry ST=0x{St:X2}", status);
+            byte st = _ps2Controller.ReadByte(KeyboardPorts.StatusRegister);
+            LoggerService.Debug("INT09: entry ST=0x{St:X2}", st);
         }
 
         byte scancode = _ps2Controller.ReadByte(KeyboardPorts.Data);

--- a/tests/Spice86.Tests/Dos/KeyboardInt16EnhancedIntegrationTests.cs
+++ b/tests/Spice86.Tests/Dos/KeyboardInt16EnhancedIntegrationTests.cs
@@ -2,52 +2,11 @@ namespace Spice86.Tests.Dos;
 
 using FluentAssertions;
 
-using Spice86.Core.Emulator.Errors;
-
 using Xunit;
 
 using static BatchTestHelpers;
 
 public class KeyboardInt16EnhancedIntegrationTests {
-    [Fact]
-    public void Int16Ah00h_DoesNotReuseStaleControllerByteForSecondBlockingRead() {
-        WithTempDirectory("dos_int16_ah00_stale_byte", tempDir => {
-            // Arrange: read one key, write '1'; read second key, write '2'.
-            // With only one key preloaded, correct behavior is to block before writing '2'.
-            CreateBinaryFile(tempDir, "READ2.COM", new byte[] {
-                0xB4, 0x00,                                                     // MOV AH, 00h
-                0xCD, 0x16,                                                     // INT 16h (blocking)
-                0xB8, 0x00, 0xB8,                                               // MOV AX, B800h
-                0x8E, 0xC0,                                                     // MOV ES, AX
-                0xBF, 0x00, 0x00,                                               // MOV DI, 0000h
-                0xB0, 0x31,                                                     // MOV AL, '1'
-                0xB4, 0x07,                                                     // MOV AH, 07h
-                0xAB,                                                           // STOSW
-                0xB4, 0x00,                                                     // MOV AH, 00h
-                0xCD, 0x16,                                                     // INT 16h (must block until second key)
-                0xBF, 0x02, 0x00,                                               // MOV DI, 0002h
-                0xB0, 0x32,                                                     // MOV AL, '2'
-                0xB4, 0x07,                                                     // MOV AH, 07h
-                0xAB,                                                           // STOSW
-                0xB8, 0x00, 0x4C,                                               // MOV AX, 4C00h
-                0xCD, 0x21                                                      // INT 21h
-            });
-
-            ushort[] keys = new ushort[] { 0x3B00 };
-
-            // Act
-            Action act = () => RunWithPreloadedKeysAndCaptureVideoCells(
-                executablePath: Path.Join(tempDir, "READ2.COM"),
-                cDrivePath: tempDir,
-                cellCount: 2,
-                keyCodes: keys);
-
-            // Assert: with one key only, the second AH=00h read must block.
-            act.Should().Throw<InvalidVMOperationException>()
-                .WithMessage("*300000 cycles*");
-        });
-    }
-
     [Fact]
     public void Int16Ah10h_ReturnsExtendedKeyScanCode() {
         WithTempDirectory("dos_int16_ah10", tempDir => {


### PR DESCRIPTION

### Description of Changes

fix: Fix INT9H not processing in Monkey Island 2 (batch file PR regression)

Those changes did not make sense anyway.

git bisect showed that this change was from the big DOS Batch + BIOS INT9H + DOS console I/O +, IOCTL 'all in one' PR.

### Rationale behind Changes

Without this, the keyboard is completely dead in Monkey Island 2.

### Suggested Testing Steps

Tested with Monkey Island 2. It works again now.