### PR TITLE
(WIP, DO NOT MERGE) Fix/dos mem allocations

### DIFF
--- a/src/Spice86.Core/Emulator/InterruptHandlers/Dos/DosInt21Handler.cs
+++ b/src/Spice86.Core/Emulator/InterruptHandlers/Dos/DosInt21Handler.cs
@@ -1175,9 +1175,14 @@ public class DosInt21Handler : InterruptHandler {
                 returnCode, paragraphsToKeep, currentPspSegment);
         }
 
+        DosMemoryControlBlock currentBlock = _dosMemoryManager.GetDosMemoryControlBlockFromSegment((ushort)(currentPspSegment - 1));
+        ushort keep = Math.Min(currentBlock.Size, paragraphsToKeep);
+        const ushort MinParagraphs = 6;
+        keep = Math.Max(MinParagraphs, keep);
+
         DosErrorCode errorCode = _dosMemoryManager.TryModifyBlock(
             currentPspSegment,
-            paragraphsToKeep,
+            keep,
             out DosMemoryControlBlock resizedBlock);
 
         if (errorCode == DosErrorCode.NoError) {

--- a/src/Spice86.Core/Emulator/OperatingSystem/DosMemoryManager.cs
+++ b/src/Spice86.Core/Emulator/OperatingSystem/DosMemoryManager.cs
@@ -529,16 +529,22 @@ public class DosMemoryManager {
     }
 
     /// <summary>
-    /// Split the block:
-    /// <ul>
-    /// <li>If size is more than the block size => error, returns false</li>
-    /// <li>If size matches the block size => nothing to do</li>
-    /// <li>If size is less the block size => splits the block by creating a new free mcb at the end of the block</li>
-    /// </ul>
+    /// Splits the block as follows:
+    /// <list type="bullet">
+    ///   <item>
+    ///     <description>If <paramref name="size"/> is greater than the block size, the operation fails and returns <c>false</c>.</description>
+    ///   </item>
+    ///   <item>
+    ///     <description>If <paramref name="size"/> matches the block size, nothing is done and the operation returns <c>true</c>.</description>
+    ///   </item>
+    ///   <item>
+    ///     <description>If <paramref name="size"/> is less than the block size, the block is split by creating a new free MCB at the end, and the operation returns <c>true</c>.</description>
+    ///   </item>
+    /// </list>
     /// </summary>
-    /// <param name="block">The block to split up.</param>
+    /// <param name="block">The block to split.</param>
     /// <param name="size">The new size for the block.</param>
-    /// <returns>Whether the operation was successful.</returns>
+    /// <returns><c>true</c> if the operation was successful; otherwise, <c>false</c>.</returns>
     private bool SplitBlock(DosMemoryControlBlock block, ushort size) {
         ushort blockSize = block.Size;
         if (blockSize == size) {

--- a/src/Spice86.Core/Emulator/OperatingSystem/DosMemoryManager.cs
+++ b/src/Spice86.Core/Emulator/OperatingSystem/DosMemoryManager.cs
@@ -488,7 +488,7 @@ public class DosMemoryManager {
         }
     }
 
-    private DosMemoryControlBlock GetDosMemoryControlBlockFromSegment(ushort blockSegment) {
+    internal DosMemoryControlBlock GetDosMemoryControlBlockFromSegment(ushort blockSegment) {
         return new DosMemoryControlBlock(_memory, MemoryUtils.ToPhysicalAddress(blockSegment, 0));
     }
 


### PR DESCRIPTION
### Description of Changes

Tries to fix one bug: 

* TerminateAndStayResident gets non-sensical values in DX.

The current changes in this PR breaks Alpha Waves!

### Rationale behind Changes

Hopefully make DOS issues with some games (Alone In the Dark, Pinball Deluxe, Maupiti Island) go away.

DOS can be something that eventually will 'just work', as far as allocations are concerned anyway.

So people can focus on the real issues (like video issues).

### Suggested Testing Steps

Tested with Maupiti Island. It goes further now but chokes on another unrelated DOS issue.

Tested with Alpha Waves and it does not like it at all.