### PR TITLE
Fix/tests inodes issue

### DIFF
--- a/tests/Directory.Packages.props
+++ b/tests/Directory.Packages.props
@@ -19,8 +19,8 @@
 		<PackageVersion Include="SingleStepTests.Intel80386.67.80-67.FF" Version="2025.11.5" />
 		<PackageVersion Include="SingleStepTests.Intel80386.68-FF" Version="2025.11.5" />
 		<PackageVersion Include="System.Text.Json" Version="10.0.0" />
-		<PackageVersion Include="Avalonia.Headless" Version="11.3.13" />
-		<PackageVersion Include="Avalonia.Headless.XUnit" Version="11.3.13" />
+		<PackageVersion Include="Avalonia.Headless" Version="11.3.14" />
+		<PackageVersion Include="Avalonia.Headless.XUnit" Version="11.3.14" />
 		<PackageVersion Include="xunit" Version="2.9.3" />
 		<PackageVersion Include="xunit.runner.visualstudio" Version="3.1.5" />
 		<PackageVersion Include="Xunit.SkippableFact" Version="1.5.61" />

--- a/tests/Spice86.Tests/Dos/BatchTestHelpers.cs
+++ b/tests/Spice86.Tests/Dos/BatchTestHelpers.cs
@@ -690,9 +690,10 @@ internal static class BatchTestHelpers {
         return existingPath;
     }
 
+    private static string SingleTempPath => Path.GetTempPath();
 
     internal static void WithTempDirectory(string prefix, Action<string> test) {
-        string tempDir = Path.Join(Path.GetTempPath(), $"{prefix}_{Guid.NewGuid():N}");
+        string tempDir = Path.Join(SingleTempPath, $"{prefix}_{Guid.NewGuid():N}");
         Directory.CreateDirectory(tempDir);
         try {
             test(tempDir);

--- a/tests/Spice86.Tests/Http/HttpApiGeneratedClientIntegrationTests.cs
+++ b/tests/Spice86.Tests/Http/HttpApiGeneratedClientIntegrationTests.cs
@@ -51,8 +51,9 @@ public sealed partial class HttpApiGeneratedClientIntegrationTests {
     }
 
     private static TestWorkspace CreateTestWorkspace(string extension) {
-        string rootPath = Path.Join(Path.GetTempPath(), "Spice86.Tests", "HttpApiGeneratedClient", Guid.NewGuid().ToString("N"));
-        string toolPath = Path.Join(Path.GetTempPath(), "Spice86.Tests", "Tools", "Kiota");
+        string baseTempPath = Path.GetTempPath();
+        string rootPath = Path.Join(baseTempPath, "Spice86.Tests", "HttpApiGeneratedClient", Guid.NewGuid().ToString("N"));
+        string toolPath = Path.Join(baseTempPath, "Spice86.Tests", "Tools", "Kiota");
         Directory.CreateDirectory(rootPath);
         Directory.CreateDirectory(toolPath);
         return new TestWorkspace(

--- a/tests/Spice86.Tests/Simd/SimdConversionsTest.cs
+++ b/tests/Spice86.Tests/Simd/SimdConversionsTest.cs
@@ -1,8 +1,8 @@
-﻿using static Spice86.Shared.Utils.SimdConversions;
-
-namespace Spice86.Tests.Utility;
+﻿namespace Spice86.Tests.Simd;
 
 using JetBrains.Annotations;
+
+using static Spice86.Shared.Utils.SimdConversions;
 
 using Spice86.Shared.Utils;
 


### PR DESCRIPTION
### Description of Changes

Creates way less temp dirs by sharing them via static private properties

### Rationale behind Changes

Quick fix for the inode issue on Linux

### Suggested Testing Steps

Could not reproduce the issue in WSL.