### PR TITLE
fix: Update FastExpressionCompiler reference to Release DLL

### DIFF
--- a/src/Spice86.Core/Spice86.Core.csproj
+++ b/src/Spice86.Core/Spice86.Core.csproj
@@ -25,7 +25,7 @@
         <PackageReference Include="Serilog.Sinks.File" />
 		<PackageReference Include="Spectre.Console.Cli" />
         <Reference Include="FastExpressionCompiler">
-          <HintPath>..\..\3rdparty\$(Configuration)\FastExpressionCompiler.dll</HintPath>
+          <HintPath>..\..\3rdparty\Release\FastExpressionCompiler.dll</HintPath>
           <Private>true</Private>
         </Reference>
         <PackageReference Include="MeltySynth" />


### PR DESCRIPTION
### Description of Changes

The project now always references the Release build of FastExpressionCompiler by setting a fixed HintPath, ensuring consistent usage regardless of build configuration.

### Rationale behind Changes

Fixes slow debugging sessions.

<img width="2098" height="1220" alt="image" src="https://github.com/user-attachments/assets/7274a4f1-342b-41c4-b3ba-ea55dbdbcbbc" />

<img width="2300" height="1679" alt="image" src="https://github.com/user-attachments/assets/296788a4-7e4b-46de-a454-46789b6d1913" />


### Suggested Testing Steps

Tested with Stunts