### PR TITLE
fix: Add BP stack frame setup to timer INT 8 handler (fixes Rules of Engagement 2 v1.05)

### DIFF
--- a/src/Spice86.Core/Emulator/InterruptHandlers/Common/MemoryWriter/MemoryAsmWriter.cs
+++ b/src/Spice86.Core/Emulator/InterruptHandlers/Common/MemoryWriter/MemoryAsmWriter.cs
@@ -133,6 +133,28 @@ public class MemoryAsmWriter : MemoryWriter {
     }
 
     /// <summary>
+    /// Writes an instruction to push the BP register onto the CPU stack.
+    /// </summary>
+    public void WritePushBp() {
+        WriteUInt8(0x55);
+    }
+
+    /// <summary>
+    /// Writes an instruction to clear the BP register.
+    /// </summary>
+    public void WriteXorBpBp() {
+        WriteUInt8(0x31);
+        WriteUInt8(0xed);
+    }
+
+    /// <summary>
+    /// Writes an instruction to pop the BP register value from the stack.
+    /// </summary>
+    public void WritePopBp() {
+        WriteUInt8(0x5d);
+    }
+
+    /// <summary>
     /// Writes a far CALL instruction to the given inMemoryAddressSwitcher default address. <br/>
     /// Throws UnrecoverableException if DefaultAddressValue is not initialized. <br/>
     /// If successful, sets the switcher PhysicalLocation to the location of the far call address, making it possible to change it dynamically.

--- a/src/Spice86.Core/Emulator/InterruptHandlers/Timer/TimerInt8Handler.cs
+++ b/src/Spice86.Core/Emulator/InterruptHandlers/Timer/TimerInt8Handler.cs
@@ -27,8 +27,11 @@ public sealed class TimerInt8Handler : IInterruptHandler {
         SegmentedAddress interruptHandlerAddress = memoryAsmWriter.CurrentAddress;
         // Increment BIOS tick counter
         memoryAsmWriter.RegisterAndWriteCallback(VectorNumber, IncTickCounterValue);
+        memoryAsmWriter.WritePushBp();
+        memoryAsmWriter.WriteXorBpBp();
         // Call user timer hook
         memoryAsmWriter.WriteInt(0x1C);
+        memoryAsmWriter.WritePopBp();
         // EOI to PIC after handler execution
         memoryAsmWriter.RegisterAndWriteCallback(AfterInt8Execution);
         memoryAsmWriter.WriteIret();


### PR DESCRIPTION
### Description of Changes

Added WritePushBp, WriteXorBpBp, and WritePopBp to MemoryAsmWriter for emitting BP stack frame instructions. Updated TimerInt8Handler to use these for proper stack frame setup and teardown around the user timer hook call. This fixes Rules of Engagement 2 v1.05.

Reference: https://github.com/dosbox-staging/dosbox-staging/pull/4852/changes

As noted in the refrence, SeaBIOS does the same in its INT1C handler.

### Rationale behind Changes

## Before

<img width="1553" height="1203" alt="image" src="https://github.com/user-attachments/assets/fb3c730c-d017-498c-a513-37d1de7f2a5a" />


## After

<img width="1534" height="1203" alt="image" src="https://github.com/user-attachments/assets/4026485a-d5e8-43d0-96fc-8865f9c31869" />


### Credits

All credits goes to @codengine for this fix.