### PR TITLE
Fix/mcp server screenshot and input support (and dependency injection refactoring)

### DIFF
--- a/src/Spice86.Core/Emulator/Devices/Input/Keyboard/KeyboardScancodeConverter.cs
+++ b/src/Spice86.Core/Emulator/Devices/Input/Keyboard/KeyboardScancodeConverter.cs
@@ -4,6 +4,7 @@ using Spice86.Shared.Emulator.Keyboard;
 
 using System.Collections.Frozen;
 using System.Collections.Generic;
+using System.Linq;
 
 /// <summary>
 /// Converts UI PhysicalKey to internal PcKeyboardKey and ultimately returns the corresponding
@@ -75,6 +76,11 @@ public class KeyboardScancodeConverter {
         { PhysicalKey.NumPadEnter, PcKeyboardKey.KpEnter }, { PhysicalKey.NumPadDecimal, PcKeyboardKey.KpPeriod }
     }.ToFrozenDictionary();
 
+    private static readonly FrozenDictionary<PcKeyboardKey, PhysicalKey> _kbdKeyToPhysical =
+        _keyToKbdKey
+            .GroupBy(kv => kv.Value)
+            .ToFrozenDictionary(g => g.Key, g => g.First().Key);
+
     /// <summary>
     /// Converts a specified physical key to its corresponding PC keyboard key value.
     /// </summary>
@@ -83,6 +89,16 @@ public class KeyboardScancodeConverter {
     /// cref="PcKeyboardKey.None"/>.</returns>
     public PcKeyboardKey ConvertToKbdKey(PhysicalKey key) {
         return _keyToKbdKey.TryGetValue(key, out PcKeyboardKey kbdKey) ? kbdKey : PcKeyboardKey.None;
+    }
+
+    /// <summary>
+    /// Converts a PC keyboard key to its corresponding physical key value.
+    /// </summary>
+    /// <param name="key">The PC keyboard key to convert.</param>
+    /// <returns>The corresponding <see cref="PhysicalKey"/> value if the mapping exists; otherwise, <see
+    /// cref="PhysicalKey.None"/>.</returns>
+    public static PhysicalKey ConvertToPhysicalKey(PcKeyboardKey key) {
+        return _kbdKeyToPhysical.TryGetValue(key, out PhysicalKey physical) ? physical : PhysicalKey.None;
     }
 
     /// <summary>

--- a/src/Spice86.Core/Emulator/Devices/Video/IVgaRenderer.cs
+++ b/src/Spice86.Core/Emulator/Devices/Video/IVgaRenderer.cs
@@ -24,4 +24,16 @@ public interface IVgaRenderer {
     /// </summary>
     /// <param name="buffer">The framebuffer used by the VGA card to draw the image on screen.</param>
     void Render(Span<uint> buffer);
+
+    /// <summary>
+    ///     Copy the last published frame without consuming the pending-frame flag.
+    ///     Use this for non-destructive reads (e.g. MCP screenshots) that must not
+    ///     interfere with the normal UI render loop.
+    ///     Does nothing when no frame has been published yet.
+    /// </summary>
+    /// <param name="buffer">Destination buffer (must be at least <see cref="BufferSize"/> elements).</param>
+    /// <exception cref="ArgumentException">
+    ///     Thrown when <paramref name="buffer"/> is smaller than the last published frame.
+    /// </exception>
+    void CopyLastFrame(Span<uint> buffer);
 }

--- a/src/Spice86.Core/Emulator/Devices/Video/Renderer.cs
+++ b/src/Spice86.Core/Emulator/Devices/Video/Renderer.cs
@@ -297,6 +297,18 @@ public class Renderer : IVgaRenderer {
         }
     }
 
+    /// <inheritdoc />
+    public void CopyLastFrame(Span<uint> buffer) {
+        uint[] lastFrame = Volatile.Read(ref _lastPublishedFrame);
+        if (lastFrame.Length == 0) {
+            return;
+        }
+        if (buffer.Length < lastFrame.Length) {
+            throw new ArgumentException("Destination buffer is smaller than the last published frame.", nameof(buffer));
+        }
+        lastFrame.AsSpan().CopyTo(buffer);
+    }
+
     private void InitCharRow() {
         _frameHorizontalDisplayEnd = _state.CrtControllerRegisters.HorizontalDisplayEnd + 1 + _frameSkew;
         _frameTotalWidth = _state.CrtControllerRegisters.HorizontalTotal + 3;

--- a/src/Spice86.Core/Emulator/Mcp/EmulatorMcpServices.cs
+++ b/src/Spice86.Core/Emulator/Mcp/EmulatorMcpServices.cs
@@ -13,6 +13,7 @@ using Spice86.Core.Emulator.Function;
 using Spice86.Core.Emulator.InterruptHandlers.Bios.Structures;
 using Spice86.Core.Emulator.InterruptHandlers.Dos.Ems;
 using Spice86.Core.Emulator.InterruptHandlers.Dos.Xms;
+using Spice86.Core.Emulator.InterruptHandlers.Input.Keyboard;
 using Spice86.Core.Emulator.IOPorts;
 using Spice86.Core.Emulator.Memory;
 using Spice86.Core.Emulator.OperatingSystem;
@@ -66,6 +67,13 @@ public sealed class EmulatorMcpServices(
     public Intel8042Controller? Intel8042Controller { get; set; }
 
     /// <summary>
+    /// Gets or sets the input event hub. MCP tools must post keyboard/mouse
+    /// mutations through this hub so they run on the emulator thread, matching
+    /// how Avalonia UI input is delivered.
+    /// </summary>
+    public InputEventHub? InputEventHub { get; set; }
+
+    /// <summary>
     /// Gets or sets the Sound Blaster device used by medium-level MCP sound tools.
     /// </summary>
     public SoundBlaster? SoundBlaster { get; set; }
@@ -94,6 +102,11 @@ public sealed class EmulatorMcpServices(
     /// Gets or sets the BIOS data area accessor used by BIOS and video MCP tools.
     /// </summary>
     public BiosDataArea? BiosDataArea { get; set; }
+
+    /// <summary>
+    /// Gets or sets the BIOS keyboard buffer for direct key injection.
+    /// </summary>
+    public BiosKeyboardBuffer? BiosKeyboardBuffer { get; set; }
 
     /// <summary>
     /// Gets or sets the interrupt vector table used by BIOS and DOS MCP tools.

--- a/src/Spice86.Core/Emulator/Mcp/EmulatorMcpTools.cs
+++ b/src/Spice86.Core/Emulator/Mcp/EmulatorMcpTools.cs
@@ -16,6 +16,7 @@ using Spice86.Core.Emulator.CPU.CfgCpu.Parser;
 using Spice86.Core.Emulator.Debugger;
 using Spice86.Core.Emulator.Devices.Input.Keyboard;
 using Spice86.Core.Emulator.Devices.Sound;
+using Spice86.Shared.Emulator.Keyboard;
 using Spice86.Core.Emulator.Devices.Sound.Blaster;
 using Spice86.Core.Emulator.Devices.Sound.Midi;
 using Spice86.Core.Emulator.Devices.Timer;
@@ -31,7 +32,9 @@ using Spice86.Core.Emulator.Memory;
 using Spice86.Core.Emulator.OperatingSystem;
 using Spice86.Core.Emulator.OperatingSystem.Enums;
 using Spice86.Core.Emulator.OperatingSystem.Structures;
+using Spice86.Core.Emulator.VM;
 using Spice86.Core.Emulator.VM.Breakpoint;
+using Spice86.Shared.Emulator.Mouse;
 using Spice86.Shared.Emulator.VM.Breakpoint;
 using Spice86.Shared.Emulator.Memory;
 using Spice86.Shared.Utils;
@@ -579,19 +582,39 @@ internal sealed class EmulatorMcpTools {
     public CallToolResult SendKeyboardKey(string key, bool isPressed) {
         return ExecuteTool(() => {
             lock (_services.ToolsLock) {
-                Intel8042Controller? controller = _services.Intel8042Controller;
-                if (controller == null) {
-                    throw new InvalidOperationException("PS/2 controller is not available");
-                }
-
                 if (!Enum.TryParse(key, true, out PcKeyboardKey parsedKey)) {
                     throw new ArgumentException($"Invalid PcKeyboardKey: '{key}'");
                 }
 
-                controller.KeyboardDevice.EnqueueKeyEvent(parsedKey, isPressed);
+                PhysicalKey physicalKey = KeyboardScancodeConverter.ConvertToPhysicalKey(parsedKey);
+                if (physicalKey == PhysicalKey.None) {
+                    throw new ArgumentException($"PcKeyboardKey '{key}' has no corresponding physical key mapping");
+                }
+
+                KeyboardEventArgs args = new(physicalKey, isPressed);
+                string action = isPressed ? "down" : "up";
+
+                if (_services.PauseHandler.IsPaused) {
+                    InputEventHub? pausedHub = _services.InputEventHub;
+                    if (pausedHub == null) {
+                        throw new InvalidOperationException("InputEventHub is not wired");
+                    }
+                    pausedHub.PostKeyboardEvent(args);
+                    return new EmulatorControlResponse {
+                        Success = true,
+                        Message = $"Keyboard event enqueued while paused: {parsedKey} {action}"
+                    };
+                }
+
+                InputEventHub? hub = _services.InputEventHub;
+                if (hub == null) {
+                    throw new InvalidOperationException("InputEventHub is not wired");
+                }
+
+                hub.PostKeyboardEvent(args);
                 return new EmulatorControlResponse {
                     Success = true,
-                    Message = $"Keyboard event sent: {parsedKey} {(isPressed ? "down" : "up")}"
+                    Message = $"Keyboard event sent: {parsedKey} {action}"
                 };
             }
         });
@@ -618,6 +641,49 @@ internal sealed class EmulatorMcpTools {
                 return new EmulatorControlResponse {
                     Success = true,
                     Message = $"Mouse packet sent ({bytes.Length} byte(s))"
+                };
+            }
+        });
+    }
+
+    [McpServerTool(Name = "send_mouse_move", UseStructuredContent = true), Description("Move the mouse to a normalized position on screen. x and y are in the range [0.0, 1.0] relative to the emulated display: (0,0) is top-left, (1,1) is bottom-right.")]
+    public CallToolResult SendMouseMove(double x, double y) {
+        return ExecuteTool(() => {
+            lock (_services.ToolsLock) {
+                InputEventHub? hub = _services.InputEventHub;
+                if (hub == null) {
+                    throw new InvalidOperationException("InputEventHub is not wired");
+                }
+
+                double clampedX = Math.Clamp(x, 0.0, 1.0);
+                double clampedY = Math.Clamp(y, 0.0, 1.0);
+                hub.PostMouseMoveEvent(new MouseMoveEventArgs(clampedX, clampedY));
+                return new EmulatorControlResponse {
+                    Success = true,
+                    Message = $"Mouse moved to ({clampedX:F3}, {clampedY:F3})"
+                };
+            }
+        });
+    }
+
+    [McpServerTool(Name = "send_mouse_button", UseStructuredContent = true), Description("Send a mouse button press or release event. button is one of: Left, Right, Middle. isPressed=true for press, false for release.")]
+    public CallToolResult SendMouseButton(string button, bool isPressed) {
+        return ExecuteTool(() => {
+            lock (_services.ToolsLock) {
+                if (!Enum.TryParse(button, true, out MouseButton parsedButton) || parsedButton == MouseButton.None) {
+                    throw new ArgumentException($"Invalid MouseButton: '{button}'. Use Left, Right, or Middle.");
+                }
+
+                InputEventHub? hub = _services.InputEventHub;
+                if (hub == null) {
+                    throw new InvalidOperationException("InputEventHub is not wired");
+                }
+
+                hub.PostMouseButtonEvent(new MouseButtonEventArgs(parsedButton, isPressed));
+                string action = isPressed ? "pressed" : "released";
+                return new EmulatorControlResponse {
+                    Success = true,
+                    Message = $"Mouse button {parsedButton} {action}"
                 };
             }
         });
@@ -1215,7 +1281,20 @@ internal sealed class EmulatorMcpTools {
                 int width = _services.VgaRenderer.Width;
                 int height = _services.VgaRenderer.Height;
                 uint[] buffer = new uint[width * height];
-                _services.VgaRenderer.Render(buffer);
+
+                _services.VgaRenderer.CopyLastFrame(buffer);
+
+                bool hasVisiblePixelData = false;
+                for (int i = 0; i < buffer.Length; i++) {
+                    if (buffer[i] != 0) {
+                        hasVisiblePixelData = true;
+                        break;
+                    }
+                }
+
+                if (!hasVisiblePixelData) {
+                    return Error("No video frame is available for screenshot capture.");
+                }
 
                 byte[] bytes = new byte[buffer.Length * 4];
                 Buffer.BlockCopy(buffer, 0, bytes, 0, bytes.Length);

--- a/src/Spice86.Core/Emulator/Mcp/EmulatorMcpTools.cs
+++ b/src/Spice86.Core/Emulator/Mcp/EmulatorMcpTools.cs
@@ -578,7 +578,7 @@ internal sealed class EmulatorMcpTools {
         });
     }
 
-    [McpServerTool(Name = "send_keyboard_key", UseStructuredContent = true), Description("Send a single keyboard key event. Parameters: key (string, PcKeyboardKey enum name like 'Enter' or 'Escape'), isPressed (bool, true=key down, false=key up). For a full keypress, call twice: once with isPressed=true, then with isPressed=false. Use PcKeyboardKey enum names: Escape, Enter, A-Z, Up, Down, Left, Right, F1-F12, Space, Tab, etc.")]
+    [McpServerTool(Name = "send_keyboard_key", UseStructuredContent = true), Description("Send a single keyboard key event. Parameters: key (string, case-insensitive PcKeyboardKey name) and isPressed (bool, true=key down, false=key up). For a full keypress, call twice: first with isPressed=true, then with isPressed=false. Common key names: A-Z, D0-D9, NumPad0-NumPad9, Escape, Enter, Space, Tab, Backspace, Insert, Delete, Home, End, PageUp, PageDown, Up, Down, Left, Right, F1-F12, LeftShift/RightShift, LeftCtrl/RightCtrl, LeftAlt/RightAlt. Invalid names return an argument error.")]
     public CallToolResult SendKeyboardKey(string key, bool isPressed) {
         return ExecuteTool(() => {
             lock (_services.ToolsLock) {
@@ -620,7 +620,7 @@ internal sealed class EmulatorMcpTools {
         });
     }
 
-    [McpServerTool(Name = "send_mouse_packet", UseStructuredContent = true), Description("Send a raw PS/2 mouse packet (3 hex bytes) through the controller AUX port. Format: SSXXYY where SS=status, XX=X delta, YY=Y delta. Example: 080000 (no movement, no button).")]
+    [McpServerTool(Name = "send_mouse_packet", UseStructuredContent = true), Description("Send raw PS/2 AUX bytes to the mouse controller as a hex string (1-8 bytes, no separators). For a standard 3-byte packet, use SSXXYY: SS=status byte, XX=X delta, YY=Y delta. Status byte bit layout: bit0=left button, bit1=right button, bit2=middle button, bit3=always 1 for a normal packet header, bit4=X sign, bit5=Y sign, bit6=X overflow, bit7=Y overflow. XX and YY are signed 8-bit deltas (two's complement). Examples: 080000 (no movement, no button), 090100 (left button + X=+1), 08FF00 (X=-1).")]
     public CallToolResult SendMousePacket([StringSyntax("Hexadecimal")] string packetData) {
         return ExecuteTool(() => {
             lock (_services.ToolsLock) {

--- a/src/Spice86.Core/Emulator/VM/InputEventQueue.cs
+++ b/src/Spice86.Core/Emulator/VM/InputEventQueue.cs
@@ -53,6 +53,45 @@ public class InputEventHub : IGuiKeyboardEvents, IGuiMouseEvents {
         }
     }
 
+    /// <summary>
+    /// Thread-safe hook for non-UI producers (e.g. the MCP server) that need to
+    /// mutate emulator input state. The action is enqueued under the same lock
+    /// as UI events and will run on the emulator thread the next time
+    /// <see cref="ProcessAllPendingInputEvents"/> is pumped.
+    /// </summary>
+    public void PostToEmulatorThread(Action action) => Enqueue(action);
+
+    /// <summary>
+    /// Enqueues a keyboard event to be fired on the emulator thread, following
+    /// the same path as UI keyboard events (PhysicalKey → PS2Keyboard scancode pipeline).
+    /// </summary>
+    public void PostKeyboardEvent(KeyboardEventArgs e) {
+        if (e.IsPressed) {
+            Enqueue(() => KeyDown?.Invoke(null, e));
+        } else {
+            Enqueue(() => KeyUp?.Invoke(null, e));
+        }
+    }
+
+    /// <summary>
+    /// Enqueues a mouse move event to be fired on the emulator thread, following the same
+    /// path as UI pointer events. Coordinates are normalized (0.0–1.0 relative to the screen).
+    /// </summary>
+    public void PostMouseMoveEvent(MouseMoveEventArgs e) =>
+        Enqueue(() => MouseMoved?.Invoke(null, e));
+
+    /// <summary>
+    /// Enqueues a mouse button event to be fired on the emulator thread, following the same
+    /// path as UI pointer events.
+    /// </summary>
+    public void PostMouseButtonEvent(MouseButtonEventArgs e) {
+        if (e.ButtonDown) {
+            Enqueue(() => MouseButtonDown?.Invoke(null, e));
+        } else {
+            Enqueue(() => MouseButtonUp?.Invoke(null, e));
+        }
+    }
+
     private void OnMouseMoved(object? sender, MouseMoveEventArgs e) =>
         Enqueue(() => MouseMoved?.Invoke(sender, e));
 
@@ -81,11 +120,13 @@ public class InputEventHub : IGuiKeyboardEvents, IGuiMouseEvents {
 
     public double MouseX {
         get => _mouseEvents?.MouseX ?? 0;
-        set { if (_mouseEvents is not null) { _mouseEvents.MouseX = value; } } }
+        set { if (_mouseEvents is not null) { _mouseEvents.MouseX = value; } }
+    }
 
     public double MouseY {
         get => _mouseEvents?.MouseY ?? 0;
-        set { if (_mouseEvents is not null) { _mouseEvents.MouseY = value; } } }
+        set { if (_mouseEvents is not null) { _mouseEvents.MouseY = value; } }
+    }
 
     public void HideMouseCursor() => _mouseEvents?.HideMouseCursor();
 

--- a/src/Spice86/Spice86DependencyInjection.cs
+++ b/src/Spice86/Spice86DependencyInjection.cs
@@ -536,7 +536,7 @@ public class Spice86DependencyInjection : IDisposable {
             state, ioPortDispatcher, a20Gate, dualPic, emulationLoopScheduler,
             configuration.FailOnUnhandledPort, loggerService, inputEventHub);
         emulatorMcpServices.Intel8042Controller = intel8042Controller;
-
+        emulatorMcpServices.BiosKeyboardBuffer = biosKeyboardBuffer;
         BiosKeyboardInt9Handler biosKeyboardInt9Handler = new(memory, biosDataArea,
             stack, state, cfgCpu, dualPic, systemBiosInt15Handler,
             intel8042Controller, biosKeyboardBuffer, loggerService);
@@ -585,6 +585,7 @@ public class Spice86DependencyInjection : IDisposable {
         }
 
         emulatorMcpServices.Intel8042Controller = intel8042Controller;
+        emulatorMcpServices.InputEventHub = inputEventHub;
         emulatorMcpServices.SoundBlaster = soundBlaster;
         emulatorMcpServices.Opl3Fm = opl;
         emulatorMcpServices.PcSpeaker = pcSpeaker;

--- a/tests/Spice86.Tests/McpIntegrationContext.cs
+++ b/tests/Spice86.Tests/McpIntegrationContext.cs
@@ -96,6 +96,7 @@ internal sealed class McpIntegrationContext : IAsyncDisposable {
 
         // Always assign optional devices, regardless of EMS/XMS enablement
         services.Intel8042Controller = spice86.McpServices.Intel8042Controller;
+        services.InputEventHub = spice86.McpServices.InputEventHub;
         services.SoundBlaster = spice86.McpServices.SoundBlaster;
         services.Opl3Fm = spice86.McpServices.Opl3Fm;
         services.PcSpeaker = spice86.McpServices.PcSpeaker;

--- a/tests/Spice86.Tests/McpServerToolStateTests.cs
+++ b/tests/Spice86.Tests/McpServerToolStateTests.cs
@@ -1016,9 +1016,17 @@ public class McpServerToolStateTests {
         McpJsonRpcAssertions.TryGetPropertyIgnoreCase(McpJsonRpcAssertions.GetStructuredContent(McpJsonRpcAssertions.GetJsonRpcResult(readCfg)), "currentContextDepth", out JsonElement _).Should().BeTrue();
         McpJsonRpcAssertions.TryGetPropertyIgnoreCase(McpJsonRpcAssertions.GetStructuredContent(McpJsonRpcAssertions.GetJsonRpcResult(listFuncs)), "functions", out JsonElement _).Should().BeTrue();
         McpJsonRpcAssertions.TryGetPropertyIgnoreCase(McpJsonRpcAssertions.GetStructuredContent(McpJsonRpcAssertions.GetJsonRpcResult(video)), "width", out JsonElement _).Should().BeTrue();
-        JsonElement shot = McpJsonRpcAssertions.GetStructuredContent(McpJsonRpcAssertions.GetJsonRpcResult(screenshot));
-        McpJsonRpcAssertions.TryGetPropertyIgnoreCase(shot, "format", out JsonElement format).Should().BeTrue();
-        format.GetString().Should().Be("png");
+        AssertScreenshotResultIsValid(McpJsonRpcAssertions.GetStructuredContent(McpJsonRpcAssertions.GetJsonRpcResult(screenshot)));
+    }
+
+    private static void AssertScreenshotResultIsValid(JsonElement shot) {
+        bool hasFormat = McpJsonRpcAssertions.TryGetPropertyIgnoreCase(shot, "format", out JsonElement format);
+        bool hasNoFrameError = McpJsonRpcAssertions.TryGetPropertyIgnoreCase(shot, "message", out JsonElement msg)
+            && msg.GetString() == "No video frame is available for screenshot capture.";
+        (hasFormat || hasNoFrameError).Should().BeTrue("screenshot must either return a PNG or report that no frame is available");
+        if (hasFormat) {
+            format.GetString().Should().Be("png");
+        }
     }
 
     private static async Task AssertPauseResumeIoToolsAsync(McpIntegrationContext context) {


### PR DESCRIPTION
### Description of Changes
- Screenshots get a copy of the last rendered frame instead of trying to render a new frame.
- Keyboard input goes through the InputEventHub to synchronize the threads.
- Added DOS MCP tools for MCBs and PSPs
- Reworked dependency injection and classes responsibilities
- Added mouse MCP tools

### Rationale behind Changes
- Screenshots were often empty because the renderer decided it had nothing to render at that moment.
- Keyboard input from MCP often did not work.

### Suggested Testing Steps
For krondor I tried to get the MCP to start a new game and end up in the game world, while skipping intro and cutscenes.
Without these changes 3/4 screenshots were blank and no amount of sending key presses and releases would skip anything.
With these changes Claude was able to tuse the mcp to skip the intro, start a new game, skip the book pages and cutscenes and end up in the 3d world.

### Credits

Fixes and work from @JorisVanEijden - Thanks! :)
