### PR TITLE
fix: Add FastExpressionCompiler.dll to NuGet package output (Nuget 13.1 release)

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -16,7 +16,7 @@
 	</PropertyGroup>
 	<!-- Nuget package info-->
 	<PropertyGroup>
-		<Version>13.0.0</Version>
+		<Version>13.1.0</Version>
 		<PackageReleaseNotes>
             <![CDATA[
             # Release Notes - https://github.com/OpenRakis/Spice86/wiki/Spice86-v13-release-notes

--- a/src/Spice86.Core/Spice86.Core.csproj
+++ b/src/Spice86.Core/Spice86.Core.csproj
@@ -46,6 +46,7 @@
         <ProjectReference Include="..\Spice86.Shared\Spice86.Shared.csproj" />
     </ItemGroup>
     <ItemGroup>
+        <None Include="..\..\3rdparty\Release\FastExpressionCompiler.dll" Pack="true" PackagePath="lib\$(TargetFramework)\" Visible="false" />
         <None Update="Resources\2MGM.license">
             <Link>2MGM.license</Link>
             <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>


### PR DESCRIPTION
Included FastExpressionCompiler.dll as a non-source file in Spice86.Core.csproj. The DLL will be packed into the NuGet package under the correct lib directory for the target framework.