### PR TITLE
fix: Open ListBox context menu on ListBox, not ListBoxItem

### DIFF
--- a/src/Spice86/Views/Behaviors/UseParentListBoxContextMenuBehavior.cs
+++ b/src/Spice86/Views/Behaviors/UseParentListBoxContextMenuBehavior.cs
@@ -51,7 +51,7 @@ public class UseParentListBoxContextMenuBehavior {
         // Open on the next dispatcher cycle to avoid pointer/menu interaction races.
         Dispatcher.UIThread.Post(() => {
             listBox.SelectedItem = listBoxItem.DataContext;
-            listBox.ContextMenu.Open(listBoxItem);
+            listBox.ContextMenu.Open(listBox);
         }, DispatcherPriority.Normal);
     }
 


### PR DESCRIPTION
### Description of Changes

Open ListBox context menu on ListBox, not ListBoxItem

### Rationale behind Changes

Solves this:

[2026-05-05 20:10:16.958 +02:00] [INFO] [0/0000:0000] GDB Server listening on port 10000
Unhandled exception. System.ArgumentException: Cannot show ContentMenu on a different control to the one it is attached to. (Parameter 'control')
   at Avalonia.Controls.ContextMenu.Open(Control control)
   at Spice86.Views.Behaviors.UseParentListBoxContextMenuBehavior.<>c__DisplayClass2_0.<OnContextRequested>b__0() in C:\Users\noalm\source\repos\Spice86\src\Spice86\Views\Behaviors\UseParentListBoxContextMenuBehavior.cs:line 54
   at Avalonia.Threading.DispatcherOperation.InvokeCore()
   at Avalonia.Threading.Dispatcher.ExecuteJobsCore(Boolean fromExplicitBackgroundProcessingCallback)
   at Avalonia.Win32.Win32Platform.WndProc(IntPtr hWnd, UInt32 msg, IntPtr wParam, IntPtr lParam)
   at Avalonia.Win32.Interop.UnmanagedMethods.DispatchMessage(MSG& lpmsg)
   at Avalonia.Win32.Win32DispatcherImpl.RunLoop(CancellationToken cancellationToken)
   at Avalonia.Threading.DispatcherFrame.Run(IControlledDispatcherImpl impl)
   at Avalonia.Threading.Dispatcher.PushFrame(DispatcherFrame frame)
   at Avalonia.Threading.Dispatcher.MainLoop(CancellationToken cancellationToken)
   at Avalonia.Controls.ApplicationLifetimes.ClassicDesktopStyleApplicationLifetime.StartCore(String[] args)
   at Avalonia.Controls.ApplicationLifetimes.ClassicDesktopStyleApplicationLifetime.Start(String[] args)
   at Avalonia.ClassicDesktopStyleApplicationLifetimeExtensions.StartWithClassicDesktopLifetime(AppBuilder builder, String[] args, ShutdownMode shutdownMode)
   at Spice86.Program.Main(String[] args) in C:\Users\noalm\source\repos\Spice86\src\Spice86\Program.cs:line 53

C:\Users\noalm\source\repos\Spice86\src\Spice86\bin\Debug\net10.0\Spice86.exe (process 31344) exited with code -532462766 (0xe0434352).
