### PR TITLE
Fix: Adjust MediaIdTable offset in DOS parameter block (Wolf3D)

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -16,7 +16,7 @@
 	</PropertyGroup>
 	<!-- Nuget package info-->
 	<PropertyGroup>
-		<Version>13.1.0</Version>
+		<Version>13.1.1</Version>
 		<PackageReleaseNotes>
             <![CDATA[
             # Release Notes - https://github.com/OpenRakis/Spice86/wiki/Spice86-v13-release-notes

--- a/src/Spice86.Core/Emulator/OperatingSystem/Dos.cs
+++ b/src/Spice86.Core/Emulator/OperatingSystem/Dos.cs
@@ -184,7 +184,8 @@ public sealed class Dos {
 
         DosTables = new DosTables(memory);
         ushort mediaIdSegment = DosTables.ReserveDosPrivateSegment((ushort)DosMediaIdTable.TableSizeInParagraphs);
-        DosMediaIdTable mediaIdTable = new(memory, MemoryUtils.ToPhysicalAddress(mediaIdSegment, 0), mediaIdSegment);
+        DosMediaIdTable mediaIdTable = new(memory,
+            MemoryUtils.ToPhysicalAddress(mediaIdSegment, DosMediaIdTable.EntryBaseOffsetInSegment), mediaIdSegment);
         DosDriveManager = new(_loggerService, configuration.CDrive, configuration.Exe, mediaIdTable);
 
         VirtualFileBase[] dosDevices = AddDefaultDevices(state, keyboardInt16Handler);

--- a/src/Spice86.Core/Emulator/OperatingSystem/Structures/DosMediaIdTable.cs
+++ b/src/Spice86.Core/Emulator/OperatingSystem/Structures/DosMediaIdTable.cs
@@ -13,11 +13,16 @@ using Spice86.Core.Emulator.ReverseEngineer.DataStructure;
 /// where media IDs are spaced at <c>i*9</c> offsets.
 /// </remarks>
 public class DosMediaIdTable : MemoryBasedDataStructure {
+    /// <summary>
+    /// The in-segment DPB offset where DOS expects the media-id table to start.
+    /// </summary>
+    public const ushort EntryBaseOffsetInSegment = 0x17;
+
     /// <summary>Bytes per drive entry.</summary>
     public const int EntrySize = 9;
 
     /// <summary>Total bytes required for all 26 drive entries.</summary>
-    public const int TableSizeInBytes = 26 * EntrySize;
+    public const int TableSizeInBytes = EntryBaseOffsetInSegment + (26 * EntrySize);
 
     /// <summary>Paragraphs (16-byte blocks) required to hold the full table.</summary>
     public const int TableSizeInParagraphs = (TableSizeInBytes + 15) / 16;
@@ -45,5 +50,5 @@ public class DosMediaIdTable : MemoryBasedDataStructure {
     /// <summary>
     /// Returns the in-segment offset of the given drive's entry, for use as BX in the DS:BX pointer.
     /// </summary>
-    public ushort EntryOffset(byte driveIndex) => (ushort)(driveIndex * EntrySize);
+    public ushort EntryOffset(byte driveIndex) => (ushort)(EntryBaseOffsetInSegment + (driveIndex * EntrySize));
 }

--- a/tests/Spice86.Tests/Dos/DosInt21IntegrationTests.cs
+++ b/tests/Spice86.Tests/Dos/DosInt21IntegrationTests.cs
@@ -1036,9 +1036,9 @@ public class DosInt21IntegrationTests {
             0x81, 0xFA, 0xFD, 0x7F, // cmp dx, 7FFDh
             0x75, 0x11,             // jne failed
 
-            // BX should point to C: media entry (index 2 => offset 0x12)
+            // BX should point to C: media entry (DPB base 0x17 + index 2 * 9 => offset 0x29)
             // DS segment is dynamic (allocated from DOS private area), so not checked
-            0x83, 0xFB, 0x12,       // cmp bx, 0012h
+            0x83, 0xFB, 0x29,       // cmp bx, 0029h
             0x75, 0x0C,             // jne failed
 
             // First byte of media-id entry for C: should be fixed-disk descriptor 0xF8


### PR DESCRIPTION
### Description of Changes

Introduce MediaIdOffsetInDosParameterBlock constant (0x17) and use it when calculating the physical address for DosMediaIdTable. This ensures the table is placed at the correct offset within the DOS parameter block.

### Rationale behind Changes

<img width="2884" height="100" alt="image" src="https://github.com/user-attachments/assets/a04e1748-93b7-4653-ae24-e79fb0c37a19" />

Wolf3D crashes at startup otherwise.

### Suggested Testing Steps

Tested manually with Wolf3D.