### PR TITLE
Improvements to DosDriveManager

### DIFF
--- a/src/Spice86.Core/Emulator/InterruptHandlers/Dos/DosDiskInt25Handler.cs
+++ b/src/Spice86.Core/Emulator/InterruptHandlers/Dos/DosDiskInt25Handler.cs
@@ -25,7 +25,7 @@ public class DosDiskInt25Handler : InterruptHandler {
         ushort startingLogicalSector = State.DX;
         SegmentedAddress bufferForData = new(State.DS, State.BX);
 
-        if (driveNumber >= DosDriveManager.MaxDriveCount || !_dosDriveManager.HasDriveAtIndex(State.AL)) {
+        if (!_dosDriveManager.HasDriveAtIndex(State.AL)) {
             State.AX = 0x8002;
             SetCarryFlag(true, true);
         } else {

--- a/src/Spice86.Core/Emulator/InterruptHandlers/Dos/DosDiskInt26Handler.cs
+++ b/src/Spice86.Core/Emulator/InterruptHandlers/Dos/DosDiskInt26Handler.cs
@@ -21,7 +21,7 @@ public class DosDiskInt26Handler : InterruptHandler {
         if (LoggerService.IsEnabled(Serilog.Events.LogEventLevel.Warning)) {
             LoggerService.Warning("DOS INT26H was called, hope for the best!");
         }
-        if (State.AL >= DosDriveManager.MaxDriveCount || !_dosDriveManager.HasDriveAtIndex(State.AL)) {
+        if (!_dosDriveManager.HasDriveAtIndex(State.AL)) {
             State.AX = 0x8002;
             SetCarryFlag(true, true);
         } else {

--- a/src/Spice86.Core/Emulator/InterruptHandlers/Dos/DosInt21Handler.cs
+++ b/src/Spice86.Core/Emulator/InterruptHandlers/Dos/DosInt21Handler.cs
@@ -662,12 +662,7 @@ public class DosInt21Handler : InterruptHandler {
             driveIndex = (byte)(driveRequest - 1);
         }
 
-        if (driveIndex >= DosDriveManager.MaxDriveCount) {
-            return false;
-        }
-
-        char driveLetter = (char)('A' + driveIndex);
-        if (!_dosDriveManager.TryGetDrive(driveLetter, out VirtualDrive? resolvedDrive)) {
+        if (!_dosDriveManager.TryGetDriveAtIndex(driveIndex, out VirtualDrive? resolvedDrive)) {
             return false;
         }
 
@@ -1781,8 +1776,7 @@ public class DosInt21Handler : InterruptHandler {
     public void SelectDefaultDrive() {
         byte driveIndex = State.DL;
         if (driveIndex < DosDriveManager.MaxDriveCount) {
-            char driveLetter = (char)('A' + driveIndex);
-            if (_dosDriveManager.TryGetDrive(driveLetter, out VirtualDrive? mountedDrive)) {
+            if (_dosDriveManager.TryGetDriveAtIndex(driveIndex, out VirtualDrive? mountedDrive)) {
                 _dosDriveManager.CurrentDrive = mountedDrive;
             }
         } else if (LoggerService.IsEnabled(LogEventLevel.Error)) {

--- a/src/Spice86.Core/Emulator/InterruptHandlers/Dos/DosInt21Handler.cs
+++ b/src/Spice86.Core/Emulator/InterruptHandlers/Dos/DosInt21Handler.cs
@@ -667,7 +667,7 @@ public class DosInt21Handler : InterruptHandler {
         }
 
         char driveLetter = (char)('A' + driveIndex);
-        if (!_dosDriveManager.TryGetValue(driveLetter, out VirtualDrive? resolvedDrive) || resolvedDrive == null) {
+        if (!_dosDriveManager.TryGetDrive(driveLetter, out VirtualDrive? resolvedDrive)) {
             return false;
         }
 
@@ -1782,7 +1782,7 @@ public class DosInt21Handler : InterruptHandler {
         byte driveIndex = State.DL;
         if (driveIndex < DosDriveManager.MaxDriveCount) {
             char driveLetter = (char)('A' + driveIndex);
-            if (_dosDriveManager.TryGetValue(driveLetter, out VirtualDrive? mountedDrive)) {
+            if (_dosDriveManager.TryGetDrive(driveLetter, out VirtualDrive? mountedDrive)) {
                 _dosDriveManager.CurrentDrive = mountedDrive;
             }
         } else if (LoggerService.IsEnabled(LogEventLevel.Error)) {

--- a/src/Spice86.Core/Emulator/Mcp/EmulatorMcpTools.cs
+++ b/src/Spice86.Core/Emulator/Mcp/EmulatorMcpTools.cs
@@ -1162,6 +1162,8 @@ internal sealed class EmulatorMcpTools {
             lock (_services.ToolsLock) {
                 Dos dos = GetDos();
                 List<DosDriveResponse> drives = dos.DosDriveManager.Values
+                    .Where(static drive => drive is VirtualDrive)
+                    .Cast<VirtualDrive>()
                     .Select(static drive => new DosDriveResponse {
                         Drive = drive.DosVolume,
                         CurrentDosDirectory = drive.CurrentDosDirectory,
@@ -1246,7 +1248,7 @@ internal sealed class EmulatorMcpTools {
                 }
 
                 char normalizedDriveLetter = char.ToUpperInvariant(driveLetter[0]);
-                if (!dos.DosDriveManager.TryGetValue(normalizedDriveLetter, out VirtualDrive? mountedDrive) || mountedDrive == null) {
+                if (!dos.DosDriveManager.TryGetDrive(normalizedDriveLetter, out VirtualDrive? mountedDrive) || mountedDrive == null) {
                     throw new InvalidOperationException($"Drive '{normalizedDriveLetter}' is not mounted");
                 }
 
@@ -1534,7 +1536,7 @@ internal sealed class EmulatorMcpTools {
 
         char driveLetterChar = driveLetter[0];
         int driveIndex = DosDriveManager.GetDriveLetterIndexOrThrow(driveLetterChar, nameof(driveLetter));
-        if (!dos.DosDriveManager.TryGetValue(driveLetterChar, out VirtualDrive? virtualDrive) || virtualDrive == null) {
+        if (!dos.DosDriveManager.TryGetDrive(driveLetterChar, out VirtualDrive? virtualDrive) || virtualDrive == null) {
             throw new InvalidOperationException($"Drive '{driveLetterChar}' is not mounted");
         }
 

--- a/src/Spice86.Core/Emulator/Mcp/EmulatorMcpTools.cs
+++ b/src/Spice86.Core/Emulator/Mcp/EmulatorMcpTools.cs
@@ -1174,7 +1174,7 @@ internal sealed class EmulatorMcpTools {
                 return new DosStateResponse {
                     CurrentDrive = dos.DosDriveManager.CurrentDrive.DosVolume,
                     CurrentDriveIndex = dos.DosDriveManager.CurrentDriveIndex,
-                    PotentialDriveLetters = dos.DosDriveManager.NumberOfPotentiallyValidDriveLetters,
+                    PotentialDriveLetters = dos.DosDriveManager.Count,
                     CurrentProgramSegmentPrefix = dos.DosSwappableDataArea.CurrentProgramSegmentPrefix,
                     DeviceCount = dos.Devices.Count,
                     HasEms = dos.Ems != null,

--- a/src/Spice86.Core/Emulator/Mcp/EmulatorMcpTools.cs
+++ b/src/Spice86.Core/Emulator/Mcp/EmulatorMcpTools.cs
@@ -1532,12 +1532,10 @@ internal sealed class EmulatorMcpTools {
             throw new ArgumentException("Drive letter must be empty or a single character between A and Z");
         }
 
-        char normalizedDriveLetter = char.ToUpperInvariant(driveLetter[0]);
-        if (!DosDriveManager.DriveLetters.TryGetValue(normalizedDriveLetter, out byte driveIndex)) {
-            throw new ArgumentException($"Drive letter '{normalizedDriveLetter}' is invalid");
-        }
-        if (!dos.DosDriveManager.TryGetValue(normalizedDriveLetter, out VirtualDrive? virtualDrive) || virtualDrive == null) {
-            throw new InvalidOperationException($"Drive '{normalizedDriveLetter}' is not mounted");
+        char driveLetterChar = driveLetter[0];
+        int driveIndex = DosDriveManager.GetDriveLetterIndexOrThrow(driveLetterChar, nameof(driveLetter));
+        if (!dos.DosDriveManager.TryGetValue(driveLetterChar, out VirtualDrive? virtualDrive) || virtualDrive == null) {
+            throw new InvalidOperationException($"Drive '{driveLetterChar}' is not mounted");
         }
 
         resolvedDrive = virtualDrive.DosVolume;

--- a/src/Spice86.Core/Emulator/Mcp/EmulatorMcpTools.cs
+++ b/src/Spice86.Core/Emulator/Mcp/EmulatorMcpTools.cs
@@ -1535,7 +1535,7 @@ internal sealed class EmulatorMcpTools {
         }
 
         char driveLetterChar = driveLetter[0];
-        int driveIndex = DosDriveManager.GetDriveLetterIndexOrThrow(driveLetterChar, nameof(driveLetter));
+        int driveIndex = DosDriveManager.GetDriveIndexOrThrow(driveLetterChar, nameof(driveLetter));
         if (!dos.DosDriveManager.TryGetDrive(driveLetterChar, out VirtualDrive? virtualDrive) || virtualDrive == null) {
             throw new InvalidOperationException($"Drive '{driveLetterChar}' is not mounted");
         }

--- a/src/Spice86.Core/Emulator/OperatingSystem/DosDriveManager.cs
+++ b/src/Spice86.Core/Emulator/OperatingSystem/DosDriveManager.cs
@@ -339,10 +339,11 @@ public class DosDriveManager : IDictionary<char, DosDriveBase>, IReadOnlyDiction
         Mount(item.Value);
     }
 
-    /// <inheritdoc/>
+    /// <summary>Removes all mounted drives from the collection.</summary>
     /// <exception cref="AggregateException">One or more exceptions were thrown while drives were being unmounted.</exception>
     /// <remarks>
-    /// This will always dispose of the drives before removing them from the collection.
+    /// This will always dispose of the drives before removing them from the collection. (Equivalent to calling
+    /// <see cref="Clear(bool)"/> with the dispose drives parameter set to <see langword="true"/>.)
     /// </remarks>
     public void Clear() => Clear(disposeDrives: true);
 
@@ -778,8 +779,18 @@ public class DosDriveManager : IDictionary<char, DosDriveBase>, IReadOnlyDiction
 
     #endregion
 
+    /// <summary>Removes all mounted drives from the collection.</summary>
+    /// <param name="disposeDrives">
+    /// If <see langword="true"/>, then all currently mounted drives will be disposed (if applicable); otherwise,
+    /// drives will only be removed from the collection.
+    /// </param>
     /// <exception cref="AggregateException">One or more exceptions were thrown while drives were being unmounted.</exception>
-    public void Clear(bool disposeDrives = true) {
+    /// <remarks>
+    /// Removing drives from this collection without disposing may result in unexpected behavior or memory leaks. It is
+    /// up to the caller to make sure that any drives that are currently mounted are disposed before clearing the
+    /// collection.
+    /// </remarks>
+    public void Clear(bool disposeDrives) {
         if (!disposeDrives) {
             Array.Clear(_driveMap);
             _mappedDriveCount--;

--- a/src/Spice86.Core/Emulator/OperatingSystem/DosDriveManager.cs
+++ b/src/Spice86.Core/Emulator/OperatingSystem/DosDriveManager.cs
@@ -95,6 +95,17 @@ public class DosDriveManager : IDictionary<char, DosDriveBase>, IReadOnlyDiction
     }
 
     /// <summary>
+    /// Attempts to get the zero-based drive index associated with the given DOS drive letter.
+    /// </summary>
+    /// <param name="value">The DOS drive letter. Valid drive letters are uppercase and lowercase ASCII letters.</param>
+    /// <param name="driveIndex">The zero-based index associated with the drive letter or -1 on failure.</param>
+    /// <returns><see langword="true"/> if the drive letter and associated drive index is valid; otherwise, <see langword="false"/>.</returns>
+    public static bool TryGetDriveLetterIndex(char value, out int driveIndex) {
+        driveIndex = GetDriveLetterIndex(value);
+        return driveIndex != -1;
+    }
+
+    /// <summary>
     /// Gets the DOS drive letter from a zero-based drive index.
     /// </summary>
     /// <param name="index">Must be a zero-based drive index between 0 (inclusive) and <see cref="MaxDriveCount"/> (exclusive).</param>
@@ -182,7 +193,7 @@ public class DosDriveManager : IDictionary<char, DosDriveBase>, IReadOnlyDiction
     /// </summary>
     public byte CurrentDriveIndex => (byte)GetDriveLetterIndexOrThrow(CurrentDrive.DriveLetter);
 
-    internal bool HasDriveAtIndex(ushort zeroBasedIndex) => zeroBasedIndex is >= 0 and < MaxDriveCount &&
+    internal bool HasDriveAtIndex(int zeroBasedIndex) => zeroBasedIndex is >= 0 and < MaxDriveCount &&
         _driveMap[zeroBasedIndex] is not null;
 
     /// <summary>

--- a/src/Spice86.Core/Emulator/OperatingSystem/DosDriveManager.cs
+++ b/src/Spice86.Core/Emulator/OperatingSystem/DosDriveManager.cs
@@ -6,7 +6,6 @@ using Spice86.Shared.Utils;
 
 using System.Collections;
 using System.Collections.Generic;
-using System.Collections.Immutable;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Runtime.CompilerServices;
@@ -174,36 +173,6 @@ public class DosDriveManager : IDictionary<char, VirtualDrive> {
     /// The currently selected drive.
     /// </summary>
     public VirtualDrive CurrentDrive { get; set; }
-
-    internal static readonly ImmutableSortedDictionary<char, byte> DriveLetters = new Dictionary<char, byte>() {
-            { 'A', 0 },
-            { 'B', 1 },
-            { 'C', 2 },
-            { 'D', 3 },
-            { 'E', 4 },
-            { 'F', 5 },
-            { 'G', 6 },
-            { 'H', 7 },
-            { 'I', 8 },
-            { 'J', 9 },
-            { 'K', 10 },
-            { 'L', 11 },
-            { 'M', 12 },
-            { 'N', 13 },
-            { 'O', 14 },
-            { 'P', 15 },
-            { 'Q', 16 },
-            { 'R', 17 },
-            { 'S', 18 },
-            { 'T', 19 },
-            { 'U', 20 },
-            { 'V', 21 },
-            { 'W', 22 },
-            { 'X', 23 },
-            { 'Y', 24 },
-            { 'Z', 25 }
-        }.ToImmutableSortedDictionary();
-
 
     /// <summary>
     /// Gets the current DOS drive zero based index.

--- a/src/Spice86.Core/Emulator/OperatingSystem/DosDriveManager.cs
+++ b/src/Spice86.Core/Emulator/OperatingSystem/DosDriveManager.cs
@@ -7,7 +7,9 @@ using Spice86.Shared.Utils;
 using System.Collections;
 using System.Collections.Generic;
 using System.Collections.Immutable;
+using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
+using System.Runtime.CompilerServices;
 
 /// <summary>
 /// The class responsible for centralizing all the mounted DOS drives.
@@ -16,6 +18,11 @@ public class DosDriveManager : IDictionary<char, VirtualDrive> {
     private readonly SortedDictionary<char, VirtualDrive> _driveMap = new();
     private readonly Dictionary<char, MemoryDrive> _memoryDriveMap = new();
     private readonly DosMediaIdTable _mediaIdTable;
+
+    /// <summary>
+    /// The maximum number of possible DOS drives that can be used.
+    /// </summary>
+    public const int MaxDriveCount = 26; // A: thru Z:
 
     /// <summary>
     /// Initializes a new instance.
@@ -40,6 +47,128 @@ public class DosDriveManager : IDictionary<char, VirtualDrive> {
             loggerService.Verbose("DOS Drives initialized: {@Drives}", _driveMap.Values);
         }
     }
+
+    #region Drive Letter Helpers
+
+    /// <summary>
+    /// Gets the zero-based drive index associated with the given DOS drive letter.
+    /// </summary>
+    /// <param name="value">The DOS drive letter. Valid drive letters are uppercase and lowercase ASCII letters.</param>
+    /// <returns>The zero-based drive index associated with the drive letter or -1 if the drive letter is invalid.</returns>
+    public static int GetDriveLetterIndex(char value) {
+        // Since only ASCII letters are valid here, this could be further optimized by using the "bitwise OR by 0x20"
+        // trick to force letters into lowercase, then subtract it by 'a' (into an int), and finally perform an
+        // unsigned comparison check to validate that it's in the range [A-Z] or [a-z] to determine whether it should
+        // return the subtracted value or -1. That's the optimization that Char.IsAsciiLetter() currently uses.
+        // Faster (but less maintainable/readable):
+        //   int result = (value | 0x20) - 'a';
+        //   return ((uint)result <= 'z' - 'a') ? result : -1;
+
+        if (char.IsBetween(value, 'A', 'Z')) {
+            return value - 'A';
+        }
+
+        if (char.IsBetween(value, 'a', 'z')) {
+            return value - 'a';
+        }
+
+        return -1;
+    }
+
+    /// <summary>
+    /// Gets the zero-based drive index associated with the given DOS drive letter.
+    /// </summary>
+    /// <param name="value">The DOS drive letter. Valid drive letters are uppercase and lowercase ASCII letters.</param>
+    /// <param name="paramName">The parameter name to pass into the <see cref="ArgumentException"/> if <paramref name="value"/> is invalid.</param>
+    /// <returns>The zero-based index associated with the drive letter.</returns>
+    /// <exception cref="ArgumentException"><paramref name="value"/> is not a valid drive letter.</exception>
+    internal static int GetDriveLetterIndexOrThrow(char value, [CallerArgumentExpression(nameof(value))] string? paramName = null) {
+        int driveIndex = GetDriveLetterIndex(value);
+        if (driveIndex == -1) {
+            throw new ArgumentException($"Drive letter '{(!char.IsControl(value) ? value : '?')}' (0x{(int)value:x}) is invalid. It must be an ASCII uppercase or lowercase character between 'A' and 'Z' (inclusive).", paramName);
+        }
+
+        Debug.Assert(driveIndex is >= 0 and < MaxDriveCount);
+        return driveIndex;
+    }
+
+    /// <summary>
+    /// Gets the DOS drive letter from a zero-based drive index.
+    /// </summary>
+    /// <param name="index">Must be a zero-based drive index between 0 (inclusive) and <see cref="MaxDriveCount"/> (exclusive).</param>
+    /// <returns>An uppercase ASCII letter representing the drive letter.</returns>
+    /// <remarks>
+    /// For performance reasons (fast and efficient inlining), this will not throw an <see cref="ArgumentException"/>
+    /// if the index is out of range. Thus <paramref name="index"/> must always be validated by the caller prior to
+    /// calling this method (and is the reason why it is an internal method).
+    /// </remarks>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    internal static char GetDriveLetterFromIndexFast(int index) {
+        Debug.Assert(index is >= 0 and < MaxDriveCount);
+        return (char)(index + 'A'); // Only works as long as MaxDriveCount is <= 26.
+    }
+
+    /// <summary>
+    /// Gets the DOS drive letter from a zero-based drive index.
+    /// </summary>
+    /// <param name="index">A zero-based drive index between 0 (inclusive) and <see cref="MaxDriveCount"/> (exclusive).</param>
+    /// <returns>An uppercase ASCII letter representing the drive letter.</returns>
+    /// <exception cref="ArgumentOutOfRangeException"><paramref name="index"/> is negative or greater than or equal to <see cref="MaxDriveCount"/>.</exception>
+    public static char GetDriveLetterFromIndex(int index) {
+        ArgumentOutOfRangeException.ThrowIfNegative(index);
+        ArgumentOutOfRangeException.ThrowIfGreaterThanOrEqual(index, MaxDriveCount);
+        return GetDriveLetterFromIndexFast(index);
+    }
+
+    /// <summary>
+    /// Attempts to get the DOS drive letter from a zero-based drive index.
+    /// </summary>
+    /// <param name="index">A zero-based drive index between 0 (inclusive) and <see cref="MaxDriveCount"/> (exclusive).</param>
+    /// <param name="driveIndex">If successful, then it is the uppercase ASCII letter representing the drive letter.</param>
+    /// <returns><see langword="true"/> if the drive index is valid; otherwise, <see langword="false"/>.</returns>
+    public static bool TryGetDriveLetterFromIndex(int index, out char driveLetter) {
+        if (index is >= 0 and < MaxDriveCount) {
+            driveLetter = GetDriveLetterFromIndexFast(index);
+            return true;
+        }
+
+        driveLetter = default;
+        return false;
+    }
+
+    /// <summary>
+    /// Validates and normalizes the given drive letter.
+    /// </summary>
+    /// <param name="value">The DOS drive letter. Valid drive letters are uppercase and lowercase ASCII letters.</param>
+    /// <returns>The normalized (uppercase) drive letter.</returns>
+    /// <exception cref="ArgumentException"><paramref name="value"/> is not a valid drive letter.</exception>
+    public static char NormalizeDriveLetter(char value) {
+        // The conversion to an index will validate the char value and the conversion from index to letter will
+        // normalize the value to an uppercase drive letter.
+        int driveIndex = GetDriveLetterIndexOrThrow(value);
+        return GetDriveLetterFromIndexFast(driveIndex);
+    }
+
+    /// <summary>
+    /// Attempts to validate and normalize the given drive letter.
+    /// </summary>
+    /// <param name="value">The DOS drive letter. Valid drive letters are uppercase and lowercase ASCII letters.</param>
+    /// <param name="normalizedDriveLetter">The normalized (uppercase) drive letter or a default <see cref="char"/> value on failure.</param>
+    /// <returns><see langword="true"/> if drive letter is valid and successfully normalized; otherwise, <see langword="false"/>.</returns>
+    public static bool TryNormalizeDriveLetter(char value, out char normalizedDriveLetter) {
+        // The conversion to an index will validate the char value and the conversion from index to letter will
+        // normalize the value to an uppercase drive letter.
+        int driveIndex = GetDriveLetterIndex(value);
+        if (driveIndex != -1) {
+            normalizedDriveLetter = GetDriveLetterFromIndexFast(driveIndex);
+            return true;
+        }
+
+        normalizedDriveLetter = default;
+        return false;
+    }
+
+    #endregion
 
     /// <summary>
     /// The currently selected drive.
@@ -79,7 +208,7 @@ public class DosDriveManager : IDictionary<char, VirtualDrive> {
     /// <summary>
     /// Gets the current DOS drive zero based index.
     /// </summary>
-    public byte CurrentDriveIndex => DriveLetters[CurrentDrive.DriveLetter];
+    public byte CurrentDriveIndex => (byte)GetDriveLetterFromIndex(CurrentDrive.DriveLetter);
 
     internal bool HasDriveAtIndex(ushort zeroBasedIndex) {
         if (zeroBasedIndex > _driveMap.Count - 1) {
@@ -107,9 +236,6 @@ public class DosDriveManager : IDictionary<char, VirtualDrive> {
     public bool IsReadOnly => ((ICollection<KeyValuePair<char, VirtualDrive>>)_driveMap).IsReadOnly;
 
     public VirtualDrive this[char key] { get => ((IDictionary<char, VirtualDrive>)_driveMap)[key]; set => ((IDictionary<char, VirtualDrive>)_driveMap)[key] = value; }
-
-
-    public const int MaxDriveCount = 26;
 
     private const byte FloppyMediaDescriptor = 0xF0;
     private const byte FixedDiskMediaDescriptor = 0xF8;

--- a/src/Spice86.Core/Emulator/OperatingSystem/DosDriveManager.cs
+++ b/src/Spice86.Core/Emulator/OperatingSystem/DosDriveManager.cs
@@ -44,6 +44,7 @@ public class DosDriveManager : IDictionary<char, DosDriveBase>, IReadOnlyDiction
         var cDrive = new VirtualDrive { DriveLetter = 'C', MountedHostDirectory = cDriveFolderPath };
         _driveMap[GetDriveIndex('C')] = cDrive;
         CurrentDrive = cDrive;
+        _mappedDriveCount = 3; // A:, B:, C:
         InitializeMediaDescriptors();
         if (loggerService.IsEnabled(Serilog.Events.LogEventLevel.Verbose)) {
             loggerService.Verbose("DOS Drives initialized: {@Drives}", Values);
@@ -195,16 +196,6 @@ public class DosDriveManager : IDictionary<char, DosDriveBase>, IReadOnlyDiction
 
     internal bool HasDriveAtIndex(int zeroBasedIndex) => zeroBasedIndex is >= 0 and < MaxDriveCount &&
         _driveMap[zeroBasedIndex] is not null;
-
-    /// <summary>
-    /// Gets the number of DOS drive letters assigned.
-    /// </summary>
-    public byte NumberOfPotentiallyValidDriveLetters {
-        get {
-            // At least A: and B:
-            return (byte)Count;
-        }
-    }
 
     private const byte FloppyMediaDescriptor = 0xF0;
     private const byte FixedDiskMediaDescriptor = 0xF8;

--- a/src/Spice86.Core/Emulator/OperatingSystem/DosDriveManager.cs
+++ b/src/Spice86.Core/Emulator/OperatingSystem/DosDriveManager.cs
@@ -340,10 +340,11 @@ public class DosDriveManager : IDictionary<char, DosDriveBase>, IReadOnlyDiction
     }
 
     /// <summary>Removes all mounted drives from the collection.</summary>
-    /// <exception cref="AggregateException">One or more exceptions were thrown while drives were being unmounted.</exception>
     /// <remarks>
     /// This will always dispose of the drives before removing them from the collection. (Equivalent to calling
     /// <see cref="Clear(bool)"/> with the dispose drives parameter set to <see langword="true"/>.)
+    /// 
+    /// This may fail and result in an incomplete drive manager if a drive throws an exception while being disposed.
     /// </remarks>
     public void Clear() => Clear(disposeDrives: true);
 
@@ -781,14 +782,15 @@ public class DosDriveManager : IDictionary<char, DosDriveBase>, IReadOnlyDiction
 
     /// <summary>Removes all mounted drives from the collection.</summary>
     /// <param name="disposeDrives">
-    /// If <see langword="true"/>, then all currently mounted drives will be disposed (if applicable); otherwise,
-    /// drives will only be removed from the collection.
+    /// If <see langword="true"/>, then all currently mounted drives will be disposed (if applicable). If
+    /// <see langword="false"/>, then drives will only be removed from the collection and will not be disposed.
     /// </param>
-    /// <exception cref="AggregateException">One or more exceptions were thrown while drives were being unmounted.</exception>
     /// <remarks>
     /// Removing drives from this collection without disposing may result in unexpected behavior or memory leaks. It is
     /// up to the caller to make sure that any drives that are currently mounted are disposed before clearing the
     /// collection.
+    /// 
+    /// This may fail and result in an incomplete drive manager if a drive throws an exception while being disposed.
     /// </remarks>
     public void Clear(bool disposeDrives) {
         if (!disposeDrives) {
@@ -799,15 +801,10 @@ public class DosDriveManager : IDictionary<char, DosDriveBase>, IReadOnlyDiction
         }
 
         // Keep track of exceptions that occur while removing drives.
-        List<Exception> exceptions = [];
         for (int i = 0; i < MaxDriveCount; i++) {
             DosDriveBase? drive = _driveMap[i];
             if (drive is not null) {
-                try {
-                    RemoveDriveInternal(drive, i);
-                } catch (Exception ex) {
-                    exceptions.Add(ex);
-                }
+                RemoveDriveInternal(drive, i);
             }
         }
 
@@ -815,11 +812,6 @@ public class DosDriveManager : IDictionary<char, DosDriveBase>, IReadOnlyDiction
 
         // Always increment the version, even if no drives were unmounted.
         _version++;
-
-        // Throw any exceptions that occurred while clearing the collection.
-        if (exceptions.Count > 0) {
-            throw new AggregateException(exceptions);
-        }
     }
 
     /// <summary>
@@ -987,7 +979,7 @@ public class DosDriveManager : IDictionary<char, DosDriveBase>, IReadOnlyDiction
     /// <param name="driveIndex">A zero-based drive index between 0 (inclusive) and <see cref="MaxDriveCount"/> (exclusive).</param>
     /// <param name="value">The mounted drive of the specified type if found; otherwise, <see langword="null"/>.</param>
     /// <returns><see langword="true"/> if a drive of the specified type exists with the given DOS drive letter; otherwise, <see langword="false"/>.</returns>
-    public bool TryGetDriveAtIndex<T>(int driveIndex, [NotNullWhen(true)] out T? value) where T : DosDriveBase{
+    public bool TryGetDriveAtIndex<T>(int driveIndex, [NotNullWhen(true)] out T? value) where T : DosDriveBase {
         if (driveIndex is >= 0 and < MaxDriveCount) {
             DosDriveBase? mountedDrive = _driveMap[driveIndex];
             if (mountedDrive is T mountedDriveType) {

--- a/src/Spice86.Core/Emulator/OperatingSystem/DosDriveManager.cs
+++ b/src/Spice86.Core/Emulator/OperatingSystem/DosDriveManager.cs
@@ -39,10 +39,10 @@ public class DosDriveManager : IDictionary<char, DosDriveBase>, IReadOnlyDiction
             cDriveFolderPath = DosPathResolver.GetExeParentFolder(executablePath);
         }
         cDriveFolderPath = ConvertUtils.ToSlashFolderPath(cDriveFolderPath);
-        _driveMap[GetDriveLetterIndex('A')] = new VirtualDrive() { DriveLetter = 'A', MountedHostDirectory = "" };
-        _driveMap[GetDriveLetterIndex('B')] = new VirtualDrive() { DriveLetter = 'B', MountedHostDirectory = "" };
+        _driveMap[GetDriveIndex('A')] = new VirtualDrive() { DriveLetter = 'A', MountedHostDirectory = "" };
+        _driveMap[GetDriveIndex('B')] = new VirtualDrive() { DriveLetter = 'B', MountedHostDirectory = "" };
         var cDrive = new VirtualDrive { DriveLetter = 'C', MountedHostDirectory = cDriveFolderPath };
-        _driveMap[GetDriveLetterIndex('C')] = cDrive;
+        _driveMap[GetDriveIndex('C')] = cDrive;
         CurrentDrive = cDrive;
         InitializeMediaDescriptors();
         if (loggerService.IsEnabled(Serilog.Events.LogEventLevel.Verbose)) {
@@ -55,9 +55,9 @@ public class DosDriveManager : IDictionary<char, DosDriveBase>, IReadOnlyDiction
     /// <summary>
     /// Gets the zero-based drive index associated with the given DOS drive letter.
     /// </summary>
-    /// <param name="value">The DOS drive letter. Valid drive letters are uppercase and lowercase ASCII letters.</param>
+    /// <param name="driveLetter">The DOS drive letter. Valid drive letters are uppercase and lowercase ASCII letters.</param>
     /// <returns>The zero-based drive index associated with the drive letter or -1 if the drive letter is invalid.</returns>
-    public static int GetDriveLetterIndex(char value) {
+    public static int GetDriveIndex(char driveLetter) {
         // Since only ASCII letters are valid here, this could be further optimized by using the "bitwise OR by 0x20"
         // trick to force letters into lowercase, then subtract it by 'a' (into an int), and finally perform an
         // unsigned comparison check to validate that it's in the range [A-Z] or [a-z] to determine whether it should
@@ -66,12 +66,12 @@ public class DosDriveManager : IDictionary<char, DosDriveBase>, IReadOnlyDiction
         //   int result = (value | 0x20) - 'a';
         //   return ((uint)result <= 'z' - 'a') ? result : -1;
 
-        if (char.IsBetween(value, 'A', 'Z')) {
-            return value - 'A';
+        if (char.IsBetween(driveLetter, 'A', 'Z')) {
+            return driveLetter - 'A';
         }
 
-        if (char.IsBetween(value, 'a', 'z')) {
-            return value - 'a';
+        if (char.IsBetween(driveLetter, 'a', 'z')) {
+            return driveLetter - 'a';
         }
 
         return -1;
@@ -80,14 +80,14 @@ public class DosDriveManager : IDictionary<char, DosDriveBase>, IReadOnlyDiction
     /// <summary>
     /// Gets the zero-based drive index associated with the given DOS drive letter.
     /// </summary>
-    /// <param name="value">The DOS drive letter. Valid drive letters are uppercase and lowercase ASCII letters.</param>
-    /// <param name="paramName">The parameter name to pass into the <see cref="ArgumentException"/> if <paramref name="value"/> is invalid.</param>
+    /// <param name="driveLetter">The DOS drive letter. Valid drive letters are uppercase and lowercase ASCII letters.</param>
+    /// <param name="paramName">The parameter name to pass into the <see cref="ArgumentException"/> if <paramref name="driveLetter"/> is invalid.</param>
     /// <returns>The zero-based index associated with the drive letter.</returns>
-    /// <exception cref="ArgumentException"><paramref name="value"/> is not a valid drive letter.</exception>
-    internal static int GetDriveLetterIndexOrThrow(char value, [CallerArgumentExpression(nameof(value))] string? paramName = null) {
-        int driveIndex = GetDriveLetterIndex(value);
+    /// <exception cref="ArgumentException"><paramref name="driveLetter"/> is not a valid drive letter.</exception>
+    internal static int GetDriveIndexOrThrow(char driveLetter, [CallerArgumentExpression(nameof(driveLetter))] string? paramName = null) {
+        int driveIndex = GetDriveIndex(driveLetter);
         if (driveIndex == -1) {
-            throw new ArgumentException($"Drive letter '{(!char.IsControl(value) ? value : '?')}' (0x{(int)value:x}) is invalid. It must be an ASCII uppercase or lowercase character between 'A' and 'Z' (inclusive).", paramName);
+            throw new ArgumentException($"Drive letter '{(!char.IsControl(driveLetter) ? driveLetter : '?')}' (0x{(int)driveLetter:x}) is invalid. It must be an ASCII uppercase or lowercase character between 'A' and 'Z' (inclusive).", paramName);
         }
 
         Debug.Assert(driveIndex is >= 0 and < MaxDriveCount);
@@ -97,51 +97,51 @@ public class DosDriveManager : IDictionary<char, DosDriveBase>, IReadOnlyDiction
     /// <summary>
     /// Attempts to get the zero-based drive index associated with the given DOS drive letter.
     /// </summary>
-    /// <param name="value">The DOS drive letter. Valid drive letters are uppercase and lowercase ASCII letters.</param>
+    /// <param name="driveLetter">The DOS drive letter. Valid drive letters are uppercase and lowercase ASCII letters.</param>
     /// <param name="driveIndex">The zero-based index associated with the drive letter or -1 on failure.</param>
     /// <returns><see langword="true"/> if the drive letter and associated drive index is valid; otherwise, <see langword="false"/>.</returns>
-    public static bool TryGetDriveLetterIndex(char value, out int driveIndex) {
-        driveIndex = GetDriveLetterIndex(value);
+    public static bool TryGetLetterIndex(char driveLetter, out int driveIndex) {
+        driveIndex = GetDriveIndex(driveLetter);
         return driveIndex != -1;
     }
 
     /// <summary>
     /// Gets the DOS drive letter from a zero-based drive index.
     /// </summary>
-    /// <param name="index">Must be a zero-based drive index between 0 (inclusive) and <see cref="MaxDriveCount"/> (exclusive).</param>
+    /// <param name="driveIndex">Must be a zero-based drive index between 0 (inclusive) and <see cref="MaxDriveCount"/> (exclusive).</param>
     /// <returns>An uppercase ASCII letter representing the drive letter.</returns>
     /// <remarks>
     /// For performance reasons (fast and efficient inlining), this will not throw an <see cref="ArgumentException"/>
-    /// if the index is out of range. Thus <paramref name="index"/> must always be validated by the caller prior to
+    /// if the index is out of range. Thus <paramref name="driveIndex"/> must always be validated by the caller prior to
     /// calling this method (and is the reason why it is an internal method).
     /// </remarks>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    internal static char GetDriveLetterFromIndexFast(int index) {
-        Debug.Assert(index is >= 0 and < MaxDriveCount);
-        return (char)(index + 'A'); // Only works as long as MaxDriveCount is <= 26.
+    internal static char GetDriveLetterFromIndexFast(int driveIndex) {
+        Debug.Assert(driveIndex is >= 0 and < MaxDriveCount);
+        return (char)(driveIndex + 'A'); // Only works as long as MaxDriveCount is <= 26.
     }
 
     /// <summary>
     /// Gets the DOS drive letter from a zero-based drive index.
     /// </summary>
-    /// <param name="index">A zero-based drive index between 0 (inclusive) and <see cref="MaxDriveCount"/> (exclusive).</param>
+    /// <param name="driveIndex">A zero-based drive index between 0 (inclusive) and <see cref="MaxDriveCount"/> (exclusive).</param>
     /// <returns>An uppercase ASCII letter representing the drive letter.</returns>
-    /// <exception cref="ArgumentOutOfRangeException"><paramref name="index"/> is negative or greater than or equal to <see cref="MaxDriveCount"/>.</exception>
-    public static char GetDriveLetterFromIndex(int index) {
-        ArgumentOutOfRangeException.ThrowIfNegative(index);
-        ArgumentOutOfRangeException.ThrowIfGreaterThanOrEqual(index, MaxDriveCount);
-        return GetDriveLetterFromIndexFast(index);
+    /// <exception cref="ArgumentOutOfRangeException"><paramref name="driveIndex"/> is negative or greater than or equal to <see cref="MaxDriveCount"/>.</exception>
+    public static char GetDriveLetterFromIndex(int driveIndex) {
+        ArgumentOutOfRangeException.ThrowIfNegative(driveIndex);
+        ArgumentOutOfRangeException.ThrowIfGreaterThanOrEqual(driveIndex, MaxDriveCount);
+        return GetDriveLetterFromIndexFast(driveIndex);
     }
 
     /// <summary>
     /// Attempts to get the DOS drive letter from a zero-based drive index.
     /// </summary>
-    /// <param name="index">A zero-based drive index between 0 (inclusive) and <see cref="MaxDriveCount"/> (exclusive).</param>
+    /// <param name="driveIndex">A zero-based drive index between 0 (inclusive) and <see cref="MaxDriveCount"/> (exclusive).</param>
     /// <param name="driveIndex">If successful, then it is the uppercase ASCII letter representing the drive letter.</param>
     /// <returns><see langword="true"/> if the drive index is valid; otherwise, <see langword="false"/>.</returns>
-    public static bool TryGetDriveLetterFromIndex(int index, out char driveLetter) {
-        if (index is >= 0 and < MaxDriveCount) {
-            driveLetter = GetDriveLetterFromIndexFast(index);
+    public static bool TryGetDriveLetterFromIndex(int driveIndex, out char driveLetter) {
+        if (driveIndex is >= 0 and < MaxDriveCount) {
+            driveLetter = GetDriveLetterFromIndexFast(driveIndex);
             return true;
         }
 
@@ -152,26 +152,26 @@ public class DosDriveManager : IDictionary<char, DosDriveBase>, IReadOnlyDiction
     /// <summary>
     /// Validates and normalizes the given drive letter.
     /// </summary>
-    /// <param name="value">The DOS drive letter. Valid drive letters are uppercase and lowercase ASCII letters.</param>
+    /// <param name="driveLetter">The DOS drive letter. Valid drive letters are uppercase and lowercase ASCII letters.</param>
     /// <returns>The normalized (uppercase) drive letter.</returns>
-    /// <exception cref="ArgumentException"><paramref name="value"/> is not a valid drive letter.</exception>
-    public static char NormalizeDriveLetter(char value) {
+    /// <exception cref="ArgumentException"><paramref name="driveLetter"/> is not a valid drive letter.</exception>
+    public static char NormalizeDriveLetter(char driveLetter) {
         // The conversion to an index will validate the char value and the conversion from index to letter will
         // normalize the value to an uppercase drive letter.
-        int driveIndex = GetDriveLetterIndexOrThrow(value);
+        int driveIndex = GetDriveIndexOrThrow(driveLetter);
         return GetDriveLetterFromIndexFast(driveIndex);
     }
 
     /// <summary>
     /// Attempts to validate and normalize the given drive letter.
     /// </summary>
-    /// <param name="value">The DOS drive letter. Valid drive letters are uppercase and lowercase ASCII letters.</param>
+    /// <param name="driveLetter">The DOS drive letter. Valid drive letters are uppercase and lowercase ASCII letters.</param>
     /// <param name="normalizedDriveLetter">The normalized (uppercase) drive letter or a default <see cref="char"/> value on failure.</param>
     /// <returns><see langword="true"/> if drive letter is valid and successfully normalized; otherwise, <see langword="false"/>.</returns>
-    public static bool TryNormalizeDriveLetter(char value, out char normalizedDriveLetter) {
+    public static bool TryNormalizeDriveLetter(char driveLetter, out char normalizedDriveLetter) {
         // The conversion to an index will validate the char value and the conversion from index to letter will
         // normalize the value to an uppercase drive letter.
-        int driveIndex = GetDriveLetterIndex(value);
+        int driveIndex = GetDriveIndex(driveLetter);
         if (driveIndex != -1) {
             normalizedDriveLetter = GetDriveLetterFromIndexFast(driveIndex);
             return true;
@@ -191,7 +191,7 @@ public class DosDriveManager : IDictionary<char, DosDriveBase>, IReadOnlyDiction
     /// <summary>
     /// Gets the current DOS drive zero based index.
     /// </summary>
-    public byte CurrentDriveIndex => (byte)GetDriveLetterIndexOrThrow(CurrentDrive.DriveLetter);
+    public byte CurrentDriveIndex => (byte)GetDriveIndexOrThrow(CurrentDrive.DriveLetter);
 
     internal bool HasDriveAtIndex(int zeroBasedIndex) => zeroBasedIndex is >= 0 and < MaxDriveCount &&
         _driveMap[zeroBasedIndex] is not null;
@@ -270,7 +270,7 @@ public class DosDriveManager : IDictionary<char, DosDriveBase>, IReadOnlyDiction
     [AllowNull]
     public DosDriveBase this[char key] {
         get {
-            return _driveMap[GetDriveLetterIndexOrThrow(key)]
+            return _driveMap[GetDriveIndexOrThrow(key)]
                 ?? throw new KeyNotFoundException($"Drive '{key}' is not mounted.");
         }
 
@@ -279,7 +279,7 @@ public class DosDriveManager : IDictionary<char, DosDriveBase>, IReadOnlyDiction
                 throw new ArgumentException("Key must match value's drive letter.");
             }
 
-            int driveIndex = GetDriveLetterIndexOrThrow(key);
+            int driveIndex = GetDriveIndexOrThrow(key);
             DosDriveBase? existingDrive = _driveMap[driveIndex];
             if (existingDrive is not null && existingDrive != value) {
                 // Unmount the existing drive first.
@@ -307,7 +307,7 @@ public class DosDriveManager : IDictionary<char, DosDriveBase>, IReadOnlyDiction
     }
 
     public bool ContainsKey(char key) {
-        int driveIndex = GetDriveLetterIndex(key);
+        int driveIndex = GetDriveIndex(key);
         if (driveIndex != -1) {
             Debug.Assert(driveIndex is >= 0 and < MaxDriveCount);
             return _driveMap[driveIndex] is not null;
@@ -322,7 +322,7 @@ public class DosDriveManager : IDictionary<char, DosDriveBase>, IReadOnlyDiction
     /// <see cref="Unmount(char)"/> or <see cref="UnmountAsync(char)"/> instead.
     /// </remarks>
     bool IDictionary<char, DosDriveBase>.Remove(char key) {
-        int driveIndex = GetDriveLetterIndex(key);
+        int driveIndex = GetDriveIndex(key);
         if (driveIndex != -1) {
             Debug.Assert(driveIndex is >= 0 and < MaxDriveCount);
             DosDriveBase? drive = _driveMap[driveIndex];
@@ -389,7 +389,7 @@ public class DosDriveManager : IDictionary<char, DosDriveBase>, IReadOnlyDiction
             throw new ArgumentException("Item value must not be null.", nameof(item));
         }
 
-        int driveIndex = GetDriveLetterIndex(item.Key);
+        int driveIndex = GetDriveIndex(item.Key);
         if (driveIndex != -1) {
             Debug.Assert(driveIndex is >= 0 and < MaxDriveCount);
             if (_driveMap[driveIndex] == item.Value) {
@@ -829,7 +829,7 @@ public class DosDriveManager : IDictionary<char, DosDriveBase>, IReadOnlyDiction
     /// <param name="drive">The DOS drive to mount.</param>
     /// <exception cref="InvalidOperationException">A DOS drive with the same drive letter has already been mounted.</exception>
     public void Mount(DosDriveBase drive) {
-        int driveIndex = GetDriveLetterIndexOrThrow(drive.DriveLetter, nameof(drive));
+        int driveIndex = GetDriveIndexOrThrow(drive.DriveLetter, nameof(drive));
         if (_driveMap[driveIndex] is not null) {
             throw new InvalidOperationException($"A DOS drive with the same drive letter '{drive.DriveLetter}' has already been mounted.");
         }
@@ -845,7 +845,7 @@ public class DosDriveManager : IDictionary<char, DosDriveBase>, IReadOnlyDiction
     /// <param name="driveLetter">The DOS drive letter. Valid drive letters are uppercase and lowercase ASCII letters.</param>
     /// <exception cref="InvalidOperationException">Drive is not mounted.</exception>
     public void Unmount(char driveLetter) {
-        int driveIndex = GetDriveLetterIndexOrThrow(driveLetter);
+        int driveIndex = GetDriveIndexOrThrow(driveLetter);
         Debug.Assert(driveIndex is >= 0 and < MaxDriveCount);
         DosDriveBase? drive = _driveMap[driveIndex]
             ?? throw new InvalidOperationException($"No DOS drive has been mounted with the drive letter '{driveLetter}'.");
@@ -865,7 +865,7 @@ public class DosDriveManager : IDictionary<char, DosDriveBase>, IReadOnlyDiction
     /// Avoid using the drive letter for any other operations until the asynchronous task completes.
     /// </remarks>
     public ValueTask UnmountAsync(char driveLetter) {
-        int driveIndex = GetDriveLetterIndexOrThrow(driveLetter);
+        int driveIndex = GetDriveIndexOrThrow(driveLetter);
         Debug.Assert(driveIndex is >= 0 and < MaxDriveCount);
         DosDriveBase? drive = _driveMap[driveIndex]
             ?? throw new InvalidOperationException($"No DOS drive has been mounted with the drive letter '{driveLetter}'.");
@@ -920,7 +920,7 @@ public class DosDriveManager : IDictionary<char, DosDriveBase>, IReadOnlyDiction
     /// <param name="drive">The mounted drive if found; otherwise, <see langword="null"/>.</param>
     /// <returns><see langword="true"/> if a drive exists with the given DOS drive letter; otherwise, <see langword="false"/>.</returns>
     public bool TryGetDrive(char driveLetter, [MaybeNullWhen(false)] out DosDriveBase drive) {
-        int driveIndex = GetDriveLetterIndex(driveLetter);
+        int driveIndex = GetDriveIndex(driveLetter);
         if (driveIndex != -1) {
             Debug.Assert(driveIndex is >= 0 and < MaxDriveCount);
             DosDriveBase? mountedDrive = _driveMap[driveIndex];
@@ -942,7 +942,7 @@ public class DosDriveManager : IDictionary<char, DosDriveBase>, IReadOnlyDiction
     /// <param name="drive">The mounted drive of the specified type if found; otherwise, <see langword="null"/>.</param>
     /// <returns><see langword="true"/> if a drive of the specified type exists with the given DOS drive letter; otherwise, <see langword="false"/>.</returns>
     public bool TryGetDrive<T>(char driveLetter, [NotNullWhen(true)] out T? drive) where T : DosDriveBase {
-        int driveIndex = GetDriveLetterIndex(driveLetter);
+        int driveIndex = GetDriveIndex(driveLetter);
         if (driveIndex != -1) {
             Debug.Assert(driveIndex is >= 0 and < MaxDriveCount);
             DosDriveBase? mountedDrive = _driveMap[driveIndex];

--- a/src/Spice86.Core/Emulator/OperatingSystem/DosDriveManager.cs
+++ b/src/Spice86.Core/Emulator/OperatingSystem/DosDriveManager.cs
@@ -373,7 +373,6 @@ public class DosDriveManager : IDictionary<char, DosDriveBase>, IReadOnlyDiction
         for (int i = 0; i < MaxDriveCount; i++) {
             DosDriveBase? entry = entries[i];
             if (entry is not null) {
-                Debug.Assert(arrayIndex < itemCount);
                 array[arrayIndex++] = new(entry.DriveLetter, entry);
             }
         }
@@ -563,7 +562,6 @@ public class DosDriveManager : IDictionary<char, DosDriveBase>, IReadOnlyDiction
             for (int i = 0; i < itemCount; i++) {
                 DosDriveBase? entry = entries[i];
                 if (entry is not null) {
-                    Debug.Assert(arrayIndex < itemCount);
                     array[arrayIndex++] = entry.DriveLetter;
                 }
             }
@@ -691,7 +689,6 @@ public class DosDriveManager : IDictionary<char, DosDriveBase>, IReadOnlyDiction
             for (int i = 0; i < itemCount; i++) {
                 DosDriveBase? entry = entries[i];
                 if (entry is not null) {
-                    Debug.Assert(arrayIndex < itemCount);
                     array[arrayIndex++] = entry;
                 }
             }

--- a/src/Spice86.Core/Emulator/OperatingSystem/DosDriveManager.cs
+++ b/src/Spice86.Core/Emulator/OperatingSystem/DosDriveManager.cs
@@ -13,9 +13,12 @@ using System.Runtime.CompilerServices;
 /// <summary>
 /// The class responsible for centralizing all the mounted DOS drives.
 /// </summary>
-public class DosDriveManager : IDictionary<char, VirtualDrive> {
-    private readonly SortedDictionary<char, VirtualDrive> _driveMap = new();
-    private readonly Dictionary<char, MemoryDrive> _memoryDriveMap = new();
+public class DosDriveManager : IDictionary<char, DosDriveBase>, IReadOnlyDictionary<char, DosDriveBase> {
+    private readonly DosDriveBase?[] _driveMap = new DosDriveBase?[MaxDriveCount];
+    private int _mappedDriveCount;
+    private uint _version; // Used to prevent simultaneous collection changes and continued enumeration.
+    private DriveLetterCollection? _keys;
+    private DriveCollection? _values;
     private readonly DosMediaIdTable _mediaIdTable;
 
     /// <summary>
@@ -36,14 +39,14 @@ public class DosDriveManager : IDictionary<char, VirtualDrive> {
             cDriveFolderPath = DosPathResolver.GetExeParentFolder(executablePath);
         }
         cDriveFolderPath = ConvertUtils.ToSlashFolderPath(cDriveFolderPath);
-        _driveMap.Add('A', new() { DriveLetter = 'A', CurrentDosDirectory = "", MountedHostDirectory = "" });
-        _driveMap.Add('B', new() { DriveLetter = 'B', CurrentDosDirectory = "", MountedHostDirectory = "" });
-        var cDrive = new VirtualDrive { DriveLetter = 'C', MountedHostDirectory = cDriveFolderPath, CurrentDosDirectory = "" };
-        _driveMap.Add('C', cDrive);
+        _driveMap[GetDriveLetterIndex('A')] = new VirtualDrive() { DriveLetter = 'A', MountedHostDirectory = "" };
+        _driveMap[GetDriveLetterIndex('B')] = new VirtualDrive() { DriveLetter = 'B', MountedHostDirectory = "" };
+        var cDrive = new VirtualDrive { DriveLetter = 'C', MountedHostDirectory = cDriveFolderPath };
+        _driveMap[GetDriveLetterIndex('C')] = cDrive;
         CurrentDrive = cDrive;
         InitializeMediaDescriptors();
         if (loggerService.IsEnabled(Serilog.Events.LogEventLevel.Verbose)) {
-            loggerService.Verbose("DOS Drives initialized: {@Drives}", _driveMap.Values);
+            loggerService.Verbose("DOS Drives initialized: {@Drives}", Values);
         }
     }
 
@@ -177,34 +180,20 @@ public class DosDriveManager : IDictionary<char, VirtualDrive> {
     /// <summary>
     /// Gets the current DOS drive zero based index.
     /// </summary>
-    public byte CurrentDriveIndex => (byte)GetDriveLetterFromIndex(CurrentDrive.DriveLetter);
+    public byte CurrentDriveIndex => (byte)GetDriveLetterIndexOrThrow(CurrentDrive.DriveLetter);
 
-    internal bool HasDriveAtIndex(ushort zeroBasedIndex) {
-        if (zeroBasedIndex > _driveMap.Count - 1) {
-            return false;
-        }
-        return true;
-    }
+    internal bool HasDriveAtIndex(ushort zeroBasedIndex) => zeroBasedIndex is >= 0 and < MaxDriveCount &&
+        _driveMap[zeroBasedIndex] is not null;
 
-    /// <suummary>
+    /// <summary>
     /// Gets the number of DOS drive letters assigned.
     /// </summary>
     public byte NumberOfPotentiallyValidDriveLetters {
         get {
             // At least A: and B:
-            return (byte)_driveMap.Count;
+            return (byte)Count;
         }
     }
-
-    public ICollection<char> Keys => ((IDictionary<char, VirtualDrive>)_driveMap).Keys;
-
-    public ICollection<VirtualDrive> Values => ((IDictionary<char, VirtualDrive>)_driveMap).Values;
-
-    public int Count => ((ICollection<KeyValuePair<char, VirtualDrive>>)_driveMap).Count;
-
-    public bool IsReadOnly => ((ICollection<KeyValuePair<char, VirtualDrive>>)_driveMap).IsReadOnly;
-
-    public VirtualDrive this[char key] { get => ((IDictionary<char, VirtualDrive>)_driveMap)[key]; set => ((IDictionary<char, VirtualDrive>)_driveMap)[key] = value; }
 
     private const byte FloppyMediaDescriptor = 0xF0;
     private const byte FixedDiskMediaDescriptor = 0xF8;
@@ -229,57 +218,785 @@ public class DosDriveManager : IDictionary<char, VirtualDrive> {
         return FixedDiskMediaDescriptor;
     }
 
-    public void Add(char key, VirtualDrive value) {
-        ((IDictionary<char, VirtualDrive>)_driveMap).Add(key, value);
+    #region Dictionary
+
+    /// <summary>
+    /// Gets a read only collection of all mapped DOS drive letters in sorted order.
+    /// </summary>
+    public DriveLetterCollection Keys => _keys ??= new(this);
+
+    ICollection<char> IDictionary<char, DosDriveBase>.Keys => Keys;
+
+    IEnumerable<char> IReadOnlyDictionary<char, DosDriveBase>.Keys => Keys;
+
+    /// <summary>
+    /// Gets a read only collection of all mapped DOS drives in sorted order.
+    /// </summary>
+    public DriveCollection Values => _values ??= new(this);
+
+    ICollection<DosDriveBase> IDictionary<char, DosDriveBase>.Values => Values;
+
+    IEnumerable<DosDriveBase> IReadOnlyDictionary<char, DosDriveBase>.Values => Values;
+
+    bool ICollection<KeyValuePair<char, DosDriveBase>>.IsReadOnly => false;
+
+    /// <summary>
+    /// Gets the number of currently mapped DOS drives.
+    /// </summary>
+    public int Count => _mappedDriveCount;
+
+    /// <summary>
+    /// Gets or sets a DOS drive mapping by the drive letter.
+    /// </summary>
+    /// <param name="key">The drive letter to retrieve. Must be a valid uppercase or lowercase ASCII letter.</param>
+    /// <returns>The mapped drive associated with the drive letter.</returns>
+    /// <exception cref="KeyNotFoundException">The drive has not been mounted.</exception>
+    /// <exception cref="ArgumentException">Setting a drive mapping where <paramref name="key"/> does not match the drive's drive letter.</exception>
+    /// <remarks>
+    /// This property allows setting the value to <see langword="null"/> to remove a drive letter mapping. If there is
+    /// an existing drive mounted at the given location, then it will be disposed before being overwritten.
+    /// </remarks>
+    [AllowNull]
+    public DosDriveBase this[char key] {
+        get {
+            return _driveMap[GetDriveLetterIndexOrThrow(key)]
+                ?? throw new KeyNotFoundException($"Drive '{key}' is not mounted.");
+        }
+
+        set {
+            if (value is not null && key != value.DriveLetter) {
+                throw new ArgumentException("Key must match value's drive letter.");
+            }
+
+            int driveIndex = GetDriveLetterIndexOrThrow(key);
+            DosDriveBase? existingDrive = _driveMap[driveIndex];
+            if (existingDrive is not null && existingDrive != value) {
+                // Unmount the existing drive first.
+                RemoveDriveInternal(existingDrive, driveIndex);
+            }
+
+            _driveMap[driveIndex] = value;
+            if (value is not null && existingDrive != value) {
+                _mappedDriveCount++;
+            }
+
+            // Note that the version will be incremented even if there is no change (value is same instance as existing
+            // value). This is to ensure that callers never try to modify the dictionary while continuing to enumerate.
+            _version++;
+        }
+    }
+
+    void IDictionary<char, DosDriveBase>.Add(char key, DosDriveBase value) {
+        ArgumentNullException.ThrowIfNull(value);
+        if (key != value.DriveLetter) {
+            throw new ArgumentException("Key must match drive letter in value.", nameof(key));
+        }
+
+        Mount(value);
     }
 
     public bool ContainsKey(char key) {
-        return ((IDictionary<char, VirtualDrive>)_driveMap).ContainsKey(key);
+        int driveIndex = GetDriveLetterIndex(key);
+        if (driveIndex != -1) {
+            Debug.Assert(driveIndex is >= 0 and < MaxDriveCount);
+            return _driveMap[driveIndex] is not null;
+        }
+
+        return false;
     }
 
-    public bool Remove(char key) {
-        return ((IDictionary<char, VirtualDrive>)_driveMap).Remove(key);
+    /// <inheritdoc/>
+    /// <remarks>
+    /// This is a dangerous operation, because the drive will not be disposed before unmounting! Use
+    /// <see cref="Unmount(char)"/> or <see cref="UnmountAsync(char)"/> instead.
+    /// </remarks>
+    bool IDictionary<char, DosDriveBase>.Remove(char key) {
+        int driveIndex = GetDriveLetterIndex(key);
+        if (driveIndex != -1) {
+            Debug.Assert(driveIndex is >= 0 and < MaxDriveCount);
+            DosDriveBase? drive = _driveMap[driveIndex];
+            if (drive is not null) {
+                _driveMap[driveIndex] = null;
+                _mappedDriveCount--;
+                _version++;
+                return true;
+            }
+        }
+
+        return false;
     }
 
-    public bool TryGetValue(char key, [MaybeNullWhen(false)] out VirtualDrive value) {
-        return ((IDictionary<char, VirtualDrive>)_driveMap).TryGetValue(key, out value);
+    public bool TryGetValue(char key, [MaybeNullWhen(false)] out DosDriveBase value) => TryGetDrive(key, out value);
+
+    void ICollection<KeyValuePair<char, DosDriveBase>>.Add(KeyValuePair<char, DosDriveBase> item) {
+        ArgumentNullException.ThrowIfNull(item.Value, nameof(item));
+        if (item.Key != item.Value.DriveLetter) {
+            throw new ArgumentException("Key must match drive letter in value.", nameof(item));
+        }
+
+        Mount(item.Value);
     }
 
-    public void Add(KeyValuePair<char, VirtualDrive> item) {
-        ((ICollection<KeyValuePair<char, VirtualDrive>>)_driveMap).Add(item);
+    /// <inheritdoc/>
+    /// <exception cref="AggregateException">One or more exceptions were thrown while drives were being unmounted.</exception>
+    /// <remarks>
+    /// This will always dispose of the drives before removing them from the collection.
+    /// </remarks>
+    public void Clear() => Clear(disposeDrives: true);
+
+    bool ICollection<KeyValuePair<char, DosDriveBase>>.Contains(KeyValuePair<char, DosDriveBase> item) {
+        return TryGetDrive(item.Key, out DosDriveBase? value) && value == item.Value;
     }
 
-    public void Clear() {
-        ((ICollection<KeyValuePair<char, VirtualDrive>>)_driveMap).Clear();
+    public void CopyTo(KeyValuePair<char, DosDriveBase>[] array, int arrayIndex) {
+        ArgumentNullException.ThrowIfNull(array);
+        ArgumentOutOfRangeException.ThrowIfNegative(arrayIndex);
+        ArgumentOutOfRangeException.ThrowIfGreaterThan(arrayIndex, array.Length);
+
+        int itemCount = _mappedDriveCount;
+        if (array.Length - arrayIndex < itemCount) {
+            throw new ArgumentException("Destination array is not long enough to copy all the items in the collection. Check array index and length.");
+        }
+
+        DosDriveBase?[] entries = _driveMap;
+        for (int i = 0; i < MaxDriveCount; i++) {
+            DosDriveBase? entry = entries[i];
+            if (entry is not null) {
+                Debug.Assert(arrayIndex < itemCount);
+                array[arrayIndex++] = new(entry.DriveLetter, entry);
+            }
+        }
     }
 
-    public bool Contains(KeyValuePair<char, VirtualDrive> item) {
-        return ((ICollection<KeyValuePair<char, VirtualDrive>>)_driveMap).Contains(item);
+    /// <inheritdoc/>
+    /// <remarks>
+    /// This is a dangerous operation, because the drive will not be disposed before unmounting! Use
+    /// <see cref="Unmount(char)"/> or <see cref="UnmountAsync(char)"/> instead.
+    /// </remarks>
+    bool ICollection<KeyValuePair<char, DosDriveBase>>.Remove(KeyValuePair<char, DosDriveBase> item) {
+        if (item.Value is null) {
+            throw new ArgumentException("Item value must not be null.", nameof(item));
+        }
+
+        int driveIndex = GetDriveLetterIndex(item.Key);
+        if (driveIndex != -1) {
+            Debug.Assert(driveIndex is >= 0 and < MaxDriveCount);
+            if (_driveMap[driveIndex] == item.Value) {
+                _driveMap[driveIndex] = null;
+                _mappedDriveCount--;
+                _version++;
+                return true;
+            }
+        }
+
+        return false;
     }
 
-    public void CopyTo(KeyValuePair<char, VirtualDrive>[] array, int arrayIndex) {
-        ((ICollection<KeyValuePair<char, VirtualDrive>>)_driveMap).CopyTo(array, arrayIndex);
+    public Enumerator GetEnumerator() {
+        return new Enumerator(this, Enumerator.ReturnTypeKeyValuePair);
     }
 
-    public bool Remove(KeyValuePair<char, VirtualDrive> item) {
-        return ((ICollection<KeyValuePair<char, VirtualDrive>>)_driveMap).Remove(item);
-    }
-
-    public IEnumerator<KeyValuePair<char, VirtualDrive>> GetEnumerator() {
-        return ((IEnumerable<KeyValuePair<char, VirtualDrive>>)_driveMap).GetEnumerator();
+    IEnumerator<KeyValuePair<char, DosDriveBase>> IEnumerable<KeyValuePair<char, DosDriveBase>>.GetEnumerator() {
+        return new Enumerator(this, Enumerator.ReturnTypeKeyValuePair);
     }
 
     IEnumerator IEnumerable.GetEnumerator() {
-        return ((IEnumerable)_driveMap).GetEnumerator();
+        return new Enumerator(this, Enumerator.ReturnTypeDictionaryEntry);
     }
+
+    public struct Enumerator : IEnumerator<KeyValuePair<char, DosDriveBase>>, IDictionaryEnumerator {
+        private readonly DosDriveManager? _dictionary;
+        private readonly uint _version; // To make sure MoveNext() fails if dictionary changes while enumerating.
+        private int _index; // One-based drive letter index or zero if before start or MaxDriveCount if at end.
+        private KeyValuePair<char, DosDriveBase> _current;
+        private readonly int _getEnumeratorReturnType;  // What should Enumerator.Current return?
+
+        internal const int ReturnTypeDictionaryEntry = 1;
+        internal const int ReturnTypeKeyValuePair = 2;
+
+        internal Enumerator(DosDriveManager dictionary, int getEnumeratorReturnType) {
+            Debug.Assert(getEnumeratorReturnType is ReturnTypeDictionaryEntry or ReturnTypeKeyValuePair);
+            _dictionary = dictionary;
+            _version = dictionary._version;
+            _current = default;
+            _getEnumeratorReturnType = getEnumeratorReturnType;
+        }
+
+        public readonly KeyValuePair<char, DosDriveBase> Current {
+            get {
+                Debug.Assert(_index is > 0 and <= MaxDriveCount);
+                Debug.Assert(_current.Value is not null);
+                Debug.Assert(_current.Key == _current.Value.DriveLetter);
+                return _current;
+            }
+        }
+
+        readonly object IEnumerator.Current {
+            get {
+                ValidateCurrentIndex();
+
+                Debug.Assert(_current.Value is not null);
+                Debug.Assert(_current.Key == _current.Value.DriveLetter);
+
+                if (_getEnumeratorReturnType == ReturnTypeDictionaryEntry) {
+                    return new DictionaryEntry(_current.Key, _current.Value);
+                }
+
+                return _current;
+            }
+        }
+
+        readonly DictionaryEntry IDictionaryEnumerator.Entry {
+            get {
+                ValidateCurrentIndex();
+                return new(_current.Key, _current.Value);
+            }
+        }
+
+        readonly object IDictionaryEnumerator.Key {
+            get {
+                ValidateCurrentIndex();
+
+                Debug.Assert(_current.Value is not null);
+                Debug.Assert(_current.Key == _current.Value.DriveLetter);
+                return _current.Key;
+            }
+        }
+
+        readonly object? IDictionaryEnumerator.Value {
+            get {
+                ValidateCurrentIndex();
+
+                Debug.Assert(_current.Value is not null);
+                Debug.Assert(_current.Key == _current.Value.DriveLetter);
+                return _current.Value;
+            }
+        }
+
+        public readonly void Dispose() { }
+
+        public bool MoveNext() {
+            if (_dictionary is null) {
+                return false;
+            }
+
+            ValidateVersion();
+
+            while (_index < MaxDriveCount) {
+                DosDriveBase? value = _dictionary._driveMap[_index];
+                _index++;
+
+                if (value is not null) {
+                    _current = new(value.DriveLetter, value);
+                    return true;
+                }
+            }
+
+            _index = MaxDriveCount + 1;
+            _current = default;
+            return false;
+        }
+
+        public void Reset() {
+            _index = 0;
+            _current = default;
+        }
+
+        [MemberNotNull(nameof(_dictionary))]
+        private readonly void ValidateCurrentIndex() {
+            if (_index is <= 0 or > MaxDriveCount) {
+                throw new InvalidOperationException("Enumeration has either not started or has already finished.");
+            }
+
+            Debug.Assert(_dictionary is not null);
+        }
+
+        private readonly void ValidateVersion() {
+            Debug.Assert(_dictionary is not null);
+            if (_version != _dictionary._version) {
+                throw new InvalidOperationException("Collection was modified; enumeration operation may not execute.");
+            }
+        }
+    }
+
+    public sealed class DriveLetterCollection(DosDriveManager manager) : ICollection<char>, IReadOnlyCollection<char> {
+        private readonly DosDriveManager _dictionary = manager;
+
+        public int Count => _dictionary.Count;
+
+        bool ICollection<char>.IsReadOnly => true;
+
+        void ICollection<char>.Add(char item) {
+            throw new NotSupportedException("Mutating a key collection derived from a dictionary is not allowed.");
+        }
+
+        void ICollection<char>.Clear() {
+            throw new NotSupportedException("Mutating a key collection derived from a dictionary is not allowed.");
+        }
+
+        public bool Contains(char item) {
+            return _dictionary.ContainsKey(item);
+        }
+
+        public void CopyTo(char[] array, int arrayIndex) {
+            ArgumentNullException.ThrowIfNull(array);
+            ArgumentOutOfRangeException.ThrowIfNegative(arrayIndex);
+            ArgumentOutOfRangeException.ThrowIfGreaterThan(arrayIndex, array.Length);
+
+            int itemCount = Count;
+            if (array.Length - arrayIndex < itemCount) {
+                throw new ArgumentException("Destination array is not long enough to copy all the items in the collection. Check array index and length.");
+            }
+
+            DosDriveBase?[] entries = _dictionary._driveMap;
+            for (int i = 0; i < itemCount; i++) {
+                DosDriveBase? entry = entries[i];
+                if (entry is not null) {
+                    Debug.Assert(arrayIndex < itemCount);
+                    array[arrayIndex++] = entry.DriveLetter;
+                }
+            }
+        }
+
+        public Enumerator GetEnumerator() {
+            return new Enumerator(_dictionary);
+        }
+
+        IEnumerator<char> IEnumerable<char>.GetEnumerator() {
+            return GetEnumerator();
+        }
+
+        bool ICollection<char>.Remove(char item) {
+            throw new NotSupportedException("Mutating a key collection derived from a dictionary is not allowed.");
+        }
+
+        IEnumerator IEnumerable.GetEnumerator() {
+            return GetEnumerator();
+        }
+
+        public struct Enumerator : IEnumerator<char> {
+            private readonly DosDriveManager? _dictionary;
+            private readonly uint _version; // To make sure MoveNext() fails if dictionary changes while enumerating.
+            private int _index; // One-based drive letter index or zero if before start or MaxDriveCount if at end.
+            private char _current;
+
+            internal Enumerator(DosDriveManager dictionary) {
+                _dictionary = dictionary;
+                _version = dictionary._version;
+                _current = default;
+            }
+
+            public readonly char Current {
+                get {
+                    Debug.Assert(_index is > 0 and <= MaxDriveCount);
+                    return _current;
+                }
+            }
+
+            readonly object IEnumerator.Current {
+                get {
+                    ValidateCurrentIndex();
+                    return _current;
+                }
+            }
+
+            public readonly void Dispose() { }
+
+            public bool MoveNext() {
+                if (_dictionary is null) {
+                    return false;
+                }
+
+                ValidateVersion();
+
+                while (_index < MaxDriveCount) {
+                    DosDriveBase? value = _dictionary._driveMap[_index];
+                    _index++;
+
+                    if (value is not null) {
+                        _current = value.DriveLetter;
+                        return true;
+                    }
+                }
+
+                _index = MaxDriveCount + 1;
+                _current = default;
+                return false;
+            }
+
+            public void Reset() {
+                _index = 0;
+                _current = default;
+            }
+
+            [MemberNotNull(nameof(_dictionary))]
+            private readonly void ValidateCurrentIndex() {
+                if (_index is <= 0 or > MaxDriveCount) {
+                    throw new InvalidOperationException("Enumeration has either not started or has already finished.");
+                }
+
+                Debug.Assert(_dictionary is not null);
+            }
+
+            private readonly void ValidateVersion() {
+                Debug.Assert(_dictionary is not null);
+                if (_version != _dictionary._version) {
+                    throw new InvalidOperationException("Collection was modified; enumeration operation may not execute.");
+                }
+            }
+        }
+    }
+
+    public sealed class DriveCollection(DosDriveManager manager) : ICollection<DosDriveBase>, IReadOnlyCollection<DosDriveBase> {
+        private readonly DosDriveManager _dictionary = manager;
+
+        public int Count => _dictionary.Count;
+
+        bool ICollection<DosDriveBase>.IsReadOnly => true;
+
+        void ICollection<DosDriveBase>.Add(DosDriveBase item) {
+            throw new NotSupportedException("Mutating a value collection derived from a dictionary is not allowed.");
+        }
+
+        void ICollection<DosDriveBase>.Clear() {
+            throw new NotSupportedException("Mutating a value collection derived from a dictionary is not allowed.");
+        }
+
+        public bool Contains(DosDriveBase item) {
+            return _dictionary.TryGetValue(item.DriveLetter, out DosDriveBase? value) && value == item;
+        }
+
+        public void CopyTo(DosDriveBase[] array, int arrayIndex) {
+            ArgumentNullException.ThrowIfNull(array);
+            ArgumentOutOfRangeException.ThrowIfNegative(arrayIndex);
+            ArgumentOutOfRangeException.ThrowIfGreaterThan(arrayIndex, array.Length);
+
+            int itemCount = Count;
+            if (array.Length - arrayIndex < itemCount) {
+                throw new ArgumentException("Destination array is not long enough to copy all the items in the collection. Check array index and length.");
+            }
+
+            DosDriveBase?[] entries = _dictionary._driveMap;
+            for (int i = 0; i < itemCount; i++) {
+                DosDriveBase? entry = entries[i];
+                if (entry is not null) {
+                    Debug.Assert(arrayIndex < itemCount);
+                    array[arrayIndex++] = entry;
+                }
+            }
+        }
+
+        public Enumerator GetEnumerator() {
+            return new Enumerator(_dictionary);
+        }
+
+        IEnumerator<DosDriveBase> IEnumerable<DosDriveBase>.GetEnumerator() {
+            return GetEnumerator();
+        }
+
+        bool ICollection<DosDriveBase>.Remove(DosDriveBase item) {
+            throw new NotSupportedException("Mutating a value collection derived from a dictionary is not allowed.");
+        }
+
+        IEnumerator IEnumerable.GetEnumerator() {
+            return GetEnumerator();
+        }
+
+        public struct Enumerator : IEnumerator<DosDriveBase> {
+            private readonly DosDriveManager? _dictionary;
+            private readonly uint _version; // To make sure MoveNext() fails if dictionary changes while enumerating.
+            private int _index; // One-based drive letter index or zero if before start or MaxDriveCount+1 if at end.
+            private DosDriveBase? _current;
+
+            internal Enumerator(DosDriveManager dictionary) {
+                _dictionary = dictionary;
+                _version = dictionary._version;
+                _current = default;
+            }
+
+            public readonly DosDriveBase Current {
+                get {
+                    Debug.Assert(_index is > 0 and <= MaxDriveCount);
+                    Debug.Assert(_current is not null);
+                    return _current;
+                }
+            }
+
+            readonly object IEnumerator.Current {
+                get {
+                    ValidateCurrentIndex();
+                    return _current;
+                }
+            }
+
+            public readonly void Dispose() { }
+
+            public bool MoveNext() {
+                if (_dictionary is null) {
+                    return false;
+                }
+
+                ValidateVersion();
+
+                while (_index < MaxDriveCount) {
+                    DosDriveBase? value = _dictionary._driveMap[_index];
+                    _index++;
+
+                    if (value is not null) {
+                        _current = value;
+                        return true;
+                    }
+                }
+
+                _index = MaxDriveCount + 1;
+                _current = null;
+                return false;
+            }
+
+            public void Reset() {
+                _index = 0;
+                _current = default;
+            }
+
+            [MemberNotNull(nameof(_dictionary), nameof(_current))]
+            private readonly void ValidateCurrentIndex() {
+                if (_index is <= 0 or > MaxDriveCount) {
+                    throw new InvalidOperationException("Enumeration has either not started or has already finished.");
+                }
+
+                Debug.Assert(_dictionary is not null);
+                Debug.Assert(_current is not null);
+            }
+
+            private readonly void ValidateVersion() {
+                Debug.Assert(_dictionary is not null);
+                if (_version != _dictionary._version) {
+                    throw new InvalidOperationException("Collection was modified; enumeration operation may not execute.");
+                }
+            }
+        }
+    }
+
+    #endregion
+
+    /// <exception cref="AggregateException">One or more exceptions were thrown while drives were being unmounted.</exception>
+    public void Clear(bool disposeDrives = true) {
+        if (!disposeDrives) {
+            Array.Clear(_driveMap);
+            _mappedDriveCount--;
+            _version++;
+            return;
+        }
+
+        // Keep track of exceptions that occur while removing drives.
+        List<Exception> exceptions = [];
+        for (int i = 0; i < MaxDriveCount; i++) {
+            DosDriveBase? drive = _driveMap[i];
+            if (drive is not null) {
+                try {
+                    RemoveDriveInternal(drive, i);
+                } catch (Exception ex) {
+                    exceptions.Add(ex);
+                }
+            }
+        }
+
+        Debug.Assert(_mappedDriveCount == 0);
+
+        // Always increment the version, even if no drives were unmounted.
+        _version++;
+
+        // Throw any exceptions that occurred while clearing the collection.
+        if (exceptions.Count > 0) {
+            throw new AggregateException(exceptions);
+        }
+    }
+
+    /// <summary>
+    /// Mounts a generic DOS drive.
+    /// </summary>
+    /// <param name="drive">The DOS drive to mount.</param>
+    /// <exception cref="InvalidOperationException">A DOS drive with the same drive letter has already been mounted.</exception>
+    public void Mount(DosDriveBase drive) {
+        int driveIndex = GetDriveLetterIndexOrThrow(drive.DriveLetter, nameof(drive));
+        if (_driveMap[driveIndex] is not null) {
+            throw new InvalidOperationException($"A DOS drive with the same drive letter '{drive.DriveLetter}' has already been mounted.");
+        }
+
+        _driveMap[driveIndex] = drive;
+        _mappedDriveCount++;
+        _version++;
+    }
+
+    /// <summary>
+    /// Unmounts the DOS drive with the specified drive letter.
+    /// </summary>
+    /// <param name="driveLetter">The DOS drive letter. Valid drive letters are uppercase and lowercase ASCII letters.</param>
+    /// <exception cref="InvalidOperationException">Drive is not mounted.</exception>
+    public void Unmount(char driveLetter) {
+        int driveIndex = GetDriveLetterIndexOrThrow(driveLetter);
+        Debug.Assert(driveIndex is >= 0 and < MaxDriveCount);
+        DosDriveBase? drive = _driveMap[driveIndex]
+            ?? throw new InvalidOperationException($"No DOS drive has been mounted with the drive letter '{driveLetter}'.");
+        RemoveDriveInternal(drive, driveIndex);
+    }
+
+    /// <summary>
+    /// Asynchronously unmounts the DOS drive with the specified drive letter.
+    /// </summary>
+    /// <param name="driveLetter">The DOS drive letter. Valid drive letters are uppercase and lowercase ASCII letters.</param>
+    /// <returns>An asynchronous task which completes when the mounted drive has been disposed and unmounted.</returns>
+    /// <exception cref="InvalidOperationException">Drive is not mounted.</exception>
+    /// <remarks>
+    /// This only performs an asynchronous non-blocking operation if the mounted drive implemented
+    /// <see cref="IAsyncDisposable"/>. If the drive implements <see cref="IDisposable"/>, but not
+    /// <see cref="IAsyncDisposable"/>, then this method will synchronously block until the drive has been disposed.
+    /// Avoid using the drive letter for any other operations until the asynchronous task completes.
+    /// </remarks>
+    public ValueTask UnmountAsync(char driveLetter) {
+        int driveIndex = GetDriveLetterIndexOrThrow(driveLetter);
+        Debug.Assert(driveIndex is >= 0 and < MaxDriveCount);
+        DosDriveBase? drive = _driveMap[driveIndex]
+            ?? throw new InvalidOperationException($"No DOS drive has been mounted with the drive letter '{driveLetter}'.");
+        return RemoveDriveInternalAsync(drive, driveIndex);
+    }
+
+    private void RemoveDriveInternal(DosDriveBase drive, int driveIndex) {
+        Debug.Assert(driveIndex is >= 0 and < MaxDriveCount);
+        try {
+            // Dispose of the drive, if possible, before unmounting.
+            if (drive is IDisposable disposable) {
+                disposable.Dispose();
+            } else if (drive is IAsyncDisposable asyncDisposable) {
+                ValueTask valueTask = asyncDisposable.DisposeAsync();
+                if (!valueTask.IsCompletedSuccessfully) {
+                    valueTask.AsTask().Wait();
+                }
+            }
+        } finally {
+            _driveMap[driveIndex] = null;
+            _mappedDriveCount--;
+            _version++;
+        }
+    }
+
+    private async ValueTask RemoveDriveInternalAsync(DosDriveBase drive, int driveIndex) {
+        Debug.Assert(driveIndex is >= 0 and < MaxDriveCount);
+        try {
+            // Dispose of the drive, if possible, before unmounting.
+            if (drive is IAsyncDisposable asyncDisposable) {
+                await asyncDisposable.DisposeAsync();
+            } else if (drive is IDisposable disposable) {
+                disposable.Dispose();
+            }
+        } finally {
+            _driveMap[driveIndex] = null;
+            _mappedDriveCount--;
+            _version++;
+        }
+    }
+
+    public DosDriveBase GetDrive(char driveLetter) => TryGetDrive(driveLetter, out DosDriveBase? drive)
+        ? drive : throw new KeyNotFoundException($"Drive '{driveLetter}' is not mounted.");
+
+    public T GetDrive<T>(char driveLetter) where T : DosDriveBase => TryGetDrive(driveLetter, out T? drive)
+        ? drive : throw new KeyNotFoundException($"Drive '{driveLetter}' is not mounted.");
+
+    /// <summary>
+    /// Attempts to get a DOS drive mounted using the given DOS drive letter.
+    /// </summary>
+    /// <param name="driveLetter">The DOS drive letter. Valid drive letters are uppercase and lowercase ASCII letters.</param>
+    /// <param name="drive">The mounted drive if found; otherwise, <see langword="null"/>.</param>
+    /// <returns><see langword="true"/> if a drive exists with the given DOS drive letter; otherwise, <see langword="false"/>.</returns>
+    public bool TryGetDrive(char driveLetter, [MaybeNullWhen(false)] out DosDriveBase drive) {
+        int driveIndex = GetDriveLetterIndex(driveLetter);
+        if (driveIndex != -1) {
+            Debug.Assert(driveIndex is >= 0 and < MaxDriveCount);
+            DosDriveBase? mountedDrive = _driveMap[driveIndex];
+            if (mountedDrive is not null) {
+                drive = mountedDrive;
+                return true;
+            }
+        }
+
+        drive = null;
+        return false;
+    }
+
+    /// <summary>
+    /// Attempts to get a DOS drive of a specific type mounted using the given DOS drive letter.
+    /// </summary>
+    /// <typeparam name="T">The type of DOS drive object to retrieve.</typeparam>
+    /// <param name="driveLetter">The DOS drive letter. Valid drive letters are uppercase and lowercase ASCII letters.</param>
+    /// <param name="drive">The mounted drive of the specified type if found; otherwise, <see langword="null"/>.</param>
+    /// <returns><see langword="true"/> if a drive of the specified type exists with the given DOS drive letter; otherwise, <see langword="false"/>.</returns>
+    public bool TryGetDrive<T>(char driveLetter, [NotNullWhen(true)] out T? drive) where T : DosDriveBase {
+        int driveIndex = GetDriveLetterIndex(driveLetter);
+        if (driveIndex != -1) {
+            Debug.Assert(driveIndex is >= 0 and < MaxDriveCount);
+            DosDriveBase? mountedDrive = _driveMap[driveIndex];
+            if (mountedDrive is T mountedDriveType) {
+                drive = mountedDriveType;
+                return true;
+            }
+        }
+
+        drive = null;
+        return false;
+    }
+
+    public DosDriveBase GetDriveAtIndex(int driveIndex) => TryGetDriveAtIndex(driveIndex, out DosDriveBase? drive)
+        ? drive : throw new KeyNotFoundException($"Drive at index {driveIndex} is not mounted.");
+
+    public T GetDriveAtIndex<T>(int driveIndex) where T : DosDriveBase => TryGetDriveAtIndex(driveIndex, out T? drive)
+        ? drive : throw new KeyNotFoundException($"Drive at index {driveIndex} is not mounted.");
+
+    /// <summary>
+    /// Attempts to get the DOS drive mounted at the given DOS drive index.
+    /// </summary>
+    /// <param name="driveIndex">A zero-based drive index between 0 (inclusive) and <see cref="MaxDriveCount"/> (exclusive).</param>
+    /// <param name="value">The mounted drive if found; otherwise, <see langword="null"/>.</param>
+    /// <returns><see langword="true"/> if a drive exists with the given DOS drive letter; otherwise, <see langword="false"/>.</returns>
+    public bool TryGetDriveAtIndex(int driveIndex, [MaybeNullWhen(false)] out DosDriveBase value) {
+        if (driveIndex is >= 0 and < MaxDriveCount) {
+            DosDriveBase? mountedDrive = _driveMap[driveIndex];
+            if (mountedDrive is not null) {
+                value = mountedDrive;
+                return true;
+            }
+        }
+
+        value = null;
+        return false;
+    }
+
+    /// <summary>
+    /// Attempts to get the DOS drive mounted at the given DOS drive index.
+    /// </summary>
+    /// <typeparam name="T">The type of DOS drive object to retrieve.</typeparam>
+    /// <param name="driveIndex">A zero-based drive index between 0 (inclusive) and <see cref="MaxDriveCount"/> (exclusive).</param>
+    /// <param name="value">The mounted drive of the specified type if found; otherwise, <see langword="null"/>.</param>
+    /// <returns><see langword="true"/> if a drive of the specified type exists with the given DOS drive letter; otherwise, <see langword="false"/>.</returns>
+    public bool TryGetDriveAtIndex<T>(int driveIndex, [NotNullWhen(true)] out T? value) where T : DosDriveBase{
+        if (driveIndex is >= 0 and < MaxDriveCount) {
+            DosDriveBase? mountedDrive = _driveMap[driveIndex];
+            if (mountedDrive is T mountedDriveType) {
+                value = mountedDriveType;
+                return true;
+            }
+        }
+
+        value = null;
+        return false;
+    }
+
+    #region MemoryDrive
 
     /// <summary>
     /// Mounts a memory-backed drive (typically Z: for AUTOEXEC.BAT).
     /// </summary>
     /// <param name="drive">The memory drive to mount.</param>
-    public void MountMemoryDrive(MemoryDrive drive) {
-        _memoryDriveMap[drive.DriveLetter] = drive;
-    }
+    public void MountMemoryDrive(MemoryDrive drive) => Mount(drive);
 
     /// <summary>
     /// Tries to get a mounted memory drive by letter.
@@ -288,6 +1005,8 @@ public class DosDriveManager : IDictionary<char, VirtualDrive> {
     /// <param name="drive">The memory drive if found; null otherwise.</param>
     /// <returns>True if memory drive exists; false otherwise.</returns>
     public bool TryGetMemoryDrive(char driveLetter, [MaybeNullWhen(false)] out MemoryDrive drive) {
-        return _memoryDriveMap.TryGetValue(driveLetter, out drive);
+        return TryGetDrive(driveLetter, out drive);
     }
+
+    #endregion
 }

--- a/src/Spice86.Core/Emulator/OperatingSystem/DosDriveManager.cs
+++ b/src/Spice86.Core/Emulator/OperatingSystem/DosDriveManager.cs
@@ -545,14 +545,12 @@ public class DosDriveManager : IDictionary<char, DosDriveBase>, IReadOnlyDiction
             ArgumentNullException.ThrowIfNull(array);
             ArgumentOutOfRangeException.ThrowIfNegative(arrayIndex);
             ArgumentOutOfRangeException.ThrowIfGreaterThan(arrayIndex, array.Length);
-
-            int itemCount = Count;
-            if (array.Length - arrayIndex < itemCount) {
+            if (array.Length - arrayIndex < Count) {
                 throw new ArgumentException("Destination array is not long enough to copy all the items in the collection. Check array index and length.");
             }
 
             DosDriveBase?[] entries = _dictionary._driveMap;
-            for (int i = 0; i < itemCount; i++) {
+            for (int i = 0; i < MaxDriveCount; i++) {
                 DosDriveBase? entry = entries[i];
                 if (entry is not null) {
                     array[arrayIndex++] = entry.DriveLetter;
@@ -672,14 +670,12 @@ public class DosDriveManager : IDictionary<char, DosDriveBase>, IReadOnlyDiction
             ArgumentNullException.ThrowIfNull(array);
             ArgumentOutOfRangeException.ThrowIfNegative(arrayIndex);
             ArgumentOutOfRangeException.ThrowIfGreaterThan(arrayIndex, array.Length);
-
-            int itemCount = Count;
-            if (array.Length - arrayIndex < itemCount) {
+            if (array.Length - arrayIndex < Count) {
                 throw new ArgumentException("Destination array is not long enough to copy all the items in the collection. Check array index and length.");
             }
 
             DosDriveBase?[] entries = _dictionary._driveMap;
-            for (int i = 0; i < itemCount; i++) {
+            for (int i = 0; i < MaxDriveCount; i++) {
                 DosDriveBase? entry = entries[i];
                 if (entry is not null) {
                     array[arrayIndex++] = entry;

--- a/src/Spice86.Core/Emulator/OperatingSystem/DosDriveManager.cs
+++ b/src/Spice86.Core/Emulator/OperatingSystem/DosDriveManager.cs
@@ -51,8 +51,6 @@ public class DosDriveManager : IDictionary<char, DosDriveBase>, IReadOnlyDiction
         }
     }
 
-    #region Drive Letter Helpers
-
     /// <summary>
     /// Gets the zero-based drive index associated with the given DOS drive letter.
     /// </summary>
@@ -182,8 +180,6 @@ public class DosDriveManager : IDictionary<char, DosDriveBase>, IReadOnlyDiction
         return false;
     }
 
-    #endregion
-
     /// <summary>
     /// The currently selected drive.
     /// </summary>
@@ -219,8 +215,6 @@ public class DosDriveManager : IDictionary<char, DosDriveBase>, IReadOnlyDiction
         }
         return FixedDiskMediaDescriptor;
     }
-
-    #region Dictionary
 
     /// <summary>
     /// Gets a read only collection of all mapped DOS drive letters in sorted order.
@@ -774,8 +768,6 @@ public class DosDriveManager : IDictionary<char, DosDriveBase>, IReadOnlyDiction
         }
     }
 
-    #endregion
-
     /// <summary>Removes all mounted drives from the collection.</summary>
     /// <param name="disposeDrives">
     /// If <see langword="true"/>, then all currently mounted drives will be disposed (if applicable). If
@@ -988,8 +980,6 @@ public class DosDriveManager : IDictionary<char, DosDriveBase>, IReadOnlyDiction
         return false;
     }
 
-    #region MemoryDrive
-
     /// <summary>
     /// Mounts a memory-backed drive (typically Z: for AUTOEXEC.BAT).
     /// </summary>
@@ -1005,6 +995,4 @@ public class DosDriveManager : IDictionary<char, DosDriveBase>, IReadOnlyDiction
     public bool TryGetMemoryDrive(char driveLetter, [MaybeNullWhen(false)] out MemoryDrive drive) {
         return TryGetDrive(driveLetter, out drive);
     }
-
-    #endregion
 }

--- a/src/Spice86.Core/Emulator/OperatingSystem/DosFcbManager.cs
+++ b/src/Spice86.Core/Emulator/OperatingSystem/DosFcbManager.cs
@@ -84,10 +84,8 @@ public class DosFcbManager {
 
         // Check for drive specification
         if (pos + 1 < filename.Length && filename[pos + 1] == ':' && !TestFieldSeps(filename[pos])) {
-            char driveChar = char.ToUpper(filename[pos]);
-            if (driveChar is >= 'A' and <= 'Z') {
-                byte driveNum = (byte)(driveChar - 'A');
-
+            char driveChar = filename[pos];
+            if (DosDriveManager.TryGetDriveLetterIndex(driveChar, out int driveNum)) {
                 // Undocumented behavior: should keep parsing even if drive is invalid
                 if (!_dosDriveManager.HasDriveAtIndex(driveNum)) {
                     retCodeDrive = true;

--- a/src/Spice86.Core/Emulator/OperatingSystem/DosFcbManager.cs
+++ b/src/Spice86.Core/Emulator/OperatingSystem/DosFcbManager.cs
@@ -85,7 +85,7 @@ public class DosFcbManager {
         // Check for drive specification
         if (pos + 1 < filename.Length && filename[pos + 1] == ':' && !TestFieldSeps(filename[pos])) {
             char driveChar = filename[pos];
-            if (DosDriveManager.TryGetDriveLetterIndex(driveChar, out int driveNum)) {
+            if (DosDriveManager.TryGetLetterIndex(driveChar, out int driveNum)) {
                 // Undocumented behavior: should keep parsing even if drive is invalid
                 if (!_dosDriveManager.HasDriveAtIndex(driveNum)) {
                     retCodeDrive = true;

--- a/src/Spice86.Core/Emulator/OperatingSystem/DosFileManager.cs
+++ b/src/Spice86.Core/Emulator/OperatingSystem/DosFileManager.cs
@@ -979,7 +979,7 @@ public class DosFileManager {
         VirtualDrive targetDrive = ResolveDriveFromFileSpec(fileSpec);
         string driveLabel = targetDrive.Label.ToUpperInvariant();
         if (isFcbSearch) {
-            byte driveIndex = DosDriveManager.DriveLetters[targetDrive.DriveLetter];
+            byte driveIndex = (byte)DosDriveManager.GetDriveLetterIndexOrThrow(targetDrive.DriveLetter, fileSpec);
             WriteFcbVolumeLabelToDta(dta, driveLabel, driveIndex);
         } else {
             WriteExtendedVolumeLabelToDta(dta, driveLabel);
@@ -1045,7 +1045,7 @@ public class DosFileManager {
         string extOnly = Path.GetExtension(entryInfo.ShortName).TrimStart('.');
 
         VirtualDrive targetDrive = ResolveDriveFromFileSpec(fileSpec);
-        byte driveNumber = (byte)(DosDriveManager.DriveLetters[targetDrive.DriveLetter] + 1);
+        byte driveNumber = (byte)(DosDriveManager.GetDriveLetterIndexOrThrow(targetDrive.DriveLetter, fileSpec) + 1);
         UpdateDosTransferAreaWithFcbResult(dta, nameOnly, extOnly, (byte)entryInfo.Attributes,
             ToDosDate(creationLocalDate), ToDosTime(creationLocalDate), entryInfo.FileSize, driveNumber);
     }

--- a/src/Spice86.Core/Emulator/OperatingSystem/DosFileManager.cs
+++ b/src/Spice86.Core/Emulator/OperatingSystem/DosFileManager.cs
@@ -1297,9 +1297,8 @@ public class DosFileManager {
             }
         } else if (subfunction <= IoctlSubfunction.QueryIoctlDevice) {
             if (subfunction != IoctlSubfunction.SetSharingRetryCount) {
-                drive = (byte)(state.BX == 0 ? _dosDriveManager.CurrentDriveIndex : state.BX - 1);
-                if (drive >= 2 && (drive >= _dosDriveManager.NumberOfPotentiallyValidDriveLetters ||
-                    _dosDriveManager.Count < (drive + 1))) {
+                drive = (byte)(state.BX == 0 ? _dosDriveManager.CurrentDriveIndex : (state.BX - 1));
+                if (drive >= _dosDriveManager.Count) {
                     if (_loggerService.IsEnabled(LogEventLevel.Warning)) {
                         _loggerService.Warning("IOCTL: Invalid drive {Drive} for {Operation}",
                             drive, operationName);

--- a/src/Spice86.Core/Emulator/OperatingSystem/DosFileManager.cs
+++ b/src/Spice86.Core/Emulator/OperatingSystem/DosFileManager.cs
@@ -979,7 +979,7 @@ public class DosFileManager {
         VirtualDrive targetDrive = ResolveDriveFromFileSpec(fileSpec);
         string driveLabel = targetDrive.Label.ToUpperInvariant();
         if (isFcbSearch) {
-            byte driveIndex = (byte)DosDriveManager.GetDriveLetterIndexOrThrow(targetDrive.DriveLetter, fileSpec);
+            byte driveIndex = (byte)DosDriveManager.GetDriveIndexOrThrow(targetDrive.DriveLetter, fileSpec);
             WriteFcbVolumeLabelToDta(dta, driveLabel, driveIndex);
         } else {
             WriteExtendedVolumeLabelToDta(dta, driveLabel);
@@ -1045,7 +1045,7 @@ public class DosFileManager {
         string extOnly = Path.GetExtension(entryInfo.ShortName).TrimStart('.');
 
         VirtualDrive targetDrive = ResolveDriveFromFileSpec(fileSpec);
-        byte driveNumber = (byte)(DosDriveManager.GetDriveLetterIndexOrThrow(targetDrive.DriveLetter, fileSpec) + 1);
+        byte driveNumber = (byte)(DosDriveManager.GetDriveIndexOrThrow(targetDrive.DriveLetter, fileSpec) + 1);
         UpdateDosTransferAreaWithFcbResult(dta, nameOnly, extOnly, (byte)entryInfo.Attributes,
             ToDosDate(creationLocalDate), ToDosTime(creationLocalDate), entryInfo.FileSize, driveNumber);
     }

--- a/src/Spice86.Core/Emulator/OperatingSystem/DosFileManager.cs
+++ b/src/Spice86.Core/Emulator/OperatingSystem/DosFileManager.cs
@@ -967,7 +967,7 @@ public class DosFileManager {
     private VirtualDrive ResolveDriveFromFileSpec(string fileSpec) {
         if (fileSpec.Length >= 2 && fileSpec[1] == DosPathResolver.VolumeSeparatorChar) {
             char driveLetter = char.ToUpperInvariant(fileSpec[0]);
-            if (_dosDriveManager.TryGetValue(driveLetter, out VirtualDrive? drive)) {
+            if (_dosDriveManager.TryGetDrive(driveLetter, out VirtualDrive? drive)) {
                 return drive;
             }
         }
@@ -1467,13 +1467,13 @@ public class DosFileManager {
                 return DosFileOperationResult.NoValue();
 
             case IoctlSubfunction.GenericBlockDeviceRequest:
-                if (drive < 2 && _dosDriveManager.ElementAtOrDefault(drive).Value is null) {
+                if (!_dosDriveManager.TryGetDriveAtIndex(drive, out DosDriveBase? mountedDrive)) {
                     if (_loggerService.IsEnabled(LogEventLevel.Warning)) {
                         _loggerService.Warning("IOCTL: Access denied for drive {Drive} - drive not available", drive);
                     }
                     return DosFileOperationResult.Error(DosErrorCode.AccessDenied);
                 }
-                if (state.CH != 0x08 || _dosDriveManager.ElementAtOrDefault(drive).Value.IsRemovable) {
+                if (state.CH != 0x08 || mountedDrive.IsRemovable) {
                     if (_loggerService.IsEnabled(LogEventLevel.Warning)) {
                         _loggerService.Warning("IOCTL: Invalid or unsupported command 0x{Command:X2} for drive {Drive}",
                             state.CH, drive);
@@ -1502,10 +1502,9 @@ public class DosFileManager {
 
                     case IoctlGenericBlockCommand.GetVolumeInformation:
                         {
-                            VirtualDrive vDrive = _dosDriveManager.ElementAtOrDefault(drive).Value;
                             DosVolumeInfo dosVolumeInfo = new(_memory, parameterBlock.Linear);
                             dosVolumeInfo.SerialNumber = 0x1234;
-                            dosVolumeInfo.VolumeLabel = vDrive.Label.ToUpperInvariant();
+                            dosVolumeInfo.VolumeLabel = mountedDrive.Label.ToUpperInvariant();
                             dosVolumeInfo.FileSystemType = drive < 2 ? "FAT12" : "FAT16";
                             break;
                         }

--- a/src/Spice86.Core/Emulator/OperatingSystem/DosFileManager.cs
+++ b/src/Spice86.Core/Emulator/OperatingSystem/DosFileManager.cs
@@ -1437,7 +1437,7 @@ public class DosFileManager {
                 if (drive < 2) {
                     state.AX = 0;
                 } else if (_dosDriveManager.TryGetDriveAtIndex(drive, out mountedDrive)) {
-                    state.AX = mountedDrive.IsRemovable ? (ushort)1 : (ushort)0;
+                    state.AX = mountedDrive.IsRemovable ? (ushort)0 : (ushort)1;
                 } else {
                     if (_loggerService.IsEnabled(LogEventLevel.Warning)) {
                         _loggerService.Warning("IOCTL: Unable to determine if drive {Drive} is removable", drive);

--- a/src/Spice86.Core/Emulator/OperatingSystem/DosFileManager.cs
+++ b/src/Spice86.Core/Emulator/OperatingSystem/DosFileManager.cs
@@ -858,7 +858,7 @@ public class DosFileManager {
         byte driveIndex = dosFile.Drive == 0xff ? _dosDriveManager.CurrentDriveIndex : dosFile.Drive;
         bool isRemovable = driveIndex <= 1;
         bool isRemote = false;
-        if (_dosDriveManager.ElementAtOrDefault(driveIndex).Value is { } drive) {
+        if (_dosDriveManager.TryGetDriveAtIndex(driveIndex, out DosDriveBase? drive)) {
             isRemovable = drive.IsRemovable;
             isRemote = drive.IsRemote;
         }
@@ -1314,6 +1314,7 @@ public class DosFileManager {
             return DosFileOperationResult.Error(DosErrorCode.FunctionNumberInvalid);
         }
 
+        DosDriveBase? mountedDrive;
         switch (subfunction) {
             case IoctlSubfunction.GetDeviceInformation:
                 VirtualFileBase? fileOrDevice = OpenFiles[handle];
@@ -1436,8 +1437,8 @@ public class DosFileManager {
                 //* cdrom drives and drive A and B are removable */
                 if (drive < 2) {
                     state.AX = 0;
-                } else if (!_dosDriveManager.ElementAtOrDefault(drive).Value.IsRemovable) {
-                    state.AX = 1;
+                } else if (_dosDriveManager.TryGetDriveAtIndex(drive, out mountedDrive)) {
+                    state.AX = mountedDrive.IsRemovable ? (ushort)1 : (ushort)0;
                 } else {
                     if (_loggerService.IsEnabled(LogEventLevel.Warning)) {
                         _loggerService.Warning("IOCTL: Unable to determine if drive {Drive} is removable", drive);
@@ -1447,7 +1448,7 @@ public class DosFileManager {
                 return DosFileOperationResult.NoValue();
 
             case IoctlSubfunction.IsDeviceRemote:
-                if ((drive >= 2) && _dosDriveManager.ElementAt(drive).Value.IsRemote) {
+                if ((drive >= 2) && _dosDriveManager.TryGetDriveAtIndex(drive, out mountedDrive) && mountedDrive.IsRemote) {
                     state.DX = 0x1000;  // device is remote
                                         // undocumented bits always clear
                 } else {
@@ -1467,7 +1468,7 @@ public class DosFileManager {
                 return DosFileOperationResult.NoValue();
 
             case IoctlSubfunction.GenericBlockDeviceRequest:
-                if (!_dosDriveManager.TryGetDriveAtIndex(drive, out DosDriveBase? mountedDrive)) {
+                if (!_dosDriveManager.TryGetDriveAtIndex(drive, out mountedDrive)) {
                     if (_loggerService.IsEnabled(LogEventLevel.Warning)) {
                         _loggerService.Warning("IOCTL: Access denied for drive {Drive} - drive not available", drive);
                     }
@@ -1527,7 +1528,7 @@ public class DosFileManager {
                     } else {
                         state.AL = 1;
                     }
-                } else if (_dosDriveManager.ElementAtOrDefault(drive).Value.IsRemovable) {
+                } else if (_dosDriveManager.TryGetDriveAtIndex(drive, out mountedDrive) && mountedDrive.IsRemovable) {
                     if (_loggerService.IsEnabled(LogEventLevel.Warning)) {
                         _loggerService.Warning("IOCTL: Get Logical Drive Map not supported for removable drive {Drive}", drive);
                     }

--- a/src/Spice86.Core/Emulator/OperatingSystem/DosPathResolver.cs
+++ b/src/Spice86.Core/Emulator/OperatingSystem/DosPathResolver.cs
@@ -41,9 +41,8 @@ internal class DosPathResolver {
             currentDir = virtualDrive.CurrentDosDirectory;
             return DosFileOperationResult.NoValue();
         } else {
-            char driveLetter = DosDriveManager.DriveLetters.Keys.ElementAtOrDefault(driveNumber - 1);
-            if (_dosDriveManager.TryGetValue(driveLetter,
-                        out VirtualDrive? virtualDrive)) {
+            if (DosDriveManager.TryGetDriveLetterFromIndex(driveNumber - 1, out char driveLetter) &&
+                _dosDriveManager.TryGetValue(driveLetter, out VirtualDrive? virtualDrive)) {
                 currentDir = virtualDrive.CurrentDosDirectory;
                 return DosFileOperationResult.NoValue();
             }
@@ -449,7 +448,7 @@ internal class DosPathResolver {
 
     private bool StartsWithDosDriveAndVolumeSeparator(string dosPath) =>
         dosPath.Length >= 2 &&
-        DosDriveManager.DriveLetters.Keys.Contains(char.ToUpperInvariant(dosPath[0])) &&
+        DosDriveManager.GetDriveLetterIndex(dosPath[0]) != -1 &&
         dosPath[1] == VolumeSeparatorChar;
 
     private bool IsPathRooted(string path) =>

--- a/src/Spice86.Core/Emulator/OperatingSystem/DosPathResolver.cs
+++ b/src/Spice86.Core/Emulator/OperatingSystem/DosPathResolver.cs
@@ -42,7 +42,7 @@ internal class DosPathResolver {
             return DosFileOperationResult.NoValue();
         } else {
             if (DosDriveManager.TryGetDriveLetterFromIndex(driveNumber - 1, out char driveLetter) &&
-                _dosDriveManager.TryGetValue(driveLetter, out VirtualDrive? virtualDrive)) {
+                _dosDriveManager.TryGetDrive(driveLetter, out VirtualDrive? virtualDrive)) {
                 currentDir = virtualDrive.CurrentDosDirectory;
                 return DosFileOperationResult.NoValue();
             }
@@ -63,7 +63,8 @@ internal class DosPathResolver {
         return string.IsNullOrWhiteSpace(parent) ? fallbackValue : ConvertUtils.ToSlashFolderPath(parent);
     }
 
-    private static bool IsWithinMountPoint(string hostFullPath, VirtualDrive virtualDrive) => hostFullPath.StartsWith(virtualDrive.MountedHostDirectory);
+    private static bool IsWithinMountPoint(string hostFullPath, VirtualDrive? virtualDrive) =>
+        virtualDrive is not null && hostFullPath.StartsWith(virtualDrive.MountedHostDirectory);
 
     /// <summary>
     /// Sets the current DOS folder.
@@ -96,7 +97,7 @@ internal class DosPathResolver {
 
     private DosFileOperationResult SetCurrentDirValue(char driveLetter, string? hostFullPath, string fullDosPath) {
         if (string.IsNullOrWhiteSpace(hostFullPath) ||
-            !IsWithinMountPoint(hostFullPath, _dosDriveManager[driveLetter]) ||
+            !IsWithinMountPoint(hostFullPath, _dosDriveManager.TryGetDrive(driveLetter, out VirtualDrive? vDrive) ? vDrive : null) ||
             Encoding.ASCII.GetByteCount(fullDosPath) > MaxPathLength) {
             return DosFileOperationResult.Error(DosErrorCode.PathNotFound);
         }
@@ -176,7 +177,7 @@ internal class DosPathResolver {
         }
 
         return StartsWithDosDriveAndVolumeSeparator(dosPath)
-            ? (_dosDriveManager[dosPath[0]].MountedHostDirectory, dosPath[2..])
+            ? (_dosDriveManager.GetDrive<VirtualDrive>(dosPath[0]).MountedHostDirectory, dosPath[2..])
             : (_dosDriveManager.CurrentDrive.MountedHostDirectory, dosPath);
     }
 

--- a/src/Spice86.Core/Emulator/OperatingSystem/DosPathResolver.cs
+++ b/src/Spice86.Core/Emulator/OperatingSystem/DosPathResolver.cs
@@ -449,7 +449,7 @@ internal class DosPathResolver {
 
     private bool StartsWithDosDriveAndVolumeSeparator(string dosPath) =>
         dosPath.Length >= 2 &&
-        DosDriveManager.GetDriveLetterIndex(dosPath[0]) != -1 &&
+        DosDriveManager.GetDriveIndex(dosPath[0]) != -1 &&
         dosPath[1] == VolumeSeparatorChar;
 
     private bool IsPathRooted(string path) =>

--- a/src/Spice86.Core/Emulator/OperatingSystem/DosProcessManager.cs
+++ b/src/Spice86.Core/Emulator/OperatingSystem/DosProcessManager.cs
@@ -973,11 +973,7 @@ public class DosProcessManager : IDosBatchExecutionHost, ICurrentProcessNameProv
             return false;
         }
 
-        if (driveByte > DosDriveManager.MaxDriveCount) {
-            return false;
-        }
-
-        ushort zeroBasedIndex = (ushort)(driveByte - 1);
+        int zeroBasedIndex = driveByte - 1;
         return _driveManager.HasDriveAtIndex(zeroBasedIndex);
     }
 

--- a/src/Spice86.Core/Emulator/OperatingSystem/Structures/DosDriveBase.cs
+++ b/src/Spice86.Core/Emulator/OperatingSystem/Structures/DosDriveBase.cs
@@ -30,6 +30,11 @@ public abstract class DosDriveBase {
     public string DosVolume => $"{DriveLetter}{DosPathResolver.VolumeSeparatorChar}";
 
     /// <summary>
+    /// Gets the absolute path to the current DOS directory in use on the drive.
+    /// </summary>
+    public string CurrentDosDirectory { get; set; } = "";
+
+    /// <summary>
     /// Gets if it is a network drive. Not supported, always <see langword="false" />
     /// </summary>
     public bool IsRemote { get; }

--- a/src/Spice86.Core/Emulator/OperatingSystem/Structures/VirtualDrive.cs
+++ b/src/Spice86.Core/Emulator/OperatingSystem/Structures/VirtualDrive.cs
@@ -7,9 +7,4 @@ public class VirtualDrive : DosDriveBase {
     /// The full host path to the mounted folder. This path serves as the root of the DOS drive.
     /// </summary>
     public required string MountedHostDirectory { get; init; }
-
-    /// <summary>
-    /// Gets the absolute path to the current DOS directory in use on the drive.
-    /// </summary>
-    public required string CurrentDosDirectory { get; set; }
 }

--- a/tests/Spice86.Tests/Dos/DosDriveManagerTests.cs
+++ b/tests/Spice86.Tests/Dos/DosDriveManagerTests.cs
@@ -1,0 +1,214 @@
+﻿namespace Spice86.Tests.Dos;
+
+using FluentAssertions;
+
+using Spice86.Core.Emulator.OperatingSystem;
+using Spice86.Core.Emulator.OperatingSystem.Structures;
+
+using System.Collections;
+using System.Collections.Generic;
+
+using Xunit;
+
+public class DosDriveManagerTests {
+    [Fact]
+    public void DefaultDriveManagerEnumeration() {
+        string tempDir = Path.Join(Path.GetTempPath(), $"dos_drive_manager_{Guid.NewGuid():N}");
+        Directory.CreateDirectory(tempDir);
+
+        try {
+            // Arrange
+            DosDriveManager dosDriveManager = DosTestHelpers.CreateDriveManager(tempDir);
+
+            // Act
+            // These internally rely on ICollection<...>.Count and ICollection<...>.CopyTo() implementations.
+            List<KeyValuePair<char, DosDriveBase>> mountedDriveEntries = [.. dosDriveManager];
+            List<char> mountedDriveLetters = [.. dosDriveManager.Keys];
+            List<DosDriveBase> mountedDrives = [.. dosDriveManager.Values];
+
+            // Assert
+            dosDriveManager.Count.Should().Be(3);
+            mountedDriveEntries.Should().AllSatisfy(static entry => {
+                entry.Should().NotBeNull();
+                entry.Key.Should().Be(entry.Value.DriveLetter);
+            });
+            mountedDriveLetters.Should().BeEquivalentTo(mountedDriveEntries
+                .Select(static entry => entry.Key));
+            mountedDrives.Should().BeEquivalentTo(mountedDriveEntries
+                .Select(static entry => entry.Value));
+        } finally {
+            Directory.Delete(tempDir, true);
+        }
+    }
+
+    [Fact]
+    public void MountMemoryDriveEnumeration() {
+        string tempDir = Path.Join(Path.GetTempPath(), $"dos_drive_manager_{Guid.NewGuid():N}");
+        Directory.CreateDirectory(tempDir);
+
+        try {
+            // Arrange
+            DosDriveManager dosDriveManager = DosTestHelpers.CreateDriveManager(tempDir);
+            dosDriveManager.MountMemoryDrive(new MemoryDrive() { DriveLetter = 'Z' });
+
+            // Act
+            // These internally rely on ICollection<...>.Count and ICollection<...>.CopyTo() implementations.
+            List<KeyValuePair<char, DosDriveBase>> mountedDriveEntries = [.. dosDriveManager];
+            List<char> mountedDriveLetters = [.. dosDriveManager.Keys];
+            List<DosDriveBase> mountedDrives = [.. dosDriveManager.Values];
+
+            // Assert
+            dosDriveManager.Count.Should().Be(4);
+            dosDriveManager['Z'].Should().BeOfType<MemoryDrive>();
+            mountedDriveEntries.Should().AllSatisfy(static entry => {
+                entry.Should().NotBeNull();
+                entry.Key.Should().Be(entry.Value.DriveLetter);
+            });
+            mountedDriveLetters.Should().BeEquivalentTo(mountedDriveEntries
+                .Select(static entry => entry.Key));
+            mountedDrives.Should().BeEquivalentTo(mountedDriveEntries
+                .Select(static entry => entry.Value));
+        } finally {
+            Directory.Delete(tempDir, true);
+        }
+    }
+
+    [Fact]
+    public void MountMemoryDriveManualEnumeration() {
+        string tempDir = Path.Join(Path.GetTempPath(), $"dos_drive_manager_{Guid.NewGuid():N}");
+        Directory.CreateDirectory(tempDir);
+
+        try {
+            // Arrange
+            DosDriveManager dosDriveManager = DosTestHelpers.CreateDriveManager(tempDir);
+            dosDriveManager.MountMemoryDrive(new MemoryDrive() { DriveLetter = 'Z' });
+
+            // Act
+            DosDriveBase aDrive = dosDriveManager['A'];
+            DosDriveBase bDrive = dosDriveManager['B'];
+            DosDriveBase cDrive = dosDriveManager['C'];
+            DosDriveBase zDrive = dosDriveManager['Z'];
+
+            using DosDriveManager.Enumerator kvpEnumerator = dosDriveManager.GetEnumerator();
+            using DosDriveManager.Enumerator kvpEnumeratorExplicit = (DosDriveManager.Enumerator)
+                ((IEnumerable<KeyValuePair<char, DosDriveBase>>)dosDriveManager).GetEnumerator();
+            using DosDriveManager.Enumerator dictEntryEnumerator = (DosDriveManager.Enumerator)
+                ((IEnumerable)dosDriveManager).GetEnumerator();
+            using DosDriveManager.DriveLetterCollection.Enumerator keyEnumerator = dosDriveManager.Keys.GetEnumerator();
+            using DosDriveManager.DriveCollection.Enumerator valueEnumerator = dosDriveManager.Values.GetEnumerator();
+
+            // Simplifies common assertions for expected valid enumeration across all enumerators.
+            void ShouldEnumerateAndCheck(char expectedDriveLetter, DosDriveBase expectedDrive) {
+                KeyValuePair<char, DosDriveBase> kvpExpected = new(expectedDriveLetter, expectedDrive);
+                DictionaryEntry dictEntryExpected = new(expectedDriveLetter, expectedDrive);
+
+                // Enumerate all enumerators to the next entry.
+                kvpEnumerator.MoveNext().Should().BeTrue();
+                kvpEnumeratorExplicit.MoveNext().Should().BeTrue();
+                dictEntryEnumerator.MoveNext().Should().BeTrue();
+                keyEnumerator.MoveNext().Should().BeTrue();
+                valueEnumerator.MoveNext().Should().BeTrue();
+
+                // Check "current" properties.
+                kvpEnumerator.Current.Should().Be(kvpExpected);
+                ((IEnumerator)kvpEnumerator).Current.Should().Be(kvpExpected);
+                ((IDictionaryEnumerator)kvpEnumerator).Key.Should().Be(expectedDriveLetter);
+                ((IDictionaryEnumerator)kvpEnumerator).Value.Should().Be(expectedDrive);
+
+                kvpEnumeratorExplicit.Current.Should().Be(kvpExpected);
+                ((IEnumerator)kvpEnumeratorExplicit).Current.Should().Be(kvpExpected);
+                ((IDictionaryEnumerator)kvpEnumeratorExplicit).Key.Should().Be(expectedDriveLetter);
+                ((IDictionaryEnumerator)kvpEnumeratorExplicit).Value.Should().Be(expectedDrive);
+
+                dictEntryEnumerator.Current.Should().Be(kvpExpected);
+                ((IEnumerator)dictEntryEnumerator).Current.Should().Be(dictEntryExpected);
+                ((IDictionaryEnumerator)dictEntryEnumerator).Key.Should().Be(expectedDriveLetter);
+                ((IDictionaryEnumerator)dictEntryEnumerator).Value.Should().Be(expectedDrive);
+
+                keyEnumerator.Current.Should().Be(expectedDriveLetter);
+                ((IEnumerator)keyEnumerator).Current.Should().Be(expectedDriveLetter);
+
+                valueEnumerator.Current.Should().Be(expectedDrive);
+                ((IEnumerator)valueEnumerator).Current.Should().Be(expectedDrive);
+            }
+
+            // Assert
+            dosDriveManager.Count.Should().Be(4);
+
+            ShouldEnumerateAndCheck('A', aDrive);
+            ShouldEnumerateAndCheck('B', bDrive);
+            ShouldEnumerateAndCheck('C', cDrive);
+            ShouldEnumerateAndCheck('Z', zDrive);
+
+            kvpEnumerator.MoveNext().Should().BeFalse();
+            kvpEnumeratorExplicit.MoveNext().Should().BeFalse();
+            dictEntryEnumerator.MoveNext().Should().BeFalse();
+            keyEnumerator.MoveNext().Should().BeFalse();
+            valueEnumerator.MoveNext().Should().BeFalse();
+        } finally {
+            Directory.Delete(tempDir, true);
+        }
+    }
+
+    [Fact]
+    public void MountMemoryDriveManualEnumerationForEach() {
+        string tempDir = Path.Join(Path.GetTempPath(), $"dos_drive_manager_{Guid.NewGuid():N}");
+        Directory.CreateDirectory(tempDir);
+
+        try {
+            // Arrange
+            DosDriveManager dosDriveManager = DosTestHelpers.CreateDriveManager(tempDir);
+            dosDriveManager.MountMemoryDrive(new MemoryDrive() { DriveLetter = 'Z' });
+
+            // Act
+            DosDriveBase aDrive = dosDriveManager['A'];
+            DosDriveBase bDrive = dosDriveManager['B'];
+            DosDriveBase cDrive = dosDriveManager['C'];
+            DosDriveBase zDrive = dosDriveManager['Z'];
+
+            // Assert
+            dosDriveManager.Count.Should().Be(4);
+
+            int index = 0;
+            foreach (KeyValuePair<char, DosDriveBase> kvp in dosDriveManager) {
+                KeyValuePair<char, DosDriveBase> expected = index switch {
+                    0 => new('A', aDrive),
+                    1 => new('B', bDrive),
+                    2 => new('C', cDrive),
+                    3 => new('Z', zDrive),
+                    _ => default
+                };
+                kvp.Should().Be(expected);
+                index++;
+            }
+
+            index = 0;
+            foreach (char driveLetter in dosDriveManager.Keys) {
+                char expected = index switch {
+                    0 => 'A',
+                    1 => 'B',
+                    2 => 'C',
+                    3 => 'Z',
+                    _ => default
+                };
+                driveLetter.Should().Be(expected);
+                index++;
+            }
+
+            index = 0;
+            foreach (DosDriveBase drive in dosDriveManager.Values) {
+                DosDriveBase? expected = index switch {
+                    0 => aDrive,
+                    1 => bDrive,
+                    2 => cDrive,
+                    3 => zDrive,
+                    _ => default
+                };
+                drive.Should().Be(expected);
+                index++;
+            }
+        } finally {
+            Directory.Delete(tempDir, true);
+        }
+    }
+}

--- a/tests/Spice86.Tests/Dos/DosFcbManagerTests.cs
+++ b/tests/Spice86.Tests/Dos/DosFcbManagerTests.cs
@@ -107,7 +107,7 @@ public class DosFcbManagerTests : IDisposable {
     [Fact]
     public void ParseFilename_InvalidDrive_ContinuesParsing() {
         // Arrange
-        _fixture.Memory.SetZeroTerminatedString(StringAddr, "Z:TEST.TXT", 128);
+        _fixture.Memory.SetZeroTerminatedString(StringAddr, "Q:TEST.TXT", 128);
 
         // Act - Undocumented behavior: should keep parsing even if drive specification is invalid
         (FcbParseResult result, uint bytesAdvanced) = _fixture.DosFcbManager.ParseFilename(StringAddr, FcbAddr, 0);

--- a/tests/Spice86.Tests/Dos/DosFcbManagerTests.cs
+++ b/tests/Spice86.Tests/Dos/DosFcbManagerTests.cs
@@ -118,7 +118,7 @@ public class DosFcbManagerTests : IDisposable {
         DosFileControlBlock fcb = new DosFileControlBlock(_fixture.Memory, FcbAddr);
         fcb.FileName.Should().Be("TEST    ");
         fcb.FileExtension.Should().Be("TXT");
-        fcb.DriveNumber.Should().Be(26); // Z: = 26
+        fcb.DriveNumber.Should().Be(('Q' - 'A') + 1); // Q: drive, one-based index
     }
 
     [Fact]

--- a/tests/Spice86.Tests/Dos/DriveAbstractionTests.cs
+++ b/tests/Spice86.Tests/Dos/DriveAbstractionTests.cs
@@ -143,7 +143,7 @@ public class DriveAbstractionTests {
         // zDrive is not null and retrieved == zDrive, so assert properties on zDrive directly.
         zDrive.DriveLetter.Should().Be('Z');
         zDrive.IsReadOnlyMedium.Should().BeTrue();
-        manager['C'].MountedHostDirectory.Should().NotBeEmpty("C: drive must remain unaffected");
+        manager.GetDrive<VirtualDrive>('C').MountedHostDirectory.Should().NotBeEmpty("C: drive must remain unaffected");
     }
 
 }


### PR DESCRIPTION
### Description of Changes
Almost complete rewrite of `DosDriveManager`. Now using `DosDriveBase` as the base value type for the dictionary and unified all DOS drive types into a single internal collection type via an array. Created helper classes/structures inside to process the `Keys` and `Values` properties on the dictionary as well as fast `GetEnumerator()` support (most of that support code was inspired by the .NET `Dictionary<TKey,TValue>` implementation).

Added several helper methods into `DosDriveManager` for converting between DOS drive letters and zero-based indexes. I thought about putting them into `DosPathResolver` instead, but that is an internal class and these methods more closely related to drive management anyways.

Removed `DosDriveManager.DriveLetters` dictionary as it's no longer needed (and is likely very slow compared to the new methods).

Added methods for mounting, unmounting (including `IDisposable` and `IAsyncDisposable`), and getting DOS drives. (Some of the explicit/"hidden" dictionary methods do not dispose of drives that are removed--see documentation comments for applicable methods. Though this can be changed if it's more desirable to use dispose on anything that removes from the dictionary--I just wanted a way for advanced users to be able to remove specific drives from the drive manager without automatically calling `Dispose()` or `DisposeAsync()`.)

Moved `CurrentDosDirectory` property from `VirtualDrive` to `DosDriveBase` and made it optional (so it's not necessary to set it--the default value of an empty string should be sufficient).

Fixed LINQ calls to `ElementAtOrDefault` and `ElementAt` into `DosDriveManager`; those LINQ calls incorrectly assume that the enumerated element index is the same as the drive letter/index (which it's not--it just happens that drives A:, B:, and C: are all allocated and map to indexes 0, 1, and 2 respectively... other drives like Z: or any other user-mounted drives may not follow that pattern with the previous implementation).

Patched one of the tests so it wouldn't fail (see notes in "Suggested Testing Steps").

***NOTE:*** One thing that I have not done that I was thinking about doing: creating a new property called `DriveIndex` into `DosDriveBase` (with defensive bounds checks on the setter) and then redirecting the `DriveLetter` property to use that instead (via the new helper APIs I have created). Doing this would improve the reliability contract for the property, would remove the need to write defensive checks when accessing the `DriveLetter` property, and could also slightly improve performance by being able to access the drive index directly.

### Rationale behind Changes
This provides a better contract for future changes. It should be cleaner than the "multiple dictionary" approach that I've seen in other pull requests. There is only one drive letter to one drive, it doesn't make sense to me to keep the different drive types separated.

This should be faster than using `Dictionary<TKey,TValue>` fields as most operations are going to be retrieving values with specific drive letters and indexes, which have a one-to-one mapping. Array should be faster at doing this at a slight (probably imperceptible) performance cost when enumerating objects (which is not used often).

### Suggested Testing Steps
I have run all Spice86.Tests, but not Spice86.Tests.UI. There are currently 2 test failures and 1 skipped. I had patched another test, because it appears that the Z: drive is mapped by default in the unit tests (as a memory drive) and the specific test was using that drive letter to check for an "invalid drive" (and it no longer is with these changes).

Test failures are here: Spice86.Tests.Dos.DosConsoleIoctlIntegrationTests.Ioctl_OutOfScopeSubfunctions_ReturnConsistentFunctionInvalidError (for 15 and 17).
I'm not entirely sure if these failures are related or not, I'm not an expert at DOS system calls.

There are some path parsing bugs at present (especially in `DosPathResolver`), but I think those changes are better suited for a different pull request.