### PR TITLE
DosPathResolver improvements & bug fixes

### DIFF
--- a/src/Spice86.Core/Emulator/Mcp/EmulatorMcpTools.cs
+++ b/src/Spice86.Core/Emulator/Mcp/EmulatorMcpTools.cs
@@ -1240,7 +1240,7 @@ internal sealed class EmulatorMcpTools {
                 }
 
                 char normalizedDriveLetter = char.ToUpperInvariant(driveLetter[0]);
-                if (!dos.DosDriveManager.TryGetDrive(normalizedDriveLetter, out VirtualDrive? mountedDrive) || mountedDrive == null) {
+                if (!dos.DosDriveManager.TryGetDrive(normalizedDriveLetter, out VirtualDrive? mountedDrive)) {
                     throw new InvalidOperationException($"Drive '{normalizedDriveLetter}' is not mounted");
                 }
 
@@ -1528,7 +1528,7 @@ internal sealed class EmulatorMcpTools {
 
         char driveLetterChar = driveLetter[0];
         int driveIndex = DosDriveManager.GetDriveIndexOrThrow(driveLetterChar, nameof(driveLetter));
-        if (!dos.DosDriveManager.TryGetDrive(driveLetterChar, out VirtualDrive? virtualDrive) || virtualDrive == null) {
+        if (!dos.DosDriveManager.TryGetDrive(driveLetterChar, out VirtualDrive? virtualDrive)) {
             throw new InvalidOperationException($"Drive '{driveLetterChar}' is not mounted");
         }
 

--- a/src/Spice86.Core/Emulator/OperatingSystem/DosBatchExecutionEngine.CommandHandlers.cs
+++ b/src/Spice86.Core/Emulator/OperatingSystem/DosBatchExecutionEngine.CommandHandlers.cs
@@ -7,6 +7,7 @@ using Spice86.Core.Emulator.OperatingSystem.Structures;
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Globalization;
 using System.IO;
 using System.Text;
@@ -343,14 +344,17 @@ internal sealed partial class DosBatchExecutionEngine {
     }
 
     internal bool TryHandleChdir(string arguments) {
-        string trimmed = arguments.Trim();
+        ReadOnlySpan<char> trimmed = arguments.AsSpan().Trim();
+        string? trimmedString = null;
         if (_loggerService.IsEnabled(LogEventLevel.Debug)) {
-            _loggerService.Debug("BATCH: CD/CHDIR args={Args}", trimmed);
+            trimmedString ??= trimmed.Length == arguments.Length ? arguments : trimmed.ToString();
+            _loggerService.Debug("BATCH: CD/CHDIR args={Args}", trimmedString);
         }
         if (trimmed.Length == 0) {
             DosFileOperationResult result = _dosFileManager.GetCurrentDir(0, out string currentDir);
             if (!result.IsError) {
                 char driveLetter = _driveManager.CurrentDrive.DriveLetter;
+                Debug.Assert(DosDriveManager.GetDriveIndex(driveLetter) != -1);
                 WriteToStandardOutput($"{driveLetter}:\\{currentDir}\r\n");
             }
 
@@ -358,10 +362,15 @@ internal sealed partial class DosBatchExecutionEngine {
         }
 
         if (trimmed.Length == 2 && trimmed[1] == ':') {
-            byte driveNumber = (byte)(char.ToUpperInvariant(trimmed[0]) - 'A' + 1);
-            DosFileOperationResult result = _dosFileManager.GetCurrentDir(driveNumber, out string currentDir);
-            if (!result.IsError) {
-                WriteToStandardOutput($"{char.ToUpperInvariant(trimmed[0])}:\\{currentDir}\r\n");
+            int driveIndex = DosDriveManager.GetDriveIndex(trimmed[0]) + 1;
+            if (driveIndex != -1) {
+                Debug.Assert(driveIndex is >= byte.MinValue and < byte.MaxValue);
+                DosFileOperationResult result = _dosFileManager.GetCurrentDir((byte)(driveIndex - 1), out string currentDir);
+                if (!result.IsError) {
+                    WriteToStandardOutput($"{DosDriveManager.GetDriveLetterFromIndexFast(driveIndex)}:\\{currentDir}\r\n");
+                } else {
+                    WriteToStandardOutput($"Invalid drive specification\r\n");
+                }
             } else {
                 WriteToStandardOutput($"Invalid drive specification\r\n");
             }
@@ -369,7 +378,9 @@ internal sealed partial class DosBatchExecutionEngine {
             return false;
         }
 
-        DosFileOperationResult setResult = _dosFileManager.SetCurrentDir(trimmed);
+        // Avoid extra string allocation by only creating a new string if the trimmed span has a different length.
+        trimmedString ??= trimmed.Length == arguments.Length ? arguments : trimmed.ToString();
+        DosFileOperationResult setResult = _dosFileManager.SetCurrentDir(trimmedString);
         if (setResult.IsError) {
             WriteToStandardOutput("Invalid directory\r\n");
         }

--- a/src/Spice86.Core/Emulator/OperatingSystem/DosBatchExecutionEngine.CommandHandlers.cs
+++ b/src/Spice86.Core/Emulator/OperatingSystem/DosBatchExecutionEngine.CommandHandlers.cs
@@ -369,67 +369,12 @@ internal sealed partial class DosBatchExecutionEngine {
             return false;
         }
 
-        // Resolve relative "." and ".." against the current directory before
-        // passing to SetCurrentDir, because the path resolver skips these
-        // elements when they appear alone without a preceding directory.
-        string resolved = ResolveRelativeDosPath(trimmed);
-        DosFileOperationResult setResult = _dosFileManager.SetCurrentDir(resolved);
+        DosFileOperationResult setResult = _dosFileManager.SetCurrentDir(trimmed);
         if (setResult.IsError) {
             WriteToStandardOutput("Invalid directory\r\n");
         }
 
         return false;
-    }
-
-    /// <summary>
-    /// Resolves a relative DOS path (e.g. ".", "..", "..\SUBDIR") against the
-    /// current drive and directory to produce an absolute DOS path.
-    /// </summary>
-    private string ResolveRelativeDosPath(string dosPath) {
-        if (dosPath.Length == 0) {
-            return dosPath;
-        }
-
-        // Already absolute (starts with drive letter or backslash)
-        char first = dosPath[0];
-        if (dosPath.Length >= 2 && dosPath[1] == ':') {
-            return dosPath;
-        }
-        if (first == '\\') {
-            return dosPath;
-        }
-
-        // Build the current directory prefix
-        char driveLetter = _driveManager.CurrentDrive.DriveLetter;
-        DosFileOperationResult result = _dosFileManager.GetCurrentDir(0, out string currentDir);
-        if (result.IsError) {
-            return dosPath;
-        }
-
-        string basePath = string.IsNullOrEmpty(currentDir)
-            ? $"{driveLetter}:\\"
-            : $"{driveLetter}:\\{currentDir}";
-
-        // Split into segments and apply . / .. navigation
-        string combined = $"{basePath}\\{dosPath}";
-        string[] parts = combined.Split(['\\'], StringSplitOptions.RemoveEmptyEntries);
-        List<string> resolved = new();
-
-        for (int i = 0; i < parts.Length; i++) {
-            string part = parts[i];
-            if (part == ".") {
-                continue;
-            }
-            if (part == "..") {
-                if (resolved.Count > 1) {
-                    resolved.RemoveAt(resolved.Count - 1);
-                }
-                continue;
-            }
-            resolved.Add(part);
-        }
-
-        return string.Join("\\", resolved);
     }
 
     internal void HandleExit() {

--- a/src/Spice86.Core/Emulator/OperatingSystem/DosBatchExecutionEngine.CommandHandlers.cs
+++ b/src/Spice86.Core/Emulator/OperatingSystem/DosBatchExecutionEngine.CommandHandlers.cs
@@ -362,10 +362,10 @@ internal sealed partial class DosBatchExecutionEngine {
         }
 
         if (trimmed.Length == 2 && trimmed[1] == ':') {
-            int driveIndex = DosDriveManager.GetDriveIndex(trimmed[0]) + 1;
+            int driveIndex = DosDriveManager.GetDriveIndex(trimmed[0]);
             if (driveIndex != -1) {
                 Debug.Assert(driveIndex is >= byte.MinValue and < byte.MaxValue);
-                DosFileOperationResult result = _dosFileManager.GetCurrentDir((byte)(driveIndex - 1), out string currentDir);
+                DosFileOperationResult result = _dosFileManager.GetCurrentDir((byte)(driveIndex + 1), out string currentDir);
                 if (!result.IsError) {
                     WriteToStandardOutput($"{DosDriveManager.GetDriveLetterFromIndexFast(driveIndex)}:\\{currentDir}\r\n");
                 } else {

--- a/src/Spice86.Core/Emulator/OperatingSystem/DosDriveManager.cs
+++ b/src/Spice86.Core/Emulator/OperatingSystem/DosDriveManager.cs
@@ -783,7 +783,7 @@ public class DosDriveManager : IDictionary<char, DosDriveBase>, IReadOnlyDiction
     public void Clear(bool disposeDrives) {
         if (!disposeDrives) {
             Array.Clear(_driveMap);
-            _mappedDriveCount--;
+            _mappedDriveCount = 0;
             _version++;
             return;
         }

--- a/src/Spice86.Core/Emulator/OperatingSystem/DosFileManager.cs
+++ b/src/Spice86.Core/Emulator/OperatingSystem/DosFileManager.cs
@@ -1097,7 +1097,11 @@ public class DosFileManager {
             return FileAccessDeniedError(dosDirectory);
         }
 
-        string prefixedDosDirectory = _dosPathResolver.PrefixWithHostDirectory(dosDirectory);
+        string? prefixedDosDirectory = _dosPathResolver.PrefixWithHostDirectory(dosDirectory);
+        if (prefixedDosDirectory is null) {
+            return PathNotFoundError(dosDirectory);
+        }
+
         try {
             Directory.CreateDirectory(prefixedDosDirectory);
             if (_loggerService.IsEnabled(LogEventLevel.Information)) {

--- a/src/Spice86.Core/Emulator/OperatingSystem/DosFileManager.cs
+++ b/src/Spice86.Core/Emulator/OperatingSystem/DosFileManager.cs
@@ -966,7 +966,7 @@ public class DosFileManager {
     /// </summary>
     private VirtualDrive ResolveDriveFromFileSpec(string fileSpec) {
         if (fileSpec.Length >= 2 && fileSpec[1] == DosPathResolver.VolumeSeparatorChar) {
-            char driveLetter = char.ToUpperInvariant(fileSpec[0]);
+            char driveLetter = fileSpec[0];
             if (_dosDriveManager.TryGetDrive(driveLetter, out VirtualDrive? drive)) {
                 return drive;
             }
@@ -979,7 +979,7 @@ public class DosFileManager {
         VirtualDrive targetDrive = ResolveDriveFromFileSpec(fileSpec);
         string driveLabel = targetDrive.Label.ToUpperInvariant();
         if (isFcbSearch) {
-            byte driveIndex = (byte)DosDriveManager.GetDriveIndexOrThrow(targetDrive.DriveLetter, fileSpec);
+            byte driveIndex = (byte)DosDriveManager.GetDriveIndexOrThrow(targetDrive.DriveLetter, nameof(fileSpec));
             WriteFcbVolumeLabelToDta(dta, driveLabel, driveIndex);
         } else {
             WriteExtendedVolumeLabelToDta(dta, driveLabel);
@@ -1045,7 +1045,7 @@ public class DosFileManager {
         string extOnly = Path.GetExtension(entryInfo.ShortName).TrimStart('.');
 
         VirtualDrive targetDrive = ResolveDriveFromFileSpec(fileSpec);
-        byte driveNumber = (byte)(DosDriveManager.GetDriveIndexOrThrow(targetDrive.DriveLetter, fileSpec) + 1);
+        byte driveNumber = (byte)(DosDriveManager.GetDriveIndexOrThrow(targetDrive.DriveLetter, nameof(fileSpec)) + 1);
         UpdateDosTransferAreaWithFcbResult(dta, nameOnly, extOnly, (byte)entryInfo.Attributes,
             ToDosDate(creationLocalDate), ToDosTime(creationLocalDate), entryInfo.FileSize, driveNumber);
     }

--- a/src/Spice86.Core/Emulator/OperatingSystem/DosPathResolver.cs
+++ b/src/Spice86.Core/Emulator/OperatingSystem/DosPathResolver.cs
@@ -293,9 +293,15 @@ internal class DosPathResolver {
         if (string.IsNullOrWhiteSpace(dosPath)) {
             return null;
         }
-        dosPath = GetFullDosPathIncludingRoot(dosPath);
 
-        (string hostPrefix, string dosRelativePath) = DeconstructDosPath(dosPath);
+        DosPathBuilderResult result = GetFullDosPathIncludingRoot(dosPath, out string? fullDosPath);
+        if (result != DosPathBuilderResult.Success) {
+            Debug.Assert(fullDosPath is null);
+            return null;
+        }
+
+        Debug.Assert(fullDosPath is not null);
+        (string hostPrefix, string dosRelativePath) = DeconstructDosPath(fullDosPath);
 
         if (string.IsNullOrWhiteSpace(dosRelativePath)) {
             return ConvertUtils.ToSlashPath(hostPrefix);

--- a/src/Spice86.Core/Emulator/OperatingSystem/DosPathResolver.cs
+++ b/src/Spice86.Core/Emulator/OperatingSystem/DosPathResolver.cs
@@ -4,6 +4,7 @@ using Spice86.Core.Emulator.OperatingSystem.Enums;
 using Spice86.Core.Emulator.OperatingSystem.Structures;
 using Spice86.Shared.Utils;
 
+using System.Diagnostics;
 using System.Linq;
 using System.Text;
 
@@ -86,13 +87,41 @@ internal class DosPathResolver {
         }
     }
 
-    private string GetDosDrivePathFromDosPath(string absoluteOrRelativeDosPath) {
-        if (IsPathRooted(absoluteOrRelativeDosPath)) {
-            if (StartsWithDosDriveAndVolumeSeparator(absoluteOrRelativeDosPath)) {
-                return $"{absoluteOrRelativeDosPath[0]}{VolumeSeparatorChar}";
+    /// <summary>Gets the associated drive letter from the specified DOS path.</summary>
+    /// <param name="path">The DOS path to resolve.</param>
+    /// <param name="driveIndex">The zero-based DOS drive index or -1 on failure.</param>
+    /// <param name="isDrivePath">
+    /// <see langword="true"/> if the specified path starts with a drive letter and volume separator; otherwise,
+    /// <see langword="false"/>.
+    /// </param>
+    /// <returns>
+    /// <see langword="true"/> if the path has a valid drive letter or references the current drive (with a valid drive
+    /// index); otherwise, <see langword="false"/>.
+    /// </returns>
+    public bool TryGetDosDriveIndexFromDosPath(ReadOnlySpan<char> path, out int driveIndex, out bool isDrivePath) {
+        if (path.Length >= 2 && path[1] == VolumeSeparatorChar) {
+            // DOS path with drive specification.
+            isDrivePath = true;
+
+            driveIndex = DosDriveManager.GetDriveIndex(path[0]);
+            if (driveIndex == -1) {
+                // Invalid DOS path (bad drive letter).
+                return false;
+            }
+        } else {
+            // DOS path without drive specification (current drive).
+            isDrivePath = false;
+
+            // Perform a defensive check and avoid throwing an exception if the current drive letter/index is invalid.
+            driveIndex = DosDriveManager.GetDriveIndex(_dosDriveManager.CurrentDrive.DriveLetter);
+            if (driveIndex == -1) {
+                // Current drive has a bad drive letter.
+                return false;
             }
         }
-        return _dosDriveManager.CurrentDrive.DosVolume;
+
+        Debug.Assert(driveIndex is >= 0 and < DosDriveManager.MaxDriveCount);
+        return true;
     }
 
     private DosFileOperationResult SetCurrentDirValue(char driveLetter, string? hostFullPath, string fullDosPath) {
@@ -106,48 +135,122 @@ internal class DosPathResolver {
         return DosFileOperationResult.NoValue();
     }
 
-    private string GetFullDosPathIncludingRoot(string absoluteOrRelativeDosPath) {
-        if (string.IsNullOrWhiteSpace(absoluteOrRelativeDosPath)) {
-            return absoluteOrRelativeDosPath;
-        }
-        StringBuilder normalizedDosPath = new();
+    internal DosPathBuilderResult GetFullDosPathIncludingRoot(ReadOnlySpan<char> dosPath,
+            ref DosPathBuilder pathBuilder) {
+        Debug.Assert(!pathBuilder.IsFrozen);
+        Debug.Assert(pathBuilder.Length == 0);
+        pathBuilder.DebugValidateState();
 
-        string backslashedDosPath = ConvertUtils.ToBackSlashPath(absoluteOrRelativeDosPath);
-
-        string driveRoot = $"{GetDosDrivePathFromDosPath(backslashedDosPath)}{DirectorySeparatorChar}";
-        normalizedDosPath.Append(driveRoot);
-
-        if (backslashedDosPath.StartsWith(driveRoot)) {
-            backslashedDosPath = backslashedDosPath[3..];
-        } else if (backslashedDosPath.StartsWith(driveRoot[..2])) {
-            backslashedDosPath = backslashedDosPath[2..];
+        ReadOnlySpan<char> dosPathSpan = dosPath.TrimStart();
+        if (!TryGetDosDriveIndexFromDosPath(dosPath, out int driveIndex, out bool isDrivePath)) {
+            return DosPathBuilderResult.InvalidDriveSpecification;
         }
 
-        IEnumerable<string> pathElements = backslashedDosPath.Split(DirectorySeparatorChar, StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+        // Try to set drive specification on path builder (this should always succeed as long as the path builder is
+        // in a valid state).
+        DosPathBuilderResult appendResult = pathBuilder.SetDriveIndex(driveIndex);
+        Debug.Assert(appendResult == DosPathBuilderResult.Success);
+        if (appendResult != DosPathBuilderResult.Success) {
+            return appendResult;
+        }
 
-        bool moveNext = false;
-        bool appendedFolder = false;
-        bool mustPrependDirectorySeparator = false;
-        foreach (string pathElement in pathElements) {
-            if (pathElement == ".." && appendedFolder) {
-                moveNext = true;
-            } else {
-                if (moveNext) {
-                    moveNext = false;
-                    continue;
-                }
-                if (pathElement != "." && pathElement != ".." && !pathElement.Contains(VolumeSeparatorChar)) {
-                    appendedFolder = true;
-                    if (mustPrependDirectorySeparator) {
-                        normalizedDosPath.Append(DirectorySeparatorChar);
-                    }
-                    normalizedDosPath.Append(pathElement.ToUpperInvariant());
-                    mustPrependDirectorySeparator = true;
-                }
+        // Remove drive specification from input path (if specified).
+        if (isDrivePath) {
+            dosPathSpan = dosPathSpan[2..];
+        }
+
+        // Handle relative paths for mounted drives.
+        // It does not matter whether the input has a drive specification or not; the path is a relative path if the
+        // first character (after the optional drive specification) is a directory separator. If the path is empty,
+        // then it is treated as a relative path to the current directory on the chosen drive.
+        // See: https://learn.microsoft.com/en-us/windows/win32/fileio/naming-a-file#fully-qualified-vs-relative-paths
+        bool isRelativePath = dosPathSpan.IsEmpty || dosPathSpan[0] is not (DirectorySeparatorChar or AltDirectorySeparatorChar);
+
+        // Try to append current DOS directory on specified drive if resolving a relative path.
+        if (isRelativePath && _dosDriveManager.TryGetDriveAtIndex(driveIndex, out DosDriveBase? drive)) {
+            appendResult = pathBuilder.AppendRelativePath(drive.CurrentDosDirectory, out _);
+            if (appendResult != DosPathBuilderResult.Success) {
+                return appendResult;
             }
         }
 
-        return ConvertUtils.ToBackSlashPath(normalizedDosPath.ToString());
+        // Handle remaining path elements.
+        appendResult = pathBuilder.AppendRelativePath(dosPathSpan, out bool endsWithSlash);
+        if (appendResult != DosPathBuilderResult.Success) {
+            return appendResult;
+        }
+
+        // Make sure full path ends with a directory separator or file name. Also freeze the path builder to prevent
+        // further modifications to the path.
+        if (endsWithSlash) {
+            // This will implicitly freeze the path builder (no need to call Freeze() after this).
+            pathBuilder.AppendFinalDirectorySeparator();
+        } else {
+            pathBuilder.Freeze();
+        }
+
+        Debug.Assert(pathBuilder.IsFrozen);
+        pathBuilder.DebugValidateState();
+        return DosPathBuilderResult.Success;
+    }
+
+    internal DosPathBuilderResult GetFullDosPathIncludingRoot(ReadOnlySpan<char> dosPath, out string? fullDosPath) {
+        // NOTE: Make sure the path builder is disposed before returning from this method.
+        // TODO: Set path builder special file name settings?
+        DosPathBuilder pathBuilder = new(
+            stackalloc char[MaxPathLength],
+            stackalloc int[DosPathBuilder.DefaultStackLength]);
+
+        DosPathBuilderResult result = GetFullDosPathIncludingRoot(dosPath, ref pathBuilder);
+        if (result != DosPathBuilderResult.Success) {
+            fullDosPath = null;
+            pathBuilder.Dispose();
+            return result;
+        }
+
+        fullDosPath = pathBuilder.ToStringWithDispose();
+        return DosPathBuilderResult.Success;
+    }
+
+    internal DosPathBuilderResult GetFullDosPathIncludingRoot(string? dosPath, out string? fullDosPath) {
+        // NOTE: Make sure the path builder is disposed before returning from this method.
+        // TODO: Set path builder special file name settings?
+        DosPathBuilder pathBuilder = new(
+            stackalloc char[MaxPathLength],
+            stackalloc int[DosPathBuilder.DefaultStackLength]);
+
+        DosPathBuilderResult result = GetFullDosPathIncludingRoot(dosPath, ref pathBuilder);
+        if (result != DosPathBuilderResult.Success) {
+            fullDosPath = null;
+            pathBuilder.Dispose();
+            return result;
+        }
+
+        // Slight memory optimization if original input string is not null and is an exact match to the path builder.
+        // There is a slight time-memory tradeoff here (prefer keeping the memory heap smaller by not allocating).
+        ReadOnlySpan<char> pathBuilderSpan = pathBuilder.AsSpan();
+        if (dosPath is not null && pathBuilderSpan.SequenceEqual(dosPath)) {
+            fullDosPath = dosPath;
+            pathBuilder.Dispose();
+            return DosPathBuilderResult.Success;
+        }
+
+        fullDosPath = pathBuilderSpan.ToString();
+        pathBuilder.Dispose();
+        return DosPathBuilderResult.Success;
+    }
+
+    private string GetFullDosPathIncludingRoot(string? absoluteOrRelativeDosPath) {
+        DosPathBuilderResult result = GetFullDosPathIncludingRoot(absoluteOrRelativeDosPath, out string? fullDosPath);
+        // It's either successful with a non-null string or failure with a null string.
+        Debug.Assert((result != DosPathBuilderResult.Success) ^ (fullDosPath is not null));
+        return result switch {
+            DosPathBuilderResult.Success => fullDosPath!,
+            DosPathBuilderResult.InvalidDriveSpecification => throw new FormatException("Invalid DOS drive specification."),
+            DosPathBuilderResult.InvalidFileNameCharacters => throw new FormatException("DOS path contains invalid file name characters."),
+            DosPathBuilderResult.InvalidReservedFileName => throw new FormatException("DOS path contains a reserved file name."),
+            _ => throw new FormatException($"Unspecified DOS path formatting error: {result}")
+        };
     }
 
     /// <summary>

--- a/src/Spice86.Core/Emulator/OperatingSystem/DosPathResolver.cs
+++ b/src/Spice86.Core/Emulator/OperatingSystem/DosPathResolver.cs
@@ -161,7 +161,7 @@ internal class DosPathResolver {
 
         // Handle relative paths for mounted drives.
         // It does not matter whether the input has a drive specification or not; the path is a relative path if the
-        // first character (after the optional drive specification) is a directory separator. If the path is empty,
+        // first character (after the optional drive specification) is not a directory separator. If the path is empty,
         // then it is treated as a relative path to the current directory on the chosen drive.
         // See: https://learn.microsoft.com/en-us/windows/win32/fileio/naming-a-file#fully-qualified-vs-relative-paths
         bool isRelativePath = dosPathSpan.IsEmpty || dosPathSpan[0] is not (DirectorySeparatorChar or AltDirectorySeparatorChar);

--- a/src/Spice86.Core/Emulator/OperatingSystem/DosPathResolver.cs
+++ b/src/Spice86.Core/Emulator/OperatingSystem/DosPathResolver.cs
@@ -141,7 +141,7 @@ internal class DosPathResolver {
         pathBuilder.DebugValidateState();
 
         ReadOnlySpan<char> dosPathSpan = dosPath.TrimStart();
-        if (!TryGetDosDriveIndexFromDosPath(dosPath, out int driveIndex, out bool isDrivePath)) {
+        if (!TryGetDosDriveIndexFromDosPath(dosPathSpan, out int driveIndex, out bool isDrivePath)) {
             return DosPathBuilderResult.InvalidDriveSpecification;
         }
 

--- a/src/Spice86.Core/Emulator/OperatingSystem/DosPathResolver.cs
+++ b/src/Spice86.Core/Emulator/OperatingSystem/DosPathResolver.cs
@@ -72,9 +72,9 @@ internal class DosPathResolver {
     /// <param name="dosPath">The new DOS path to use as the current DOS folder.</param>
     /// <returns>A <see cref="DosFileOperationResult"/> that details the result of the operation.</returns>
     public DosFileOperationResult SetCurrentDir(string dosPath) {
-        string fullDosPath = GetFullDosPathIncludingRoot(dosPath);
+        string? fullDosPath = GetFullDosPathIncludingRoot(dosPath);
 
-        if (!StartsWithDosDriveAndVolumeSeparator(fullDosPath)) {
+        if (fullDosPath is null || !StartsWithDosDriveAndVolumeSeparator(fullDosPath)) {
             return DosFileOperationResult.Error(DosErrorCode.PathNotFound);
         }
 
@@ -238,17 +238,11 @@ internal class DosPathResolver {
         return DosPathBuilderResult.Success;
     }
 
-    private string GetFullDosPathIncludingRoot(string? absoluteOrRelativeDosPath) {
-        DosPathBuilderResult result = GetFullDosPathIncludingRoot(absoluteOrRelativeDosPath, out string? fullDosPath);
+    internal string? GetFullDosPathIncludingRoot(string? dosPath) {
+        DosPathBuilderResult result = GetFullDosPathIncludingRoot(dosPath, out string? fullDosPath);
         // It's either successful with a non-null string or failure with a null string.
         Debug.Assert((result != DosPathBuilderResult.Success) ^ (fullDosPath is not null));
-        return result switch {
-            DosPathBuilderResult.Success => fullDosPath!,
-            DosPathBuilderResult.InvalidDriveSpecification => throw new FormatException("Invalid DOS drive specification."),
-            DosPathBuilderResult.InvalidFileNameCharacters => throw new FormatException("DOS path contains invalid file name characters."),
-            DosPathBuilderResult.InvalidReservedFileName => throw new FormatException("DOS path contains a reserved file name."),
-            _ => throw new FormatException($"Unspecified DOS path formatting error: {result}")
-        };
+        return result == DosPathBuilderResult.Success ? fullDosPath : null;
     }
 
     /// <summary>
@@ -268,38 +262,43 @@ internal class DosPathResolver {
         return ConvertUtils.ToSlashFolderPath(fullHostPath);
     }
 
-    private (string hostPrefixPath, string dosRelativePath) DeconstructDosPath(string dosPath) {
-        if (IsPathRooted(dosPath)) {
-            int length = 1;
-            if (StartsWithDosDriveAndVolumeSeparator(dosPath)) {
-                length = 3;
-            }
-            return (_dosDriveManager.CurrentDrive.MountedHostDirectory, dosPath[length..]);
+    private (string? hostPrefixPath, string dosRelativePath) DeconstructDosPath(string dosPath) {
+        // This method is currently only called with paths that have been processed via GetFullDosPathIncludingRoot.
+        // Thus the input path here should always be a full rooted path with a drive specification.
+        if (dosPath.Length < 3 || !char.IsAsciiLetter(dosPath[0]) || dosPath[1] != VolumeSeparatorChar ||
+                dosPath[2] != DirectorySeparatorChar) {
+            throw new ArgumentException("Given DOS path is not a full rooted path with a drive specification.", nameof(dosPath));
         }
 
-        return StartsWithDosDriveAndVolumeSeparator(dosPath)
-            ? (_dosDriveManager.GetDrive<VirtualDrive>(dosPath[0]).MountedHostDirectory, dosPath[2..])
-            : (_dosDriveManager.CurrentDrive.MountedHostDirectory, dosPath);
+        // Avoid throwing an exception if the drive does not exist. Let the caller figure out what to do by setting the
+        // host prefix path to null. Technically the drive letter will always be a valid in the drive manager, but it
+        // is not always guaranteed to be a VirtualDrive.
+        if (!_dosDriveManager.TryGetDrive(dosPath[0], out VirtualDrive? drive)) {
+            return (null, dosPath[3..]);
+        }
+
+        return (drive.MountedHostDirectory, dosPath[3..]);
     }
 
     /// <summary>
-    /// Converts the DOS path to a full host path.<br/>
+    /// Converts the DOS path to a full host path.
     /// </summary>
     /// <param name="dosPath">The DOS path to convert.</param>
-    /// <returns>A string containing the full file path in the host file system, or <c>null</c> if nothing was found.</returns>
-    public string? GetFullHostPathFromDosOrDefault(string dosPath) {
+    /// <returns>A string containing the full file path in the host file system, or <see langword="null"/> if nothing was found or the DOS path cannot be resolved.</returns>
+    public string? GetFullHostPathFromDosOrDefault(string? dosPath) {
         if (string.IsNullOrWhiteSpace(dosPath)) {
             return null;
         }
 
-        DosPathBuilderResult result = GetFullDosPathIncludingRoot(dosPath, out string? fullDosPath);
-        if (result != DosPathBuilderResult.Success) {
-            Debug.Assert(fullDosPath is null);
+        dosPath = GetFullDosPathIncludingRoot(dosPath);
+        if (dosPath is null) {
             return null;
         }
 
-        Debug.Assert(fullDosPath is not null);
-        (string hostPrefix, string dosRelativePath) = DeconstructDosPath(fullDosPath);
+        (string? hostPrefix, string dosRelativePath) = DeconstructDosPath(dosPath);
+        if (hostPrefix is null) {
+            return null;
+        }
 
         if (string.IsNullOrWhiteSpace(dosRelativePath)) {
             return ConvertUtils.ToSlashPath(hostPrefix);
@@ -334,14 +333,21 @@ internal class DosPathResolver {
     /// The parent directory must exist; the filename is appended as-is.
     /// </summary>
     /// <param name="dosPath">The DOS path of the new file.</param>
-    /// <returns>A host file path, or <c>null</c> if the parent directory cannot be resolved.</returns>
-    public string? ResolveNewFilePath(string dosPath) {
+    /// <returns>A host file path, or <see langword="null"/> if the parent directory or the DOS path cannot be resolved.</returns>
+    public string? ResolveNewFilePath(string? dosPath) {
         if (string.IsNullOrWhiteSpace(dosPath)) {
             return null;
         }
 
         dosPath = GetFullDosPathIncludingRoot(dosPath);
-        (string hostPrefix, string dosRelativePath) = DeconstructDosPath(dosPath);
+        if (dosPath is null) {
+            return null;
+        }
+
+        (string? hostPrefix, string dosRelativePath) = DeconstructDosPath(dosPath);
+        if (hostPrefix is null) {
+            return null;
+        }
 
         if (string.IsNullOrWhiteSpace(dosRelativePath)) {
             return null;
@@ -369,14 +375,21 @@ internal class DosPathResolver {
     /// when the path has no extension. Use this only for execution-related path resolution.
     /// </summary>
     /// <param name="dosPath">The DOS path to convert.</param>
-    /// <returns>A string containing the full file path in the host file system, or <c>null</c> if nothing was found.</returns>
-    public string? GetFullHostExecutablePathFromDosOrDefault(string dosPath) {
+    /// <returns>A string containing the full file path in the host file system, or <see langword="null"/> if nothing was found or the DOS path cannot be resolved.</returns>
+    public string? GetFullHostExecutablePathFromDosOrDefault(string? dosPath) {
         if (string.IsNullOrWhiteSpace(dosPath)) {
             return null;
         }
-        dosPath = GetFullDosPathIncludingRoot(dosPath);
 
-        (string hostPrefix, string dosRelativePath) = DeconstructDosPath(dosPath);
+        dosPath = GetFullDosPathIncludingRoot(dosPath);
+        if (dosPath is null) {
+            return null;
+        }
+
+        (string? hostPrefix, string dosRelativePath) = DeconstructDosPath(dosPath);
+        if (hostPrefix is null) {
+            return null;
+        }
 
         if (string.IsNullOrWhiteSpace(dosRelativePath)) {
             return ConvertUtils.ToSlashPath(hostPrefix);
@@ -544,14 +557,23 @@ internal class DosPathResolver {
     /// Does not search for the file or folder on disk.
     /// </summary>
     /// <param name="dosPath">The DOS path to convert.</param>
-    /// <returns>A string containing the combination of the host path and the DOS path.</returns>
-    public string PrefixWithHostDirectory(string dosPath) {
+    /// <returns>A string containing the combination of the host path and the DOS path, or <see langword="null"/> if the DOS path cannot be resolved.</returns>
+    public string? PrefixWithHostDirectory(string? dosPath) {
         if (string.IsNullOrWhiteSpace(dosPath)) {
             return dosPath;
         }
+
         dosPath = GetFullDosPathIncludingRoot(dosPath);
-        (string HostPrefix, string DosRelativePath) = DeconstructDosPath(dosPath);
-        return ConvertUtils.ToSlashPath(Path.Join(HostPrefix, DosRelativePath));
+        if (dosPath is null) {
+            return null;
+        }
+
+        (string? hostPrefix, string dosRelativePath) = DeconstructDosPath(dosPath);
+        if (hostPrefix is null) {
+            return null;
+        }
+
+        return ConvertUtils.ToSlashPath(Path.Join(hostPrefix, dosRelativePath));
     }
 
     private bool StartsWithDosDriveAndVolumeSeparator(string dosPath) =>

--- a/src/Spice86.Core/Emulator/OperatingSystem/DosPathResolver.cs
+++ b/src/Spice86.Core/Emulator/OperatingSystem/DosPathResolver.cs
@@ -148,7 +148,6 @@ internal class DosPathResolver {
         // Try to set drive specification on path builder (this should always succeed as long as the path builder is
         // in a valid state).
         DosPathBuilderResult appendResult = pathBuilder.SetDriveIndex(driveIndex);
-        Debug.Assert(appendResult == DosPathBuilderResult.Success);
         if (appendResult != DosPathBuilderResult.Success) {
             return appendResult;
         }

--- a/src/Spice86.Core/Emulator/OperatingSystem/DosPathResolver.cs
+++ b/src/Spice86.Core/Emulator/OperatingSystem/DosPathResolver.cs
@@ -42,8 +42,7 @@ internal class DosPathResolver {
             currentDir = virtualDrive.CurrentDosDirectory;
             return DosFileOperationResult.NoValue();
         } else {
-            if (DosDriveManager.TryGetDriveLetterFromIndex(driveNumber - 1, out char driveLetter) &&
-                _dosDriveManager.TryGetDrive(driveLetter, out VirtualDrive? virtualDrive)) {
+            if (_dosDriveManager.TryGetDriveAtIndex(driveNumber - 1, out VirtualDrive? virtualDrive)) {
                 currentDir = virtualDrive.CurrentDosDirectory;
                 return DosFileOperationResult.NoValue();
             }

--- a/src/Spice86.Core/Emulator/OperatingSystem/Enums/DosPathBuilderResult.cs
+++ b/src/Spice86.Core/Emulator/OperatingSystem/Enums/DosPathBuilderResult.cs
@@ -1,0 +1,19 @@
+﻿namespace Spice86.Core.Emulator.OperatingSystem.Enums;
+
+/// <summary>Result of performing operations related to building DOS paths.</summary>
+internal enum DosPathBuilderResult {
+    /// <summary>Operation successful.</summary>
+    Success = 0,
+
+    /// <summary>Operation not successful due to path builder being frozen (immutable).</summary>
+    PathBuilderFrozen,
+
+    /// <summary>Operation not successful due to an invalid drive specification.</summary>
+    InvalidDriveSpecification,
+
+    /// <summary>Operation not successful due to path containing invalid file name characters.</summary>
+    InvalidFileNameCharacters,
+
+    /// <summary>Operation not successful due to path containing a reserved/invalid/device file name.</summary>
+    InvalidReservedFileName
+}

--- a/src/Spice86.Core/Emulator/OperatingSystem/Enums/DosSpecialFileName.cs
+++ b/src/Spice86.Core/Emulator/OperatingSystem/Enums/DosSpecialFileName.cs
@@ -1,0 +1,142 @@
+﻿namespace Spice86.Core.Emulator.OperatingSystem.Enums;
+
+/// <summary>
+/// Special DOS file names (including file names for directory traversal or host operating system reserved file names).
+/// </summary>
+internal enum DosSpecialFileName {
+    /// <summary>
+    /// Not a device file name.
+    /// </summary>
+    None = 0,
+
+    /// <summary>
+    /// An empty file name. Typically skipped or handled as an error.
+    /// </summary>
+    Empty,
+
+    /// <summary>
+    /// The current directory specifier: <c>.</c>
+    /// </summary>
+    CurrentDirectory,
+
+    /// <summary>
+    /// The parent directory specifier: <c>..</c>
+    /// </summary>
+    ParentDirectory,
+
+    /// <summary>
+    /// An unknown or invalid device or file name. Should always be handled as an error (to prevent bad host-mapped
+    /// file names).
+    /// </summary>
+    Invalid,
+
+    /// <summary>
+    /// The null device, <c>NUL</c> (typically a "black hole").
+    /// </summary>
+    Null,
+
+    /// <summary>
+    /// The console device, <c>CON</c> (keyboard input, display output).
+    /// </summary>
+    Console,
+
+    /// <summary>
+    /// The auxiliary device, <c>AUX</c> (typically the first connected COM port).
+    /// </summary>
+    Auxiliary,
+
+    /// <summary>
+    /// The printer device, <c>PRN</c> (typically the first connected LPT port).
+    /// </summary>
+    Printer,
+
+    /// <summary>
+    /// COM port #1, <c>COM1</c> or <c>COM¹</c>.
+    /// </summary>
+    SerialPort1,
+
+    /// <summary>
+    /// COM port #2, <c>COM2</c> or <c>COM²</c>.
+    /// </summary>
+    SerialPort2,
+
+    /// <summary>
+    /// COM port #3, <c>COM3</c> or <c>COM³</c>.
+    /// </summary>
+    SerialPort3,
+
+    /// <summary>
+    /// COM port #4, <c>COM4</c>.
+    /// </summary>
+    SerialPort4,
+
+    /// <summary>
+    /// COM port #5, <c>COM5</c>.
+    /// </summary>
+    SerialPort5,
+
+    /// <summary>
+    /// COM port #6, <c>COM6</c>.
+    /// </summary>
+    SerialPort6,
+
+    /// <summary>
+    /// COM port #7, <c>COM7</c>.
+    /// </summary>
+    SerialPort7,
+
+    /// <summary>
+    /// COM port #8, <c>COM8</c>.
+    /// </summary>
+    SerialPort8,
+
+    /// <summary>
+    /// COM port #9, <c>COM9</c>.
+    /// </summary>
+    SerialPort9,
+
+    /// <summary>
+    /// COM port #1, <c>COM1</c> or <c>COM¹</c>.
+    /// </summary>
+    ParallelPort1,
+
+    /// <summary>
+    /// COM port #2, <c>COM2</c> or <c>COM²</c>.
+    /// </summary>
+    ParallelPort2,
+
+    /// <summary>
+    /// COM port #3, <c>COM3</c> or <c>COM³</c>.
+    /// </summary>
+    ParallelPort3,
+
+    /// <summary>
+    /// COM port #4, <c>COM4</c>.
+    /// </summary>
+    ParallelPort4,
+
+    /// <summary>
+    /// COM port #5, <c>COM5</c>.
+    /// </summary>
+    ParallelPort5,
+
+    /// <summary>
+    /// COM port #6, <c>COM6</c>.
+    /// </summary>
+    ParallelPort6,
+
+    /// <summary>
+    /// COM port #7, <c>COM7</c>.
+    /// </summary>
+    ParallelPort7,
+
+    /// <summary>
+    /// COM port #8, <c>COM8</c>.
+    /// </summary>
+    ParallelPort8,
+
+    /// <summary>
+    /// COM port #9, <c>COM9</c>.
+    /// </summary>
+    ParallelPort9,
+}

--- a/src/Spice86.Core/Emulator/OperatingSystem/Enums/DosSpecialFileName.cs
+++ b/src/Spice86.Core/Emulator/OperatingSystem/Enums/DosSpecialFileName.cs
@@ -96,47 +96,47 @@ internal enum DosSpecialFileName {
     SerialPort9,
 
     /// <summary>
-    /// COM port #1, <c>COM1</c> or <c>COM¹</c>.
+    /// Parallel port #1, <c>LPT1</c> or <c>LPT¹</c>.
     /// </summary>
     ParallelPort1,
 
     /// <summary>
-    /// COM port #2, <c>COM2</c> or <c>COM²</c>.
+    /// Parallel port #2, <c>LPT2</c> or <c>LPT²</c>.
     /// </summary>
     ParallelPort2,
 
     /// <summary>
-    /// COM port #3, <c>COM3</c> or <c>COM³</c>.
+    /// Parallel port #3, <c>LPT3</c> or <c>LPT³</c>.
     /// </summary>
     ParallelPort3,
 
     /// <summary>
-    /// COM port #4, <c>COM4</c>.
+    /// Parallel port #4, <c>LPT4</c>.
     /// </summary>
     ParallelPort4,
 
     /// <summary>
-    /// COM port #5, <c>COM5</c>.
+    /// Parallel port #5, <c>LPT5</c>.
     /// </summary>
     ParallelPort5,
 
     /// <summary>
-    /// COM port #6, <c>COM6</c>.
+    /// Parallel port #6, <c>LPT6</c>.
     /// </summary>
     ParallelPort6,
 
     /// <summary>
-    /// COM port #7, <c>COM7</c>.
+    /// Parallel port #7, <c>LPT7</c>.
     /// </summary>
     ParallelPort7,
 
     /// <summary>
-    /// COM port #8, <c>COM8</c>.
+    /// Parallel port #8, <c>LPT8</c>.
     /// </summary>
     ParallelPort8,
 
     /// <summary>
-    /// COM port #9, <c>COM9</c>.
+    /// Parallel port #9, <c>LPT9</c>.
     /// </summary>
     ParallelPort9,
 }

--- a/src/Spice86.Core/Emulator/OperatingSystem/Enums/DosSpecialFileNameSettings.cs
+++ b/src/Spice86.Core/Emulator/OperatingSystem/Enums/DosSpecialFileNameSettings.cs
@@ -1,0 +1,18 @@
+﻿namespace Spice86.Core.Emulator.OperatingSystem.Enums;
+
+using System;
+
+/// <summary>Settings for controlling how DOS special file names are parsed and handled.</summary>
+[Flags]
+public enum DosSpecialFileNameSettings {
+    /// <summary>Default settings.</summary>
+    None = 0,
+
+    /// <summary>Do not allow superscript '1', '2', or '3' in builtin device names.</summary>
+    /// <remarks>
+    /// Windows automatically parses device names containing superscript digits the same as regular device names
+    /// containing ASCII digits. This will indicate to the parser that those device names should be treated as invalid
+    /// file names.
+    /// </remarks>
+    NoDeviceSuperscriptDigits = 1 << 0,
+}

--- a/src/Spice86.Core/Emulator/OperatingSystem/Structures/DosPathBuilder.cs
+++ b/src/Spice86.Core/Emulator/OperatingSystem/Structures/DosPathBuilder.cs
@@ -28,7 +28,7 @@ internal ref struct DosPathBuilder {
     /// <a href="https://learn.microsoft.com/en-us/windows/win32/fileio/naming-a-file"/>. Note that this contains
     /// <see cref="VolumeSeparatorChar"/>, <see cref="DirectorySeparatorChar"/>, and
     /// <see cref="AltDirectorySeparatorChar"/>. The list has also been expanded to include all currently defined
-    /// Unicode control characters (including 0x7F), to prevent potential problems with host operation system file
+    /// Unicode control characters (including 0x7F), to prevent potential problems with host operating system file
     /// systems and user interfaces.
     /// </remarks>
     internal static ReadOnlySpan<char> InvalidFileNameChars => [
@@ -105,17 +105,19 @@ internal ref struct DosPathBuilder {
     }
 
     /// <summary>Gets a value indicating whether the path builder has been frozen (immutable).</summary>
-    /// <remarks>
-    /// The contents may still and should never be accessed after the path builder has been disposed.
-    /// </remarks>
+    /// <remarks>This property will be reset to <see langword="false"/> (mutable) when the builder disposed.</remarks>
     public readonly bool IsFrozen => _isFrozen;
 
     /// <summary>Releases internal memory associated with the path builder.</summary>
-    /// <remarks><strong>Do not access memory previously retrieved via <see cref="AsSpan()"/> after calling this method!</strong></remarks>
+    /// <remarks>
+    /// <para><strong>Do not access memory previously retrieved via <see cref="AsSpan()"/> after calling this method!</strong></para>
+    /// <para>This will also reset the frozen state and make the path builder mutable again.</para>
+    /// </remarks>
     public void Dispose() {
-        // These dispose methods will clear the value internal value list instances and set their lengths to zero. This
-        // allows more data to be appended (though any stack allocated scratch buffer will be lost--so it will only use
-        // pooled memory). Because of this, the path builder will become mutable again (so path builder can be reused).
+        // These dispose methods will clear the internal value list instances, release the internal memory used, and
+        // set their lengths to zero. This allows more data to be appended (though any stack allocated scratch buffer
+        // will be lost--so it will only use pooled memory). Because of this, the path builder will become mutable
+        // again (so path builder can be reused).
         _pathBuilder.Dispose();
         _pathStack.Dispose();
         _isFrozen = false;
@@ -140,8 +142,8 @@ internal ref struct DosPathBuilder {
     /// </summary>
     /// <returns>A string representing the current path.</returns>
     /// <remarks>
-    /// This may not be valid if the drive letter has not been set or it has not been successfully frozen.
-    /// <strong>Do not access memory previously retrieved via <see cref="AsSpan()"/> after calling this method!</strong>
+    /// <para><strong>Do not access memory previously retrieved via <see cref="AsSpan()"/> after calling this method!</strong></para>
+    /// <para>This may not be valid if the drive letter has not been set or it has not been successfully frozen.</para>
     /// </remarks>
     public string ToStringWithDispose() {
         string result = _pathBuilder.AsSpan().ToString();
@@ -153,12 +155,12 @@ internal ref struct DosPathBuilder {
     /// <returns>A result indicating success or an error.</returns>
     /// <remarks>
     /// A directory separator character will be automatically appended if the current path only contains a drive
-    /// specification and no valid path elements have been appended (thus the minimum number of character in the path
-    /// builder after calling this will always be three: drive letter, volume separator, and directory separator). This
-    /// method can be called multiple times and can be called after calling
+    /// specification and no valid path elements have been appended (thus the minimum number of characters in the path
+    /// builder after calling this with a successful result will always be three: drive letter, volume separator, and
+    /// directory separator). This method can be called multiple times and can also be called after calling
     /// <see cref="AppendFinalDirectorySeparator()"/>. The drive letter must be assigned prior to freezing the path
-    /// builder (<see cref="SetDriveIndex(int)"/> or <see cref="SetDriveLetter(char)"/> must be called at least one
-    /// time for the path to be valid).
+    /// builder (<see cref="SetDriveIndex(int)"/> or <see cref="SetDriveLetter(char)"/> must be called at least once
+    /// for the path to be valid).
     /// </remarks>
     public DosPathBuilderResult Freeze() {
         // Do nothing if the path builder has already been frozen.
@@ -179,12 +181,12 @@ internal ref struct DosPathBuilder {
         }
 
         _isFrozen = true;
-        _pathStack.Dispose(); // no longer necessary
+        _pathStack.Dispose(); // path element stack is no longer necessary
         return DosPathBuilderResult.Success;
     }
 
     /// <summary>Attempts to set the drive index.</summary>
-    /// <param name="driveIndex">A zero-based DOS drive index that will be converted into a drive letter.</param>
+    /// <param name="driveIndex">A valid zero-based DOS drive index that will be converted into a drive letter.</param>
     /// <returns>A result indicating success or an error.</returns>
     /// <remarks>This can be called multiple times and also after appending other path elements.</remarks>
     public DosPathBuilderResult SetDriveIndex(int driveIndex) {
@@ -224,8 +226,8 @@ internal ref struct DosPathBuilder {
     /// <remarks>
     /// This can only be called once (as the path builder will be frozen and become immutable). This cannot be called
     /// if the path builder has already been frozen or a drive letter has not been assigned
-    /// (<see cref="SetDriveIndex(int)"/> or <see cref="SetDriveLetter(char)"/> must be called at least one time for
-    /// the path to be valid).
+    /// (<see cref="SetDriveIndex(int)"/> or <see cref="SetDriveLetter(char)"/> must be called at least once for the
+    /// path to be valid).
     /// </remarks>
     public DosPathBuilderResult AppendFinalDirectorySeparator() {
         // Make sure a drive specification has been set.
@@ -240,11 +242,12 @@ internal ref struct DosPathBuilder {
 
         DebugValidateState();
 
-        // If the last character is already a directory separator character, then there is no need to append.
+        // A valid unfrozen path builder instance should never end with a directory separator character. So it should
+        // be safe to append the final directory separator here.
         _pathBuilder.Append(DirectorySeparatorChar);
 
         _isFrozen = true;
-        _pathStack.Dispose(); // no longer necessary
+        _pathStack.Dispose(); // path element stack is no longer necessary
         return DosPathBuilderResult.Success;
     }
 
@@ -253,10 +256,10 @@ internal ref struct DosPathBuilder {
     /// <returns>A result indicating success or an error.</returns>
     /// <remarks>
     /// Any leading white space is always ignored. The file name cannot contain any invalid file name characters,
-    /// cannot be empty, invalid, reserved, directory traversal (e.g., "." or ".."), or end with white space or a
-    /// period. This cannot be called if the path builder has already been frozen or a drive letter has not been
-    /// assigned (<see cref="SetDriveIndex(int)"/> or <see cref="SetDriveLetter(char)"/> must be called at least one
-    /// time for the path to be valid).
+    /// cannot be empty, an invalid or reserved name, directory traversal (e.g., "." or ".."), or end with white space
+    /// or a period. This cannot be called if the path builder has already been frozen or a drive letter has not been
+    /// assigned (<see cref="SetDriveIndex(int)"/> or <see cref="SetDriveLetter(char)"/> must be called at least once
+    /// for the path to be valid).
     /// </remarks>
     public DosPathBuilderResult AppendFileName(ReadOnlySpan<char> fileName) {
         // Make sure a drive specification has been set.
@@ -301,10 +304,10 @@ internal ref struct DosPathBuilder {
     /// <remarks>
     /// All empty path elements are ignored. This will always append to the existing path, even if the path starts with
     /// a directory separator. Any leading white space in individual path elements are always ignored. The individual
-    /// path elements cannot contain any invalid file name characters, invalid, reserved, or end with white space or a
-    /// period. This cannot be called if the path builder has already been frozen or a drive letter has not been
-    /// assigned (<see cref="SetDriveIndex(int)"/> or <see cref="SetDriveLetter(char)"/> must be called at least one
-    /// time for the path to be valid).
+    /// path elements cannot contain any invalid file name characters, invalid or reserved names, or end with white
+    /// space or a period. This cannot be called if the path builder has already been frozen or a drive letter has not
+    /// been assigned (<see cref="SetDriveIndex(int)"/> or <see cref="SetDriveLetter(char)"/> must be called at least
+    /// once for the path to be valid).
     /// </remarks>
     public DosPathBuilderResult AppendRelativePath(ReadOnlySpan<char> relativePath,
             out bool endsWithDirectorySeparator) {
@@ -406,9 +409,10 @@ internal ref struct DosPathBuilder {
     /// All empty path elements are ignored. This will always remove all path characters after the drive letter and
     /// volume separator, even if the path is empty or does not start with a directory separator. Any leading white
     /// space in individual path elements are always ignored. The individual path elements cannot contain any invalid
-    /// file name characters, invalid, reserved, or end with white space or a period. This cannot be called if the path
-    /// builder has already been frozen or a drive letter has not been assigned (<see cref="SetDriveIndex(int)"/> or
-    /// <see cref="SetDriveLetter(char)"/> must be called at least one time for the path to be valid).
+    /// file name characters, invalid or reserved names, or end with white space or a period. This cannot be called if
+    /// the path builder has already been frozen or a drive letter has not been assigned
+    /// (<see cref="SetDriveIndex(int)"/> or <see cref="SetDriveLetter(char)"/> must be called at least once for the
+    /// path to be valid).
     /// </remarks>
     public DosPathBuilderResult AppendRootedPath(ReadOnlySpan<char> rootedPath, out bool endsWithDirectorySeparator) {
         // Make sure a drive specification has been set.
@@ -634,8 +638,8 @@ internal ref struct DosPathBuilder {
 
     /// <summary>Performs debug assertions to validate the state of the path builder.</summary>
     /// <remarks>
-    /// This is only called in debug builds. Though passing these checks does not mean that that path builder contains
-    /// a valid DOS full path specification.
+    /// This is only executed when using debug builds. Passing these state checks does not necessarily mean that that
+    /// path builder contains a valid DOS full path specification.
     /// </remarks>
     [Conditional("DEBUG")]
     internal readonly void DebugValidateState() {

--- a/src/Spice86.Core/Emulator/OperatingSystem/Structures/DosPathBuilder.cs
+++ b/src/Spice86.Core/Emulator/OperatingSystem/Structures/DosPathBuilder.cs
@@ -22,7 +22,7 @@ internal ref struct DosPathBuilder {
     /// <summary>The initial number of elements the caller should stack allocate for the path stack buffer.</summary>
     public const int DefaultStackLength = 16;
 
-    /// <summary>The file name characters that are not allowed, as a search values object.</summary>
+    /// <summary>The file name characters that are not allowed.</summary>
     /// <remarks>
     /// The list of disallowed characters is partially derived from:
     /// <a href="https://learn.microsoft.com/en-us/windows/win32/fileio/naming-a-file"/>. Note that this contains

--- a/src/Spice86.Core/Emulator/OperatingSystem/Structures/DosPathBuilder.cs
+++ b/src/Spice86.Core/Emulator/OperatingSystem/Structures/DosPathBuilder.cs
@@ -501,34 +501,37 @@ internal ref struct DosPathBuilder {
         DosSpecialFileName deviceName = DosSpecialFileName.None;
         if (fileName.Length == 3) {
             switch (fileName[0]) {
-                case 'C':
-                case 'c':
+                case 'C' or 'c':
                     // "CON"
                     if (fileName[1] is 'O' or 'o' && fileName[2] is 'N' or 'n') {
                         deviceName = DosSpecialFileName.Console;
                     }
                     break;
 
-                case 'P':
-                case 'p':
+                case 'P' or 'p':
                     // "PRN"
                     if (fileName[1] is 'R' or 'r' && fileName[2] is 'N' or 'n') {
                         deviceName = DosSpecialFileName.Printer;
                     }
                     break;
 
-                case 'A':
-                case 'a':
+                case 'A' or 'a':
                     // "AUX"
                     if (fileName[1] is 'U' or 'u' && fileName[2] is 'X' or 'x') {
                         deviceName = DosSpecialFileName.Auxiliary;
                     }
                     break;
+
+                case 'N' or 'n':
+                    // "NUL"
+                    if (fileName[1] is 'U' or 'u' && fileName[2] is 'L' or 'l') {
+                        deviceName = DosSpecialFileName.Null;
+                    }
+                    break;
             }
         } else if (fileName.Length == 4) {
             switch (fileName[0]) {
-                case 'C':
-                case 'c':
+                case 'C' or 'c':
                     // "COM1" thru "COM9", "COM¹", "COM²", "COM³"
                     if (fileName[1] is 'O' or 'o' && fileName[2] is 'M' or 'm') {
                         switch (fileName[3]) {
@@ -579,8 +582,7 @@ internal ref struct DosPathBuilder {
                     }
                     break;
 
-                case 'L':
-                case 'l':
+                case 'L' or 'l':
                     // "LPT1" thru "LPT9", "LPT¹", "LPT²", "LPT³"
                     if (fileName[1] is 'P' or 'p' && fileName[2] is 'T' or 't') {
                         switch (fileName[3]) {
@@ -694,4 +696,19 @@ internal ref struct DosPathBuilder {
             lastPathIndex = pathIndex;
         }
     }
+
+    /// <summary>Gets a default error message from a result to use for logging or throwing exceptions.</summary>
+    /// <param name="result">The DOS path builder result.</param>
+    /// <returns>
+    /// <see langword="null"/> if the result is <see cref="DosPathBuilderResult.Success"/>; otherwise, a string
+    /// containing the interpreted error message.
+    /// </returns>
+    public static string? GetResultErrorMessage(DosPathBuilderResult result) => result switch {
+        DosPathBuilderResult.Success => null,
+        DosPathBuilderResult.PathBuilderFrozen => "DOS path builder is frozen and cannot be modified.",
+        DosPathBuilderResult.InvalidDriveSpecification => "DOS drive specification is invalid.",
+        DosPathBuilderResult.InvalidFileNameCharacters => "DOS path contains invalid file name characters.",
+        DosPathBuilderResult.InvalidReservedFileName => "DOS path contains a reserved file name.",
+        _ => $"DOS path builder unspecified error: {result}"
+    };
 }

--- a/src/Spice86.Core/Emulator/OperatingSystem/Structures/DosPathBuilder.cs
+++ b/src/Spice86.Core/Emulator/OperatingSystem/Structures/DosPathBuilder.cs
@@ -1,0 +1,693 @@
+﻿namespace Spice86.Core.Emulator.OperatingSystem.Structures;
+
+using Spice86.Core.Emulator.OperatingSystem.Enums;
+
+using System;
+using System.Buffers;
+using System.Diagnostics;
+
+/// <summary>A performance driven DOS full path builder.</summary>
+/// <remarks>
+/// It is absolutely essential that callers call <see cref="Dispose()"/> or <see cref="ToStringWithDispose()"/> when
+/// finished with the path builder instance. If not, then memory leaks may occur (especially if using
+/// <see cref="DosPathBuilder()"/>, <see cref="DosPathBuilder(int, int)"/>, or
+/// <see cref="DosPathBuilder(Span{char}, Span{int})"/> and the internal data buffers need to grow beyond the initial
+/// user supplied scratch buffer capacities).
+/// </remarks>
+internal ref struct DosPathBuilder {
+    internal const char VolumeSeparatorChar = DosPathResolver.VolumeSeparatorChar;
+    internal const char DirectorySeparatorChar = DosPathResolver.DirectorySeparatorChar;
+    internal const char AltDirectorySeparatorChar = DosPathResolver.AltDirectorySeparatorChar;
+
+    /// <summary>The initial number of elements the caller should stack allocate for the path stack buffer.</summary>
+    public const int DefaultStackLength = 16;
+
+    /// <summary>The file name characters that are not allowed, as a search values object.</summary>
+    /// <remarks>
+    /// The list of disallowed characters is partially derived from:
+    /// <a href="https://learn.microsoft.com/en-us/windows/win32/fileio/naming-a-file"/>. Note that this contains
+    /// <see cref="VolumeSeparatorChar"/>, <see cref="DirectorySeparatorChar"/>, and
+    /// <see cref="AltDirectorySeparatorChar"/>. The list has also been expanded to include all currently defined
+    /// Unicode control characters (including 0x7F), to prevent potential problems with host operation system file
+    /// systems and user interfaces.
+    /// </remarks>
+    internal static ReadOnlySpan<char> InvalidFileNameChars => [
+        '\x00', '\x01', '\x02', '\x03', '\x04', '\x05', '\x06', '\x07',
+        '\x08', '\x09', '\x0A', '\x0B', '\x0C', '\x0D', '\x0E', '\x0F',
+        '\x10', '\x11', '\x12', '\x13', '\x14', '\x15', '\x16', '\x17',
+        '\x18', '\x19', '\x1A', '\x1B', '\x1C', '\x1D', '\x1E', '\x1F',
+        '"', '*', '\\', ':', '<', '>', '?', '|', '/',
+        // Other control characters. These might be allowed by DOS and Windows internally, but they may result in the
+        // inability for the Windows shell or other applications or operating systems to interact with or render files
+        // with these characters.
+        '\x7F',
+        '\x80', '\x81', '\x82', '\x83', '\x84', '\x85', '\x86', '\x87',
+        '\x88', '\x89', '\x8A', '\x8B', '\x8C', '\x8D', '\x8E', '\x8F',
+        '\x90', '\x91', '\x92', '\x93', '\x94', '\x95', '\x96', '\x97',
+        '\x98', '\x99', '\x9A', '\x9B', '\x9C', '\x9D', '\x9E', '\x9F',
+    ];
+
+    /// <summary>The file name characters that are not allowed, as a search values object.</summary>
+    /// <remarks>See <see cref="InvalidFileNameChars"/>.</remarks>
+    internal static readonly SearchValues<char> InvalidFileNameSearchValues = SearchValues.Create(InvalidFileNameChars);
+
+    private ValueListBuilder<char> _pathBuilder;
+    private ValueListStack<int> _pathStack;
+    private DosSpecialFileNameSettings _specialFileNameSettings;
+    private bool _isFrozen;
+
+    /// <summary>Initializes an empty DOS path builder with no preallocated scratch buffers.</summary>
+    /// <remarks>
+    /// This is useful if caller is using this to call <see cref="ParseSpecialFileName(ReadOnlySpan{char})"/> without
+    /// building a DOS path.
+    /// </remarks>
+    public DosPathBuilder() { }
+
+    /// <summary>Initializes a DOS path builder with user supplied scratch buffers.</summary>
+    /// <param name="scratchPathBuffer">The initial buffer to use for path characters.</param>
+    /// <param name="scratchStackBuffer">The initial buffer to use for path element stack entries.</param>
+    /// <remarks>
+    /// The intended use for this constructor is for the caller to supply <see langword="stackalloc"/> allocated
+    /// buffers to avoid using heap/pooled memory. If memory allocations are required, then use the other constructor
+    /// overload which accepts initial integer capacities (and will thus use pooled memory).
+    /// 
+    /// Do not modify these scratch buffers while using this path builder! Outside modifications to these buffers may
+    /// result in data corruption or other undefined behavior.
+    /// </remarks>
+    public DosPathBuilder(Span<char> scratchPathBuffer, Span<int> scratchStackBuffer) {
+        _pathBuilder = new(scratchPathBuffer);
+        _pathStack = new(scratchStackBuffer);
+    }
+
+    /// <summary>Initializes a DOS path builder with array pool allocated buffers.</summary>
+    /// <param name="charsCapacity">The default minimum number of path characters to allocate.</param>
+    /// <param name="stackCapacity">The default minimum number of path element stack entries to allocate.</param>
+    public DosPathBuilder(int charsCapacity, int stackCapacity = DefaultStackLength) {
+        _pathBuilder = new(charsCapacity);
+        _pathStack = new(stackCapacity);
+    }
+
+    /// <summary>Gets a value indicating whether the path has a valid drive specification.</summary>
+    public readonly bool HasDriveSpecification => _pathBuilder.Length >= 2;
+
+    /// <summary>Gets the current length of the path.</summary>
+    public readonly int Length => _pathBuilder.Length;
+
+    /// <summary>Gets the character at the given index within the path.</summary>
+    /// <param name="index">The index within the path character buffer. Must be a valid index.</param>
+    /// <returns>The character at the given index.</returns>
+    public readonly char this[int index] => _pathBuilder[index];
+
+    /// <summary>Gets or sets the settings to use for special file name parsing and handling.</summary>
+    public DosSpecialFileNameSettings SpecialFileNameSettings {
+        readonly get => _specialFileNameSettings;
+        set => _specialFileNameSettings = value;
+    }
+
+    /// <summary>Gets a value indicating whether the path builder has been frozen (immutable).</summary>
+    /// <remarks>
+    /// The contents may still and should never be accessed after the path builder has been disposed.
+    /// </remarks>
+    public readonly bool IsFrozen => _isFrozen;
+
+    /// <summary>Releases internal memory associated with the path builder.</summary>
+    /// <remarks><strong>Do not access memory previously retrieved via <see cref="AsSpan()"/> after calling this method!</strong></remarks>
+    public void Dispose() {
+        // These dispose methods will clear the value internal value list instances and set their lengths to zero. This
+        // allows more data to be appended (though any stack allocated scratch buffer will be lost--so it will only use
+        // pooled memory). Because of this, the path builder will become mutable again (so path builder can be reused).
+        _pathBuilder.Dispose();
+        _pathStack.Dispose();
+        _isFrozen = false;
+    }
+
+    /// <summary>Gets a read only span representing the current path.</summary>
+    /// <returns>A read only span with path characters.</returns>
+    /// <remarks>
+    /// This may not be valid if the drive letter has not been set or it has not been successfully frozen.
+    /// </remarks>
+    public readonly ReadOnlySpan<char> AsSpan() => _pathBuilder.AsSpan();
+
+    /// <summary>Creates a string representing the current path.</summary>
+    /// <returns>A string representing the current path.</returns>
+    /// <remarks>
+    /// This may not be valid if the drive letter has not been set or it has not been successfully frozen.
+    /// </remarks>
+    public override readonly string ToString() => _pathBuilder.AsSpan().ToString();
+
+    /// <summary>
+    /// Creates a string representing the current path and releases internal memory associated with the path builder.
+    /// </summary>
+    /// <returns>A string representing the current path.</returns>
+    /// <remarks>
+    /// This may not be valid if the drive letter has not been set or it has not been successfully frozen.
+    /// <strong>Do not access memory previously retrieved via <see cref="AsSpan()"/> after calling this method!</strong>
+    /// </remarks>
+    public string ToStringWithDispose() {
+        string result = _pathBuilder.AsSpan().ToString();
+        Dispose();
+        return result;
+    }
+
+    /// <summary>Attempts to freeze the path instance to make the path builder immutable.</summary>
+    /// <returns>A result indicating success or an error.</returns>
+    /// <remarks>
+    /// A directory separator character will be automatically appended if the current path only contains a drive
+    /// specification and no valid path elements have been appended (thus the minimum number of character in the path
+    /// builder after calling this will always be three: drive letter, volume separator, and directory separator). This
+    /// method can be called multiple times and can be called after calling
+    /// <see cref="AppendFinalDirectorySeparator()"/>. The drive letter must be assigned prior to freezing the path
+    /// builder (<see cref="SetDriveIndex(int)"/> or <see cref="SetDriveLetter(char)"/> must be called at least one
+    /// time for the path to be valid).
+    /// </remarks>
+    public DosPathBuilderResult Freeze() {
+        // Do nothing if the path builder has already been frozen.
+        if (_isFrozen) {
+            return DosPathBuilderResult.Success;
+        }
+
+        // Make sure a drive specification has been set.
+        if (!HasDriveSpecification) {
+            return DosPathBuilderResult.InvalidDriveSpecification;
+        }
+
+        DebugValidateState();
+
+        // If the path is only a drive specification, then append a directory separator before freezing.
+        if (_pathBuilder.Length <= 2) {
+            _pathBuilder.Append(DirectorySeparatorChar);
+        }
+
+        _isFrozen = true;
+        _pathStack.Dispose(); // no longer necessary
+        return DosPathBuilderResult.Success;
+    }
+
+    /// <summary>Attempts to set the drive index.</summary>
+    /// <param name="driveIndex">A zero-based DOS drive index that will be converted into a drive letter.</param>
+    /// <returns>A result indicating success or an error.</returns>
+    /// <remarks>This can be called multiple times and also after appending other path elements.</remarks>
+    public DosPathBuilderResult SetDriveIndex(int driveIndex) {
+        // Cannot set if drive index is invalid.
+        if (driveIndex is < 0 or >= DosDriveManager.MaxDriveCount) {
+            return DosPathBuilderResult.InvalidDriveSpecification;
+        }
+
+        // Cannot set if path builder is frozen.
+        if (_isFrozen) {
+            return DosPathBuilderResult.PathBuilderFrozen;
+        }
+
+        // Does the path have a drive specification that needs to be replaced or does a new one need to be appended?
+        char driveLetter = DosDriveManager.GetDriveLetterFromIndexFast(driveIndex);
+        if (!HasDriveSpecification) {
+            Debug.Assert(_pathBuilder.Length == 0);
+            _pathBuilder.Append(driveLetter);
+            _pathBuilder.Append(':');
+        } else {
+            DebugValidateState();
+            _pathBuilder[0] = driveLetter;
+        }
+
+        return DosPathBuilderResult.Success;
+    }
+
+    /// <summary>Attempts to set the drive letter.</summary>
+    /// <param name="driveLetter">A valid DOS drive letter.</param>
+    /// <returns>A result indicating success or an error.</returns>
+    /// <remarks>This can be called multiple times and also after appending other path elements.</remarks>
+    public DosPathBuilderResult SetDriveLetter(char driveLetter) =>
+        SetDriveIndex(DosDriveManager.GetDriveIndex(driveLetter));
+
+    /// <summary>Appends the final directory separator character to the path and freezes the path builder.</summary>
+    /// <returns>A result indicating success or an error.</returns>
+    /// <remarks>
+    /// This can only be called once (as the path builder will be frozen and become immutable). This cannot be called
+    /// if the path builder has already been frozen or a drive letter has not been assigned
+    /// (<see cref="SetDriveIndex(int)"/> or <see cref="SetDriveLetter(char)"/> must be called at least one time for
+    /// the path to be valid).
+    /// </remarks>
+    public DosPathBuilderResult AppendFinalDirectorySeparator() {
+        // Make sure a drive specification has been set.
+        if (!HasDriveSpecification) {
+            return DosPathBuilderResult.InvalidDriveSpecification;
+        }
+
+        // Cannot append if path builder is frozen.
+        if (_isFrozen) {
+            return DosPathBuilderResult.PathBuilderFrozen;
+        }
+
+        DebugValidateState();
+
+        // If the last character is already a directory separator character, then there is no need to append.
+        _pathBuilder.Append(DirectorySeparatorChar);
+
+        _isFrozen = true;
+        _pathStack.Dispose(); // no longer necessary
+        return DosPathBuilderResult.Success;
+    }
+
+    /// <summary>Appends a single file or directory name to the path builder.</summary>
+    /// <param name="fileName">A valid file or directory name.</param>
+    /// <returns>A result indicating success or an error.</returns>
+    /// <remarks>
+    /// Any leading white space is always ignored. The file name cannot contain any invalid file name characters,
+    /// cannot be empty, invalid, reserved, directory traversal (e.g., "." or ".."), or end with white space or a
+    /// period. This cannot be called if the path builder has already been frozen or a drive letter has not been
+    /// assigned (<see cref="SetDriveIndex(int)"/> or <see cref="SetDriveLetter(char)"/> must be called at least one
+    /// time for the path to be valid).
+    /// </remarks>
+    public DosPathBuilderResult AppendFileName(ReadOnlySpan<char> fileName) {
+        // Make sure a drive specification has been set.
+        if (!HasDriveSpecification) {
+            return DosPathBuilderResult.InvalidDriveSpecification;
+        }
+
+        // Cannot append if path builder is frozen.
+        if (_isFrozen) {
+            return DosPathBuilderResult.PathBuilderFrozen;
+        }
+
+        DebugValidateState();
+
+        // Trim leading white space from file name. Leading white space characters are always ignored.
+        fileName = fileName.TrimStart();
+
+        // Check for any invalid file name characters.
+        if (fileName.ContainsAny(InvalidFileNameSearchValues)) {
+            // Do not allow invalid file name characters in path element.
+            return DosPathBuilderResult.InvalidFileNameCharacters;
+        }
+
+        // Check if file name is valid. Cannot be empty, invalid, reserved, or a directory traversal file name.
+        DosSpecialFileName specialFileName = ParseSpecialFileName(fileName);
+        if (specialFileName != DosSpecialFileName.None) {
+            return DosPathBuilderResult.InvalidReservedFileName;
+        }
+
+        // Append directory separator and file name.
+        Debug.Assert(_pathBuilder.Length >= 2);
+        _pathStack.Push(_pathBuilder.Length);
+        _pathBuilder.Append(DirectorySeparatorChar);
+        _pathBuilder.Append(fileName);
+        return DosPathBuilderResult.Success;
+    }
+
+    /// <summary>Appends a relative path to the path builder.</summary>
+    /// <param name="relativePath">A relative file or directory path.</param>
+    /// <param name="endsWithDirectorySeparator">Indicates if the input path ended with a directory separator.</param>
+    /// <returns>A result indicating success or an error.</returns>
+    /// <remarks>
+    /// All empty path elements are ignored. This will always append to the existing path, even if the path starts with
+    /// a directory separator. Any leading white space in individual path elements are always ignored. The individual
+    /// path elements cannot contain any invalid file name characters, invalid, reserved, or end with white space or a
+    /// period. This cannot be called if the path builder has already been frozen or a drive letter has not been
+    /// assigned (<see cref="SetDriveIndex(int)"/> or <see cref="SetDriveLetter(char)"/> must be called at least one
+    /// time for the path to be valid).
+    /// </remarks>
+    public DosPathBuilderResult AppendRelativePath(ReadOnlySpan<char> relativePath,
+            out bool endsWithDirectorySeparator) {
+        // Make sure a drive specification has been set.
+        if (!HasDriveSpecification) {
+            endsWithDirectorySeparator = default;
+            return DosPathBuilderResult.InvalidDriveSpecification;
+        }
+
+        // Cannot append if path builder is frozen.
+        if (_isFrozen) {
+            endsWithDirectorySeparator = default;
+            return DosPathBuilderResult.PathBuilderFrozen;
+        }
+
+        DebugValidateState();
+
+        // If the input path is empty or white space, then it does not end with a directory separator.
+        if (relativePath.IsWhiteSpace()) {
+            endsWithDirectorySeparator = false;
+            return DosPathBuilderResult.Success;
+        }
+
+        ReadOnlySpan<char> lastPathElement = default;
+        while (!relativePath.IsEmpty) {
+            // Get next path element.
+            int slashIndex = relativePath.IndexOfAny(DirectorySeparatorChar, AltDirectorySeparatorChar);
+            if (slashIndex < 0) {
+                lastPathElement = relativePath;
+                relativePath = [];
+            } else {
+                lastPathElement = relativePath[..slashIndex];
+                relativePath = relativePath[(slashIndex + 1)..];
+            }
+
+            // Trim leading white space and check for any invalid path characters.
+            lastPathElement = lastPathElement.TrimStart();
+            if (lastPathElement.ContainsAny(InvalidFileNameSearchValues)) {
+                // Do not allow invalid file name characters in path element.
+                endsWithDirectorySeparator = default;
+                return DosPathBuilderResult.InvalidFileNameCharacters;
+            }
+
+            // Parse and handle current path element.
+            DosSpecialFileName specialFileName = ParseSpecialFileName(lastPathElement);
+            switch (specialFileName) {
+                case DosSpecialFileName.None: {
+                        // Append normal file name element.
+                        Debug.Assert(_pathBuilder.Length >= 2);
+                        _pathStack.Push(_pathBuilder.Length);
+                        _pathBuilder.Append(DirectorySeparatorChar);
+                        _pathBuilder.Append(lastPathElement);
+                        break;
+                    }
+
+                case DosSpecialFileName.Empty:
+                case DosSpecialFileName.CurrentDirectory: {
+                        // Skip special name "." and empty names.
+                        break;
+                    }
+
+                case DosSpecialFileName.ParentDirectory: {
+                        // Remove last appended directory element if possible.
+                        if (!_pathStack.TryPop(out int lastPathLength)) {
+                            // This may occur if the path is trying to traverse to the root or beyond the root. This is
+                            // allowed in both cases, but the drive letter and volume separator will always be
+                            // preserved.
+                            lastPathLength = 2;
+                        }
+
+                        Debug.Assert(lastPathLength >= 2);
+                        _pathBuilder.Length = lastPathLength;
+                        break;
+                    }
+
+                default: {
+                        // TODO: Are directory separators, drive specifications, and other path elements allowed for
+                        // reserved device names?
+
+                        // Do not allow reserved file names in the path. The path builder would need to be extended to
+                        // allow full paths as well as special device names (which is currently not implemented).
+                        endsWithDirectorySeparator = default;
+                        return DosPathBuilderResult.InvalidReservedFileName;
+                    }
+            }
+        }
+
+        // At least one non-white space character was detected. If the last path element is empty, then there was a
+        // directory separator before the last (empty) path element.
+        endsWithDirectorySeparator = lastPathElement.IsEmpty;
+        return DosPathBuilderResult.Success;
+    }
+
+    /// <summary>Appends a relative path to the path builder.</summary>
+    /// <param name="relativePath">A relative file or directory path.</param>
+    /// <param name="endsWithDirectorySeparator">Indicates if the input path ended with a directory separator.</param>
+    /// <returns>A result indicating success or an error.</returns>
+    /// <remarks>
+    /// All empty path elements are ignored. This will always remove all path characters after the drive letter and
+    /// volume separator, even if the path is empty or does not start with a directory separator. Any leading white
+    /// space in individual path elements are always ignored. The individual path elements cannot contain any invalid
+    /// file name characters, invalid, reserved, or end with white space or a period. This cannot be called if the path
+    /// builder has already been frozen or a drive letter has not been assigned (<see cref="SetDriveIndex(int)"/> or
+    /// <see cref="SetDriveLetter(char)"/> must be called at least one time for the path to be valid).
+    /// </remarks>
+    public DosPathBuilderResult AppendRootedPath(ReadOnlySpan<char> rootedPath, out bool endsWithDirectorySeparator) {
+        // Make sure a drive specification has been set.
+        if (!HasDriveSpecification) {
+            endsWithDirectorySeparator = default;
+            return DosPathBuilderResult.InvalidDriveSpecification;
+        }
+
+        // Cannot append if path builder is frozen.
+        if (_isFrozen) {
+            endsWithDirectorySeparator = default;
+            return DosPathBuilderResult.PathBuilderFrozen;
+        }
+
+        // A rooted path will remove everything except the drive letter and volume separator.
+        _pathStack.Clear();
+        _pathBuilder.Length = 2;
+
+        DebugValidateState();
+
+        return AppendRelativePath(rootedPath, out endsWithDirectorySeparator);
+    }
+
+    /// <summary>Attempts to parse special file names and performs basic sanity checks.</summary>
+    /// <param name="fileName">File name to parse.</param>
+    /// <returns>
+    /// One of the defined special file names, <see cref="DosSpecialFileName.Invalid"/> for an invalid/reserved file
+    /// name, or <see cref="DosSpecialFileName.None"/> if the file name is a regular file or directory name.
+    /// </returns>
+    /// <remarks>
+    /// This method does not check for any individual invalid file name characters. The caller must trim leading white
+    /// space characters from the start of the file name prior to calling this method.
+    /// </remarks>
+    public readonly DosSpecialFileName ParseSpecialFileName(ReadOnlySpan<char> fileName) {
+        // The algorithm/checks are derived from:
+        // https://learn.microsoft.com/en-us/windows/win32/fileio/naming-a-file#naming-conventions
+        //
+        // This might be more strict than the standard DOS file naming conventions, but it uses the Windows naming
+        // conventions to prevent issues with potentially malicious or problematic DOS programs from creating file
+        // names that are reserved on Windows (or file names that are difficult to remove/rename in the shell).
+        //
+        // NOTE: DO NOT THROW EXCEPTIONS IN THIS METHOD!
+
+        if (fileName.IsEmpty) {
+            return DosSpecialFileName.Empty;
+        }
+
+        Debug.Assert(!char.IsWhiteSpace(fileName[0]));
+
+        // Do not allow file names that end with white space.
+        if (char.IsWhiteSpace(fileName[^1])) {
+            return DosSpecialFileName.Invalid;
+        }
+
+        // Ignore file extension if defined. Reserved names include file extensions. Also handle special/reserved file
+        // names that start and/or end with period.
+        int dotIndex = fileName.IndexOf('.');
+        if (dotIndex >= 0) {
+            // Check for "." and ".." directory traversal file names.
+            if (dotIndex == 0) {
+                if (fileName.Length == 1) {
+                    return DosSpecialFileName.CurrentDirectory;
+                }
+                if (fileName.Length == 2 && fileName[1] == '.') {
+                    return DosSpecialFileName.ParentDirectory;
+                }
+            }
+
+            // Do not allow file names that end with a period (pedantic Windows naming convention). Special file names
+            // "." and ".." are handled above, so this should be safe.
+            if (fileName[^1] == '.') {
+                return DosSpecialFileName.Invalid;
+            }
+
+            // Trim white space to be more pedantic by not allowing any reserved names that have white space at the end
+            // (before the file extension).
+            fileName = fileName[..dotIndex].TrimEnd();
+        }
+
+        // Note that "COM¹", "COM²", "COM³", "LPT¹", "LPT²", and "LPT³" (using ISO/IEC 8859-1 superscript numbers) are
+        // always handled as special names (pedantic Windows naming convention). Parser settings are used to determine
+        // whether they are treated as the associated devices or generic invalid reserved file names.
+
+        // For improved lookup performance: this implementation first uses the device file name length to
+        // differentiate, then it checks the first letter of the device names before checking the remaining characters.
+        DosSpecialFileName deviceName = DosSpecialFileName.None;
+        if (fileName.Length == 3) {
+            switch (fileName[0]) {
+                case 'C':
+                case 'c':
+                    // "CON"
+                    if (fileName[1] is 'O' or 'o' && fileName[2] is 'N' or 'n') {
+                        deviceName = DosSpecialFileName.Console;
+                    }
+                    break;
+
+                case 'P':
+                case 'p':
+                    // "PRN"
+                    if (fileName[1] is 'R' or 'r' && fileName[2] is 'N' or 'n') {
+                        deviceName = DosSpecialFileName.Printer;
+                    }
+                    break;
+
+                case 'A':
+                case 'a':
+                    // "AUX"
+                    if (fileName[1] is 'U' or 'u' && fileName[2] is 'X' or 'x') {
+                        deviceName = DosSpecialFileName.Auxiliary;
+                    }
+                    break;
+            }
+        } else if (fileName.Length == 4) {
+            switch (fileName[0]) {
+                case 'C':
+                case 'c':
+                    // "COM1" thru "COM9", "COM¹", "COM²", "COM³"
+                    if (fileName[1] is 'O' or 'o' && fileName[2] is 'M' or 'm') {
+                        switch (fileName[3]) {
+                            case '1': // ASCII digit '1'
+                                deviceName = DosSpecialFileName.SerialPort1;
+                                break;
+                            case '2': // ASCII digit '2'
+                                deviceName = DosSpecialFileName.SerialPort2;
+                                break;
+                            case '3': // ASCII digit '3'
+                                deviceName = DosSpecialFileName.SerialPort3;
+                                break;
+                            case '4': // ASCII digit '4'
+                                deviceName = DosSpecialFileName.SerialPort4;
+                                break;
+                            case '5': // ASCII digit '5'
+                                deviceName = DosSpecialFileName.SerialPort5;
+                                break;
+                            case '6': // ASCII digit '6'
+                                deviceName = DosSpecialFileName.SerialPort6;
+                                break;
+                            case '7': // ASCII digit '7'
+                                deviceName = DosSpecialFileName.SerialPort7;
+                                break;
+                            case '8': // ASCII digit '8'
+                                deviceName = DosSpecialFileName.SerialPort8;
+                                break;
+                            case '9': // ASCII digit '9'
+                                deviceName = DosSpecialFileName.SerialPort9;
+                                break;
+
+                            case '¹': // Superscript '1'
+                                deviceName = _specialFileNameSettings.HasFlag(DosSpecialFileNameSettings.NoDeviceSuperscriptDigits)
+                                    ? DosSpecialFileName.Invalid // always block (pedantic Windows naming rule)
+                                    : DosSpecialFileName.SerialPort1;
+                                break;
+                            case '²': // Superscript '2'
+                                deviceName = _specialFileNameSettings.HasFlag(DosSpecialFileNameSettings.NoDeviceSuperscriptDigits)
+                                    ? DosSpecialFileName.Invalid // always block (pedantic Windows naming rule)
+                                    : DosSpecialFileName.SerialPort2;
+                                break;
+                            case '³': // Superscript '3'
+                                deviceName = _specialFileNameSettings.HasFlag(DosSpecialFileNameSettings.NoDeviceSuperscriptDigits)
+                                    ? DosSpecialFileName.Invalid // always block (pedantic Windows naming rule)
+                                    : DosSpecialFileName.SerialPort3;
+                                break;
+                        }
+                    }
+                    break;
+
+                case 'L':
+                case 'l':
+                    // "LPT1" thru "LPT9", "LPT¹", "LPT²", "LPT³"
+                    if (fileName[1] is 'P' or 'p' && fileName[2] is 'T' or 't') {
+                        switch (fileName[3]) {
+                            case '1': // ASCII digit '1'
+                                deviceName = DosSpecialFileName.ParallelPort1;
+                                break;
+                            case '2': // ASCII digit '2'
+                                deviceName = DosSpecialFileName.ParallelPort2;
+                                break;
+                            case '3': // ASCII digit '3'
+                                deviceName = DosSpecialFileName.ParallelPort3;
+                                break;
+                            case '4': // ASCII digit '4'
+                                deviceName = DosSpecialFileName.ParallelPort4;
+                                break;
+                            case '5': // ASCII digit '5'
+                                deviceName = DosSpecialFileName.ParallelPort5;
+                                break;
+                            case '6': // ASCII digit '6'
+                                deviceName = DosSpecialFileName.ParallelPort6;
+                                break;
+                            case '7': // ASCII digit '7'
+                                deviceName = DosSpecialFileName.ParallelPort7;
+                                break;
+                            case '8': // ASCII digit '8'
+                                deviceName = DosSpecialFileName.ParallelPort8;
+                                break;
+                            case '9': // ASCII digit '9'
+                                deviceName = DosSpecialFileName.ParallelPort9;
+                                break;
+
+                            case '¹': // Superscript '1'
+                                deviceName = _specialFileNameSettings.HasFlag(DosSpecialFileNameSettings.NoDeviceSuperscriptDigits)
+                                    ? DosSpecialFileName.Invalid // always block (pedantic Windows naming rule)
+                                    : DosSpecialFileName.ParallelPort1;
+                                break;
+                            case '²': // Superscript '2'
+                                deviceName = _specialFileNameSettings.HasFlag(DosSpecialFileNameSettings.NoDeviceSuperscriptDigits)
+                                    ? DosSpecialFileName.Invalid // always block (pedantic Windows naming rule)
+                                    : DosSpecialFileName.ParallelPort2;
+                                break;
+                            case '³': // Superscript '3'
+                                deviceName = _specialFileNameSettings.HasFlag(DosSpecialFileNameSettings.NoDeviceSuperscriptDigits)
+                                    ? DosSpecialFileName.Invalid // always block (pedantic Windows naming rule)
+                                    : DosSpecialFileName.ParallelPort3;
+                                break;
+                        }
+                    }
+                    break;
+            }
+        }
+
+        return deviceName;
+    }
+
+    /// <summary>Performs debug assertions to validate the state of the path builder.</summary>
+    /// <remarks>
+    /// This is only called in debug builds. Though passing these checks does not mean that that path builder contains
+    /// a valid DOS full path specification.
+    /// </remarks>
+    [Conditional("DEBUG")]
+    internal readonly void DebugValidateState() {
+        ReadOnlySpan<char> path = _pathBuilder.AsSpan();
+        ReadOnlySpan<int> pathElementIndexes = _pathStack.AsSpan();
+
+        // An path builder without a drive specification is only in a valid state if it is empty, there are no path
+        // elements, and it is not frozen. (A valid state does not mean that it is a valid path though.)
+        if (!HasDriveSpecification) {
+            Debug.Assert(path.Length == 0);
+            Debug.Assert(pathElementIndexes.Length == 0);
+            Debug.Assert(!IsFrozen);
+            return;
+        }
+
+        // A valid path should always start with an uppercase drive letter and volume separator.
+        Debug.Assert(path.Length >= 2 && char.IsAsciiLetterUpper(path[0]) && path[1] == VolumeSeparatorChar);
+        Debug.Assert(HasDriveSpecification); // pedantic check
+
+        // Frozen paths can break some of the path rules. Frozen paths can end with a directory separator and they can
+        // have an empty path element stack.
+        if (IsFrozen) {
+            // A valid frozen path should always be at least 3 characters and have a directory separator immediately
+            // following the drive specification.
+            Debug.Assert(path.Length >= 3 && path[2] == DirectorySeparatorChar);
+            return;
+        }
+
+        // The last character in a mutable path builder cannot be a directory separator.
+        Debug.Assert(path[^1] != DirectorySeparatorChar);
+
+        // There should be no path elements if there is only a drive specification.
+        Debug.Assert(path.Length > 2 || pathElementIndexes.IsEmpty);
+
+        // Validate the path element stack.
+        int lastPathIndex = -1;
+        for (int i = 0; i < pathElementIndexes.Length; i++) {
+            int pathIndex = pathElementIndexes[i];
+
+            // The first path element must immediately follow the drive specification.
+            Debug.Assert(i != 0 || pathIndex == 2);
+
+            // All path elements must be a valid index specified after the drive specification.
+            Debug.Assert(pathIndex >= 2);
+            Debug.Assert(pathIndex < path.Length);
+
+            // All path elements must point to a directory separator character.
+            Debug.Assert(path[pathIndex] == DirectorySeparatorChar);
+
+            // All path elements must be in order with no duplicates.
+            Debug.Assert(pathIndex > lastPathIndex);
+            lastPathIndex = pathIndex;
+        }
+    }
+}

--- a/src/Spice86.Core/ValueListBuilder.cs
+++ b/src/Spice86.Core/ValueListBuilder.cs
@@ -1,0 +1,207 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+// Derived from dotnet/runtime: commit 2ec033b0cecf21f67a2431caa8efaebc1dd77b14
+// Changes from original:
+// - Changed namespace to "Spice86.Core".
+// - Reformatted to follow Spice86 conventions.
+// - Removed conditional blocks for SYSTEM_PRIVATE_CORELIB (requires .NET runtime internal APIs).
+// - Added "readonly" keyword to Length property getter, AsSpan method, and TryCopyTo method.
+// - Added IsArrayBacked property to determine if the list is currently allocated as an array.
+
+namespace Spice86.Core;
+
+using System.Buffers;
+using System.Diagnostics;
+using System.Runtime.CompilerServices;
+
+internal ref partial struct ValueListBuilder<T> {
+    private Span<T> _span;
+    private T[]? _arrayFromPool;
+    private int _pos;
+
+    public ValueListBuilder(Span<T?> scratchBuffer) {
+        _span = scratchBuffer!;
+    }
+
+    public ValueListBuilder(int capacity) {
+        Grow(capacity);
+    }
+
+    public readonly bool IsArrayBacked => _arrayFromPool != null;
+
+    public int Length {
+        readonly get => _pos;
+        set {
+            Debug.Assert(value >= 0);
+            Debug.Assert(value <= _span.Length);
+            _pos = value;
+        }
+    }
+
+    public ref T this[int index] {
+        get {
+            Debug.Assert(index < _pos);
+            return ref _span[index];
+        }
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public void Append(T item) {
+        int pos = _pos;
+
+        // Workaround for https://github.com/dotnet/runtime/issues/72004
+        Span<T> span = _span;
+        if ((uint)pos < (uint)span.Length) {
+            span[pos] = item;
+            _pos = pos + 1;
+        } else {
+            AddWithResize(item);
+        }
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public void Append(scoped ReadOnlySpan<T> source) {
+        int pos = _pos;
+        Span<T> span = _span;
+        if (source.Length == 1 && (uint)pos < (uint)span.Length) {
+            span[pos] = source[0];
+            _pos = pos + 1;
+        } else {
+            AppendMultiChar(source);
+        }
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private void AppendMultiChar(scoped ReadOnlySpan<T> source) {
+        if ((uint)(_pos + source.Length) > (uint)_span.Length) {
+            Grow(source.Length);
+        }
+
+        source.CopyTo(_span.Slice(_pos));
+        _pos += source.Length;
+    }
+
+    public void Insert(int index, scoped ReadOnlySpan<T> source) {
+        Debug.Assert(index == 0, "Implementation currently only supports index == 0");
+
+        if ((uint)(_pos + source.Length) > (uint)_span.Length) {
+            Grow(source.Length);
+        }
+
+        _span.Slice(0, _pos).CopyTo(_span.Slice(source.Length));
+        source.CopyTo(_span);
+        _pos += source.Length;
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public Span<T> AppendSpan(int length) {
+        Debug.Assert(length >= 0);
+
+        int pos = _pos;
+        Span<T> span = _span;
+        if ((uint)(pos + length) <= (uint)span.Length) {
+            _pos = pos + length;
+            return span.Slice(pos, length);
+        } else {
+            return AppendSpanWithGrow(length);
+        }
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private Span<T> AppendSpanWithGrow(int length) {
+        int pos = _pos;
+        Grow(length);
+        _pos += length;
+        return _span.Slice(pos, length);
+    }
+
+    // Hide uncommon path
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private void AddWithResize(T item) {
+        Debug.Assert(_pos == _span.Length);
+        int pos = _pos;
+        Grow(1);
+        _span[pos] = item;
+        _pos = pos + 1;
+    }
+
+    public readonly ReadOnlySpan<T> AsSpan() {
+        return _span.Slice(0, _pos);
+    }
+
+    public readonly bool TryCopyTo(Span<T> destination, out int itemsWritten) {
+        if (_span.Slice(0, _pos).TryCopyTo(destination)) {
+            itemsWritten = _pos;
+            return true;
+        }
+
+        itemsWritten = 0;
+        return false;
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public void Dispose() {
+        int pos = _pos;
+        T[]? toReturn = _arrayFromPool;
+
+        this = default;
+
+        if (toReturn != null) {
+            if (!typeof(T).IsPrimitive) {
+                Array.Clear(toReturn, 0, pos);
+            }
+
+            ArrayPool<T>.Shared.Return(toReturn);
+        }
+    }
+
+    /// <summary>
+    /// Resize the internal buffer either by doubling current buffer size or
+    /// by adding <paramref name="additionalCapacityBeyondPos"/> to
+    /// <see cref="_pos"/> whichever is greater.
+    /// </summary>
+    /// <param name="additionalCapacityBeyondPos">
+    /// Number of chars requested beyond current position.
+    /// </param>
+    /// <remarks>
+    /// Note that consuming implementations depend on the list only growing if it's absolutely
+    /// required.  If the list is already large enough to hold the additional items be added,
+    /// it must not grow. The list is used in a number of places where the reference is checked
+    /// and it's expected to match the initial reference provided to the constructor if that
+    /// span was sufficiently large.
+    /// </remarks>
+    private void Grow(int additionalCapacityBeyondPos) {
+        Debug.Assert(additionalCapacityBeyondPos > 0);
+        Debug.Assert(_pos > _span.Length - additionalCapacityBeyondPos, "Grow called incorrectly, no resize is needed.");
+
+        const int ArrayMaxLength = 0x7FFFFFC7; // same as Array.MaxLength
+
+        // Double the size of the span.  If it's currently empty, default to size 4,
+        // although it'll be increased in Rent to the pool's minimum bucket size.
+        int nextCapacity = Math.Max(_span.Length != 0 ? _span.Length * 2 : 4, _pos + additionalCapacityBeyondPos);
+
+        // If the computed doubled capacity exceeds the possible length of an array, then we
+        // want to downgrade to either the maximum array length if that's large enough to hold
+        // an additional item, or the current length + 1 if it's larger than the max length, in
+        // which case it'll result in an OOM when calling Rent below.  In the exceedingly rare
+        // case where _span.Length is already int.MaxValue (in which case it couldn't be a managed
+        // array), just use that same value again and let it OOM in Rent as well.
+        if ((uint)nextCapacity > ArrayMaxLength) {
+            nextCapacity = Math.Max(Math.Max(_span.Length + 1, ArrayMaxLength), _span.Length);
+        }
+
+        T[] array = ArrayPool<T>.Shared.Rent(nextCapacity);
+        _span.CopyTo(array);
+
+        T[]? toReturn = _arrayFromPool;
+        _span = _arrayFromPool = array;
+        if (toReturn != null) {
+            if (!typeof(T).IsPrimitive) {
+                Array.Clear(toReturn, 0, _pos);
+            }
+
+            ArrayPool<T>.Shared.Return(toReturn);
+        }
+    }
+}

--- a/src/Spice86.Core/ValueListStack.cs
+++ b/src/Spice86.Core/ValueListStack.cs
@@ -1,0 +1,139 @@
+﻿namespace Spice86.Core;
+
+using System;
+using System.Diagnostics.CodeAnalysis;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+/// <summary>A fast stack implementation with optional span-based backing storage.</summary>
+/// <typeparam name="T">The stack element type.</typeparam>
+internal ref partial struct ValueListStack<T> {
+    private ValueListBuilder<T> _list;
+
+    /// <summary>Initializes a new stack with a user-supplied scratch buffer.</summary>
+    /// <param name="scratchBuffer">A span containing the initial element storage for the stack.</param>
+    /// <remarks>
+    /// This is typically a <see langword="stackalloc"/> allocated buffer from the caller's scope. The stack will still
+    /// be empty after calling this method. It is still up to the caller to explicitly push elements on to the empty
+    /// stack after initialization.
+    /// </remarks>
+    public ValueListStack(Span<T?> scratchBuffer) => _list = new(scratchBuffer);
+
+    /// <summary>Initializes a new stack with a specified initial capacity.</summary>
+    /// <param name="capacity">The initial minimum capacity to allocate. Must be greater than or equal to zero.</param>
+    /// <remarks>
+    /// The internal storage will use the default <see cref="System.Buffers.ArrayPool{T}"/> for heap allocations.
+    /// </remarks>
+    public ValueListStack(int capacity) => _list = new(capacity);
+
+    /// <summary>Gets or sets the length of the stack in elements.</summary>
+    /// <value>The length of the stack in elements. Must be greater than or equal to zero.</value>
+    /// <remarks>
+    /// Changing the stack length will add or remove elements, but they will not be initialized or cleared. That is a
+    /// task that is up to the caller to perform.
+    /// </remarks>
+    public int Length {
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        readonly get => _list.Length;
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        set => _list.Length = value;
+    }
+
+    /// <summary>Gets a reference to the element at the specified index.</summary>
+    /// <param name="index">
+    /// Zero-based index to the requested stack element. Must be greater than or equal to zero and less than
+    /// <see cref="Length"/>. Index zero represents the first element added to the stack, one represents the second
+    /// element, etc. The last index is always the last element added to the stack.
+    /// </param>
+    /// <returns>A reference to the specified element.</returns>
+    public ref T this[int index] {
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        get => ref _list[index];
+    }
+
+    /// <summary>Gets the elements on the stack as a read only span.</summary>
+    /// <returns>A read only span containing the current elements on the stack.</returns>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public readonly ReadOnlySpan<T> AsSpan() => _list.AsSpan();
+
+    /// <summary>Disposes of the internal stack memory.</summary>
+    /// <remarks>
+    /// Calling this after the stack is no longer needed is absolutely essential, otherwise memory leaks may occur!
+    /// </remarks>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public void Dispose() => _list.Dispose();
+
+    /// <summary>Pushes a single element on to the end of the stack.</summary>
+    /// <param name="item">The element to copy into the stack.</param>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public void Push(T item) => _list.Append(item);
+
+    /// <summary>Pushes an entire span of elements on to the end of the stack.</summary>
+    /// <param name="source">
+    /// The elements to copy into the stack. Must be specified in the same order as returned by <see cref="AsSpan()"/>.
+    /// </param>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public void PushMany(scoped ReadOnlySpan<T> source) => _list.Append(source);
+
+    /// <summary>Pushes an uninitialized element on to the end of the stack.</summary>
+    /// <returns>A reference to the uninitialized element.</returns>
+    /// <remarks>
+    /// This is a potentially dangerous operation. It is up to the caller to initialize the element. This is useful for
+    /// performing zero-copy initialization on large structure elements.
+    /// </remarks>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public ref T PushReserve() => ref _list.AppendSpan(1)[0];
+
+    /// <summary>Pushes multiple uninitialized elements on to the end of the stack.</summary>
+    /// <param name="length">The number of elements to push. Must be greater than or equal to zero.</param>
+    /// <returns>A span containing the uninitialized elements that were pushed.</returns>
+    /// <remarks>
+    /// This is a potentially dangerous operation. It is up to the caller to initialize all the elements.. This is
+    /// useful for performing zero-copy initialization on large structure elements.
+    /// </remarks>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public Span<T> PushReserveMany(int length) => _list.AppendSpan(length);
+
+    /// <summary>Attempts to pop a single element from the stack.</summary>
+    /// <param name="item">
+    /// The item that was popped from the stack or <see langword="default"/> if the stack is empty.
+    /// </param>
+    /// <returns>
+    /// <see langword="true"/> if an element was successfully popped from the stack; otherwise, <see cref="false"/>.
+    /// </returns>
+    public bool TryPop([MaybeNullWhen(false)] out T item) {
+        if (Length <= 0) {
+            item = default;
+            return false;
+        }
+
+        // Get a reference to the last item and copy it into the output parameter.
+        int lastElementIndex = _list.Length - 1;
+        ref T lastItem = ref _list[lastElementIndex];
+        item = lastItem;
+
+        // Clear the element from the underlying list if the backing storage is in an array. (This is what
+        // ValueListBuilder<T> does when calling Dispose() or when it grows. Since ValueListBuilder<T> does not have a
+        // concept of removing items explicitly, it is technically up to the caller: this method.)
+        if (_list.IsArrayBacked && !typeof(T).IsPrimitive) {
+            lastItem = default!;
+        }
+
+        // Update stack length to exclude the popped element.
+        _list.Length = lastElementIndex;
+        return true;
+    }
+
+    /// <summary>Clears all elements in the stack.</summary>
+    public void Clear() {
+        // Clear all elements from the underlying list if the backing storage is in an array. (This is what
+        // ValueListBuilder<T> does when calling Dispose() or when it grows. Since ValueListBuilder<T> does not have a
+        // concept of removing items explicitly, it is technically up to the caller: this method.)
+        if (_list.IsArrayBacked && !typeof(T).IsPrimitive) {
+            MemoryMarshal.CreateSpan(ref _list[0], _list.Length).Clear();
+        }
+
+        _list.Length = 0;
+    }
+}

--- a/src/Spice86.Core/ValueListStack.cs
+++ b/src/Spice86.Core/ValueListStack.cs
@@ -130,7 +130,9 @@ internal ref partial struct ValueListStack<T> {
         // Clear all elements from the underlying list if the backing storage is in an array. (This is what
         // ValueListBuilder<T> does when calling Dispose() or when it grows. Since ValueListBuilder<T> does not have a
         // concept of removing items explicitly, it is technically up to the caller: this method.)
-        if (_list.IsArrayBacked && !typeof(T).IsPrimitive) {
+        // The length check isn't strictly necessary here due to how ValueListBuilder works, but it provides extra
+        // safety for a negligible cost.
+        if (_list.IsArrayBacked && !typeof(T).IsPrimitive && _list.Length > 0) {
             MemoryMarshal.CreateSpan(ref _list[0], _list.Length).Clear();
         }
 

--- a/tests/Spice86.Tests/Dos/DosBatchRoutingIntegrationTests.cs
+++ b/tests/Spice86.Tests/Dos/DosBatchRoutingIntegrationTests.cs
@@ -1261,7 +1261,7 @@ public class DosBatchRoutingIntegrationTests {
             RunBatchScript(tempDir, "CD SUBDIR\r\nCD > OUT.TXT\r\n");
 
             // Assert
-            string output = File.ReadAllText(Path.Join(tempDir, "OUT.TXT")).Trim();
+            string output = File.ReadAllText(Path.Join(tempDir, "SUBDIR", "OUT.TXT")).Trim();
             output.Should().Contain("SUBDIR", "CD should have changed to the subdirectory");
         });
     }
@@ -1297,7 +1297,7 @@ public class DosBatchRoutingIntegrationTests {
             RunBatchScript(tempDir, "CD SUB\r\nCD.\r\nCD > OUT.TXT\r\n");
 
             // Assert: should still be in SUB
-            string output = File.ReadAllText(Path.Join(tempDir, "OUT.TXT")).Trim();
+            string output = File.ReadAllText(Path.Join(tempDir, "SUB", "OUT.TXT")).Trim();
             output.Should().Contain("SUB", "CD. should stay in the current directory");
         });
     }
@@ -1628,7 +1628,7 @@ public class DosBatchRoutingIntegrationTests {
             RunBatchScript(tempDir, "MD NEWDIR\r\nCD NEWDIR\r\nCD > OUT.TXT\r\n");
 
             // Assert
-            string output = File.ReadAllText(Path.Join(tempDir, "OUT.TXT")).Trim();
+            string output = File.ReadAllText(Path.Join(tempDir, "NEWDIR", "OUT.TXT")).Trim();
             output.Should().Contain("NEWDIR", "MD should have created the directory");
         });
     }
@@ -1643,7 +1643,7 @@ public class DosBatchRoutingIntegrationTests {
             RunBatchScript(tempDir, "MKDIR SUBDIR\r\nCD SUBDIR\r\nCD > OUT.TXT\r\n");
 
             // Assert
-            string output = File.ReadAllText(Path.Join(tempDir, "OUT.TXT")).Trim();
+            string output = File.ReadAllText(Path.Join(tempDir, "SUBDIR", "OUT.TXT")).Trim();
             output.Should().Contain("SUBDIR");
         });
     }

--- a/tests/Spice86.Tests/Dos/DosDriveManagerTests.cs
+++ b/tests/Spice86.Tests/Dos/DosDriveManagerTests.cs
@@ -29,13 +29,18 @@ public class DosDriveManagerTests {
             // Assert
             dosDriveManager.Count.Should().Be(3);
             mountedDriveEntries.Should().AllSatisfy(static entry => {
-                entry.Should().NotBeNull();
+                entry.Value.Should().NotBeNull();
                 entry.Key.Should().Be(entry.Value.DriveLetter);
             });
             mountedDriveLetters.Should().BeEquivalentTo(mountedDriveEntries
                 .Select(static entry => entry.Key));
             mountedDrives.Should().BeEquivalentTo(mountedDriveEntries
                 .Select(static entry => entry.Value));
+
+            mountedDriveEntries.Should().BeEquivalentTo(
+                dosDriveManager.As<IEnumerable<KeyValuePair<char, DosDriveBase>>>());
+            mountedDriveLetters.Should().BeEquivalentTo(dosDriveManager.Keys);
+            mountedDrives.Should().BeEquivalentTo(dosDriveManager.Values);
         } finally {
             Directory.Delete(tempDir, true);
         }
@@ -61,13 +66,18 @@ public class DosDriveManagerTests {
             dosDriveManager.Count.Should().Be(4);
             dosDriveManager['Z'].Should().BeOfType<MemoryDrive>();
             mountedDriveEntries.Should().AllSatisfy(static entry => {
-                entry.Should().NotBeNull();
+                entry.Value.Should().NotBeNull();
                 entry.Key.Should().Be(entry.Value.DriveLetter);
             });
             mountedDriveLetters.Should().BeEquivalentTo(mountedDriveEntries
                 .Select(static entry => entry.Key));
             mountedDrives.Should().BeEquivalentTo(mountedDriveEntries
                 .Select(static entry => entry.Value));
+
+            mountedDriveEntries.Should().BeEquivalentTo(
+                dosDriveManager.As<IEnumerable<KeyValuePair<char, DosDriveBase>>>());
+            mountedDriveLetters.Should().BeEquivalentTo(dosDriveManager.Keys);
+            mountedDrives.Should().BeEquivalentTo(dosDriveManager.Values);
         } finally {
             Directory.Delete(tempDir, true);
         }
@@ -145,6 +155,12 @@ public class DosDriveManagerTests {
             dictEntryEnumerator.MoveNext().Should().BeFalse();
             keyEnumerator.MoveNext().Should().BeFalse();
             valueEnumerator.MoveNext().Should().BeFalse();
+
+            kvpEnumerator.MoveNext().Should().BeFalse();
+            kvpEnumeratorExplicit.MoveNext().Should().BeFalse();
+            dictEntryEnumerator.MoveNext().Should().BeFalse();
+            keyEnumerator.MoveNext().Should().BeFalse();
+            valueEnumerator.MoveNext().Should().BeFalse();
         } finally {
             Directory.Delete(tempDir, true);
         }
@@ -171,6 +187,7 @@ public class DosDriveManagerTests {
 
             int index = 0;
             foreach (KeyValuePair<char, DosDriveBase> kvp in dosDriveManager) {
+                index.Should().BeInRange(0, 3);
                 KeyValuePair<char, DosDriveBase> expected = index switch {
                     0 => new('A', aDrive),
                     1 => new('B', bDrive),
@@ -181,9 +198,11 @@ public class DosDriveManagerTests {
                 kvp.Should().Be(expected);
                 index++;
             }
+            index.Should().Be(4);
 
             index = 0;
             foreach (char driveLetter in dosDriveManager.Keys) {
+                index.Should().BeInRange(0, 3);
                 char expected = index switch {
                     0 => 'A',
                     1 => 'B',
@@ -194,9 +213,11 @@ public class DosDriveManagerTests {
                 driveLetter.Should().Be(expected);
                 index++;
             }
+            index.Should().Be(4);
 
             index = 0;
             foreach (DosDriveBase drive in dosDriveManager.Values) {
+                index.Should().BeInRange(0, 3);
                 DosDriveBase? expected = index switch {
                     0 => aDrive,
                     1 => bDrive,
@@ -207,6 +228,7 @@ public class DosDriveManagerTests {
                 drive.Should().Be(expected);
                 index++;
             }
+            index.Should().Be(4);
         } finally {
             Directory.Delete(tempDir, true);
         }

--- a/tests/Spice86.Tests/Dos/Structures/DosPathBuilderTests.cs
+++ b/tests/Spice86.Tests/Dos/Structures/DosPathBuilderTests.cs
@@ -1,0 +1,135 @@
+﻿namespace Spice86.Tests.Dos.Structures;
+
+using FluentAssertions;
+
+using Spice86.Core.Emulator.OperatingSystem.Enums;
+using Spice86.Core.Emulator.OperatingSystem.Structures;
+
+using System;
+
+using Xunit;
+
+public class DosPathBuilderTests {
+    [Theory]
+    [InlineData("", DosSpecialFileName.Empty)]
+    [InlineData("foo", DosSpecialFileName.None)]
+    [InlineData(" foo", DosSpecialFileName.None)]
+    [InlineData(".foo", DosSpecialFileName.None)]
+    [InlineData("foo ", DosSpecialFileName.Invalid)]
+    [InlineData("foo.", DosSpecialFileName.Invalid)]
+    [InlineData(".", DosSpecialFileName.CurrentDirectory)]
+    [InlineData("..", DosSpecialFileName.ParentDirectory)]
+    [InlineData("NUL", DosSpecialFileName.Null)]
+    [InlineData("Nul", DosSpecialFileName.Null)]
+    [InlineData("NUL.TXT", DosSpecialFileName.Null)]
+    [InlineData("NUL .TXT", DosSpecialFileName.Null)]
+    [InlineData("NULL", DosSpecialFileName.None)]
+    [InlineData("con", DosSpecialFileName.Console)]
+    [InlineData("CoN.TAR.GZ", DosSpecialFileName.Console)]
+    [InlineData("AUx", DosSpecialFileName.Auxiliary)]
+    [InlineData("PRN", DosSpecialFileName.Printer)]
+    [InlineData("COM", DosSpecialFileName.None)]
+    [InlineData("COM1", DosSpecialFileName.SerialPort1)]
+    [InlineData("cOM2", DosSpecialFileName.SerialPort2)]
+    [InlineData("coM3", DosSpecialFileName.SerialPort3)]
+    [InlineData("com4", DosSpecialFileName.SerialPort4)]
+    [InlineData("cOm5", DosSpecialFileName.SerialPort5)]
+    [InlineData("COm6", DosSpecialFileName.SerialPort6)]
+    [InlineData("COM7", DosSpecialFileName.SerialPort7)]
+    [InlineData("COM8", DosSpecialFileName.SerialPort8)]
+    [InlineData("COM9", DosSpecialFileName.SerialPort9)]
+    [InlineData("COM¹", DosSpecialFileName.SerialPort1)]
+    [InlineData("COM²", DosSpecialFileName.SerialPort2)]
+    [InlineData("COM³", DosSpecialFileName.SerialPort3)]
+    [InlineData("LPT", DosSpecialFileName.None)]
+    [InlineData("LPT1", DosSpecialFileName.ParallelPort1)]
+    [InlineData("lPT2", DosSpecialFileName.ParallelPort2)]
+    [InlineData("lpT3", DosSpecialFileName.ParallelPort3)]
+    [InlineData("lpt4", DosSpecialFileName.ParallelPort4)]
+    [InlineData("lPt5", DosSpecialFileName.ParallelPort5)]
+    [InlineData("LPt6", DosSpecialFileName.ParallelPort6)]
+    [InlineData("LPT7", DosSpecialFileName.ParallelPort7)]
+    [InlineData("LPT8", DosSpecialFileName.ParallelPort8)]
+    [InlineData("LPT9", DosSpecialFileName.ParallelPort9)]
+    [InlineData("LPT¹", DosSpecialFileName.ParallelPort1)]
+    [InlineData("LPT²", DosSpecialFileName.ParallelPort2)]
+    [InlineData("LPT³", DosSpecialFileName.ParallelPort3)]
+    internal void SpecialFileNames_DefaultSettings(string fileName, DosSpecialFileName expectedSpecialFileName) {
+        // Arrange
+        using DosPathBuilder builder = new();
+
+        // Act
+        // Documentation for ParseSpecialFileName() indicates that leading white space must always be trimmed.
+        ReadOnlySpan<char> fileNameTrimmed = fileName.AsSpan().TrimStart();
+        DosSpecialFileName result = builder.ParseSpecialFileName(fileNameTrimmed);
+
+        // Assert
+        result.Should().Be(expectedSpecialFileName);
+    }
+
+    [Theory]
+    [InlineData("COM¹", DosSpecialFileName.Invalid)]
+    [InlineData("COM²", DosSpecialFileName.Invalid)]
+    [InlineData("COM³", DosSpecialFileName.Invalid)]
+    [InlineData("LPT¹", DosSpecialFileName.Invalid)]
+    [InlineData("LPT²", DosSpecialFileName.Invalid)]
+    [InlineData("LPT³", DosSpecialFileName.Invalid)]
+    internal void SpecialFileNames_NoDeviceSuperscriptSetting(string fileName, DosSpecialFileName expectedSpecialFileName) {
+        // Arrange
+        using DosPathBuilder builder = new() {
+            SpecialFileNameSettings = DosSpecialFileNameSettings.NoDeviceSuperscriptDigits
+        };
+
+        // Act
+        // Documentation for ParseSpecialFileName() indicates that leading white space must always be trimmed.
+        ReadOnlySpan<char> fileNameTrimmed = fileName.AsSpan().TrimStart();
+        DosSpecialFileName result = builder.ParseSpecialFileName(fileNameTrimmed);
+
+        // Assert
+        result.Should().Be(expectedSpecialFileName);
+    }
+
+    [Theory]
+    [InlineData('A', null, null, null, @"A:\")]
+    [InlineData('Z', null, null, null, @"Z:\")]
+    [InlineData('c', "FOO", null, null, @"C:\FOO")]
+    [InlineData('C', "/foo", null, null, @"C:\foo")]
+    [InlineData('c', "/foo", "bar", null, @"C:\bar")]
+    [InlineData('c', " /foo", null, "bar", @"C:\foo\bar")]
+    [InlineData('z', "// foo", null, null, @"Z:\foo")]
+    [InlineData('z', @"//.foo\ \\bar\", null, null, @"Z:\.foo\bar")]
+    [InlineData('Q', "foo", "/baz", "bar", @"Q:\baz\bar")]
+    [InlineData('B', null, null, "'[f00]_", @"B:\'[f00]_")]
+    [InlineData('B', null, "'[f00]_", null, @"B:\'[f00]_")]
+    [InlineData('r', "foo;bar", null, null, @"R:\foo;bar")]
+    public void BuildPath_Drive_Relative_Rooted_FileName(char driveLetter, string? appendRelativePath, string? appendRootedPathAfterRelative,
+            string? appendFileName, string expectedPath) {
+        // Arrange
+        using DosPathBuilder builder = new();
+
+        // Act
+        DosPathBuilderResult resultSetDriveLetter = builder.SetDriveLetter(driveLetter);
+        DosPathBuilderResult resultAppendRelativePath = appendRelativePath is not null
+            ? builder.AppendRelativePath(appendRelativePath, out _)
+            : DosPathBuilderResult.Success;
+        DosPathBuilderResult resultAppendAbsolutePath = appendRootedPathAfterRelative is not null
+            ? builder.AppendRootedPath(appendRootedPathAfterRelative, out _)
+            : DosPathBuilderResult.Success;
+        DosPathBuilderResult resultAppendFileName = appendFileName is not null
+            ? builder.AppendFileName(appendFileName)
+            : DosPathBuilderResult.Success;
+        DosPathBuilderResult resultFreeze = builder.Freeze();
+        string resultPath = builder.ToString();
+        DosPathBuilderResult resultFreeze2 = builder.Freeze();
+
+        // Assert
+        resultSetDriveLetter.Should().Be(DosPathBuilderResult.Success);
+        resultAppendRelativePath.Should().Be(DosPathBuilderResult.Success);
+        resultAppendAbsolutePath.Should().Be(DosPathBuilderResult.Success);
+        resultAppendFileName.Should().Be(DosPathBuilderResult.Success);
+        resultFreeze.Should().Be(DosPathBuilderResult.Success);
+        resultFreeze2.Should().Be(DosPathBuilderResult.Success);
+        resultPath.Should().Be(expectedPath);
+        builder.IsFrozen.Should().BeTrue();
+    }
+}


### PR DESCRIPTION
### Description of Changes
* Added new `DosPathBuilder` helper type for efficiently building DOS full path strings.
  * This includes the following new enumerations: `DosPathBuilderResult`, `DosSpecialFileName`, and `DosSpecialFileNameSettings`.
  * This includes the following new low-level internal generic helper types: `ValueListBuilder<T>` and `ValueListStack<T>`. `ValueListBuilder<T>` is mostly derived from the internal type of the same name that's used in the .NET source code.
  * `DosPathBuilder` (as well as `ValueListBuilder<T>` and `ValueListStack<T>`) can only be used on the stack (and to other methods by reference) due to its performance-driven design. (It is able to utilize user supplied `stackalloc` buffers and/or other `Span<T>`-based buffers for improved efficiency and reduced heap allocations.)
* Refactored `DosPathResolver.GetFullDosPathIncludingRoot` method and added new overload methods utilizing the new `DosPathBuilder` type.
* Added new `DosPathResolver.TryGetDosDriveIndexFromDosPath` method and removed old `GetDosDrivePathFromDosPath` method that is now unnecessary.
* Updated `DosPathResolver.GetFullHostPathFromDosOrDefault` method so it does not throw an exception when an invalid path is given (caused by above changes).
* Updated `DosBatchExecutionEngine.TryHandleChdir` method to directly pass the user-supplied path argument into the `DosPathResolver.GetFullHostPathFromDosOrDefault` method and removed the `ResolveRelativeDosPath` workaround method.
* Updated tests in `DosBatchRoutingIntegrationTests` to include necessary sub-directory path parts which were exposed as test failures when the above DOS path-related changes were made. (Fixes #2148)
* A few minor improvements to `DosDriveManagerTests`.

### Rationale behind Changes
To fix path-related bugs in `DosPathResolver` and optimize performance.

I may have been a little bit overzealous with the optimizations to `DosBatchExecutionEngine.TryHandleChdir`, because it now utilizes `ReadOnlySpan<char>` for the path argument white space trimming and only creates the "trimmed" `String` object when it is necessary to use strings for other APIs.

### Suggested Testing Steps
Normal testing procedures.
