### PR TITLE
Fix/dos relative path regression

### DIFF
--- a/src/Spice86.Core/Emulator/OperatingSystem/Structures/DosPathBuilder.cs
+++ b/src/Spice86.Core/Emulator/OperatingSystem/Structures/DosPathBuilder.cs
@@ -292,6 +292,11 @@ internal ref struct DosPathBuilder {
         // DOS empty-extension marker: "NAME." canonicalizes to "NAME" (FreeDOS truename behavior).
         // ParseSpecialFileName has already validated that no more than one trailing dot is present.
         fileName = TrimTrailingEmptyExtensionDot(fileName);
+        if (fileName.Length >= 1 && fileName[^1] == '.') {
+            // Normalization exposed another trailing dot (for example "foo. ." -> "foo.").
+            // Keep this invalid to match FreeDOS multi-dot rejection semantics.
+            return DosPathBuilderResult.InvalidReservedFileName;
+        }
 
         // Append directory separator and file name.
         Debug.Assert(_pathBuilder.Length >= 2);
@@ -361,6 +366,12 @@ internal ref struct DosPathBuilder {
                 case DosSpecialFileName.None: {
                         // DOS empty-extension marker: "NAME." canonicalizes to "NAME" (FreeDOS truename).
                         ReadOnlySpan<char> appendElement = TrimTrailingEmptyExtensionDot(lastPathElement);
+                        if (appendElement.Length >= 1 && appendElement[^1] == '.') {
+                            // Normalization exposed another trailing dot (for example "foo. ." -> "foo.").
+                            // Keep this invalid to match FreeDOS multi-dot rejection semantics.
+                            endsWithDirectorySeparator = default;
+                            return DosPathBuilderResult.InvalidReservedFileName;
+                        }
                         // Append normal file name element.
                         Debug.Assert(_pathBuilder.Length >= 2);
                         _pathStack.Push(_pathBuilder.Length);

--- a/src/Spice86.Core/Emulator/OperatingSystem/Structures/DosPathBuilder.cs
+++ b/src/Spice86.Core/Emulator/OperatingSystem/Structures/DosPathBuilder.cs
@@ -443,16 +443,19 @@ internal ref struct DosPathBuilder {
     }
 
     /// <summary>
-    /// Strips a single trailing dot from a path segment. Matches FreeDOS <c>truename</c> behavior:
-    /// the trailing dot is the DOS empty-extension marker and is dropped during canonicalization.
+    /// Strips trailing whitespace and a single trailing empty-extension dot from a path segment.
+    /// Matches FreeDOS <c>truename</c> behavior: 8.3 directory entries are space-padded so trailing
+    /// spaces in a query naturally match the on-disk name, and a single trailing dot is the DOS
+    /// empty-extension marker which is dropped during canonicalization.
     /// </summary>
     /// <remarks>
     /// Callers must have already validated the segment via <see cref="ParseSpecialFileName"/>, so any
     /// double-trailing-dot case has been rejected before reaching this method.
     /// </remarks>
     private static ReadOnlySpan<char> TrimTrailingEmptyExtensionDot(ReadOnlySpan<char> fileName) {
+        fileName = fileName.TrimEnd();
         if (fileName.Length >= 1 && fileName[^1] == '.') {
-            return fileName[..^1];
+            fileName = fileName[..^1].TrimEnd();
         }
         return fileName;
     }
@@ -483,9 +486,13 @@ internal ref struct DosPathBuilder {
 
         Debug.Assert(!char.IsWhiteSpace(fileName[0]));
 
-        // Do not allow file names that end with white space.
-        if (char.IsWhiteSpace(fileName[^1])) {
-            return DosSpecialFileName.Invalid;
+        // Tolerate trailing whitespace: FreeDOS-style 8.3 directory entries are space-padded and
+        // callers commonly pass FCB-padded ASCIIZ buffers (e.g. AITD's TATOU.COM AH=3Dh Open).
+        // Strip it for the special-name classification below; the canonicalization step also
+        // strips it via TrimTrailingEmptyExtensionDot before appending to the path.
+        fileName = fileName.TrimEnd();
+        if (fileName.IsEmpty) {
+            return DosSpecialFileName.Empty;
         }
 
         // Ignore file extension if defined. Reserved names include file extensions. Also handle special/reserved file

--- a/src/Spice86.Core/Emulator/OperatingSystem/Structures/DosPathBuilder.cs
+++ b/src/Spice86.Core/Emulator/OperatingSystem/Structures/DosPathBuilder.cs
@@ -289,6 +289,10 @@ internal ref struct DosPathBuilder {
             return DosPathBuilderResult.InvalidReservedFileName;
         }
 
+        // DOS empty-extension marker: "NAME." canonicalizes to "NAME" (FreeDOS truename behavior).
+        // ParseSpecialFileName has already validated that no more than one trailing dot is present.
+        fileName = TrimTrailingEmptyExtensionDot(fileName);
+
         // Append directory separator and file name.
         Debug.Assert(_pathBuilder.Length >= 2);
         _pathStack.Push(_pathBuilder.Length);
@@ -355,11 +359,13 @@ internal ref struct DosPathBuilder {
             DosSpecialFileName specialFileName = ParseSpecialFileName(lastPathElement);
             switch (specialFileName) {
                 case DosSpecialFileName.None: {
+                        // DOS empty-extension marker: "NAME." canonicalizes to "NAME" (FreeDOS truename).
+                        ReadOnlySpan<char> appendElement = TrimTrailingEmptyExtensionDot(lastPathElement);
                         // Append normal file name element.
                         Debug.Assert(_pathBuilder.Length >= 2);
                         _pathStack.Push(_pathBuilder.Length);
                         _pathBuilder.Append(DirectorySeparatorChar);
-                        _pathBuilder.Append(lastPathElement);
+                        _pathBuilder.Append(appendElement);
                         break;
                     }
 
@@ -436,6 +442,21 @@ internal ref struct DosPathBuilder {
         return AppendRelativePath(rootedPath, out endsWithDirectorySeparator);
     }
 
+    /// <summary>
+    /// Strips a single trailing dot from a path segment. Matches FreeDOS <c>truename</c> behavior:
+    /// the trailing dot is the DOS empty-extension marker and is dropped during canonicalization.
+    /// </summary>
+    /// <remarks>
+    /// Callers must have already validated the segment via <see cref="ParseSpecialFileName"/>, so any
+    /// double-trailing-dot case has been rejected before reaching this method.
+    /// </remarks>
+    private static ReadOnlySpan<char> TrimTrailingEmptyExtensionDot(ReadOnlySpan<char> fileName) {
+        if (fileName.Length >= 1 && fileName[^1] == '.') {
+            return fileName[..^1];
+        }
+        return fileName;
+    }
+
     /// <summary>Attempts to parse special file names and performs basic sanity checks.</summary>
     /// <param name="fileName">File name to parse.</param>
     /// <returns>
@@ -481,15 +502,26 @@ internal ref struct DosPathBuilder {
                 }
             }
 
-            // Do not allow file names that end with a period (pedantic Windows naming convention). Special file names
-            // "." and ".." are handled above, so this should be safe.
+            // Do not allow file names that end with a period unless that period is the empty-extension marker.
+            // DOS semantics: a single trailing dot means "no extension" (FreeDOS truename strips it; see
+            // kernel/kernel/newstuff.c "strip trailing dot"). Multiple trailing dots remain ill-formed
+            // (FreeDOS PNE_DOT multi-dot rejection). Special file names "." and ".." are handled above.
             if (fileName[^1] == '.') {
-                return DosSpecialFileName.Invalid;
+                if (fileName.Length >= 2 && fileName[^2] == '.') {
+                    return DosSpecialFileName.Invalid;
+                }
+                // Single trailing dot: strip it and re-evaluate. If an inner dot remains, the prefix
+                // before it is the name segment (for reserved device-name detection). Otherwise the
+                // whole stripped value is the name segment.
+                fileName = fileName[..^1];
+                dotIndex = fileName.IndexOf('.');
             }
 
-            // Trim white space to be more pedantic by not allowing any reserved names that have white space at the end
-            // (before the file extension).
-            fileName = fileName[..dotIndex].TrimEnd();
+            if (dotIndex >= 0) {
+                // Trim white space to be more pedantic by not allowing any reserved names that have
+                // white space at the end (before the file extension).
+                fileName = fileName[..dotIndex].TrimEnd();
+            }
         }
 
         // Note that "COM¹", "COM²", "COM³", "LPT¹", "LPT²", and "LPT³" (using ISO/IEC 8859-1 superscript numbers) are

--- a/tests/Spice86.Tests/Dos/DosFileManagerTests.cs
+++ b/tests/Spice86.Tests/Dos/DosFileManagerTests.cs
@@ -232,4 +232,81 @@ public class DosFileManagerTests {
             Directory.Delete(mountPoint, recursive: true);
         }
     }
+
+    [Fact]
+    public void OpenFile_TrailingDot_OpensExtensionlessFile() {
+        // Regression: The Summoning calls INT 21h AH=3D with "V." to open a host file
+        // literally named "V" (no extension). DOS semantics: "FILE." == "FILE" with empty
+        // extension. FreeDOS truename strips a single trailing dot.
+
+        // Arrange
+        string mountPoint = CreateTempMountWithExtensionlessFile("V");
+        try {
+            using DosTestFixture fixture = new(mountPoint);
+
+            // Act
+            DosFileOperationResult result = fixture.DosFileManager.OpenFileOrDevice("V.", FileAccessMode.ReadOnly);
+
+            // Assert
+            result.IsError.Should().BeFalse(
+                "a DOS trailing-dot filename must resolve to the same on-disk file as the bare name");
+            CloseIfOpen(fixture, result);
+        } finally {
+            Directory.Delete(mountPoint, recursive: true);
+        }
+    }
+
+    [Fact]
+    public void OpenFile_BareNameMatchesExtensionlessFile() {
+        // Regression guard for the reverse direction: opening "V" must continue to work
+        // when the host file is literally "V" (no extension).
+
+        // Arrange
+        string mountPoint = CreateTempMountWithExtensionlessFile("V");
+        try {
+            using DosTestFixture fixture = new(mountPoint);
+
+            // Act
+            DosFileOperationResult result = fixture.DosFileManager.OpenFileOrDevice("V", FileAccessMode.ReadOnly);
+
+            // Assert
+            result.IsError.Should().BeFalse("a bare DOS name must open an extension-less host file");
+            CloseIfOpen(fixture, result);
+        } finally {
+            Directory.Delete(mountPoint, recursive: true);
+        }
+    }
+
+    [Fact]
+    public void OpenFile_DoubleTrailingDotIsRejected() {
+        // FreeDOS rejects multiple trailing dots (PNE_DOT). Ensure we surface a DOS error
+        // rather than silently matching or crashing.
+
+        // Arrange
+        string mountPoint = CreateTempMountWithExtensionlessFile("V");
+        try {
+            using DosTestFixture fixture = new(mountPoint);
+
+            // Act
+            DosFileOperationResult result = fixture.DosFileManager.OpenFileOrDevice("V..", FileAccessMode.ReadOnly);
+
+            // Assert
+            result.IsError.Should().BeTrue("multiple trailing dots are ill-formed in DOS file names");
+        } finally {
+            Directory.Delete(mountPoint, recursive: true);
+        }
+    }
+
+    private static string CreateTempMountWithExtensionlessFile(string fileName) {
+        string mountPoint = Path.Join(Path.GetTempPath(), $"Spice86_FM_Tests_{Guid.NewGuid()}");
+        Directory.CreateDirectory(mountPoint);
+        File.WriteAllText(Path.Join(mountPoint, fileName), "payload");
+        return mountPoint;
+    }
+
+    private static void CloseIfOpen(DosTestFixture fixture, DosFileOperationResult result) {
+        if (result.Value is uint handle) {
+            fixture.DosFileManager.CloseFileOrDevice((ushort)handle);
+        }
+    }
 }

--- a/tests/Spice86.Tests/Dos/DosFileManagerTests.cs
+++ b/tests/Spice86.Tests/Dos/DosFileManagerTests.cs
@@ -278,6 +278,31 @@ public class DosFileManagerTests {
     }
 
     [Fact]
+    public void OpenFile_TrailingSpaces_OpensSpacePaddedFile() {
+        // Regression: Alone in the Dark's TATOU.COM (launched by GO.BAT) passes an FCB-style
+        // space-padded ASCIIZ buffer ("Info.cc1            ") to INT 21h AH=3D. DOS semantics:
+        // trailing whitespace on a file name is silently tolerated (FreeDOS 8.3 entries are
+        // space-padded so trailing spaces match the padding). The canonicalized name must
+        // resolve to the same host file as the bare name.
+
+        // Arrange
+        string mountPoint = CreateTempMountWithExtensionlessFile("INFO.CC1");
+        try {
+            using DosTestFixture fixture = new(mountPoint);
+
+            // Act
+            DosFileOperationResult result = fixture.DosFileManager.OpenFileOrDevice("Info.cc1            ", FileAccessMode.ReadOnly);
+
+            // Assert
+            result.IsError.Should().BeFalse(
+                "a DOS filename with trailing spaces must resolve to the same on-disk file as the unpadded name");
+            CloseIfOpen(fixture, result);
+        } finally {
+            Directory.Delete(mountPoint, recursive: true);
+        }
+    }
+
+    [Fact]
     public void OpenFile_DoubleTrailingDotIsRejected() {
         // FreeDOS rejects multiple trailing dots (PNE_DOT). Ensure we surface a DOS error
         // rather than silently matching or crashing.

--- a/tests/Spice86.Tests/Dos/Structures/DosPathBuilderTests.cs
+++ b/tests/Spice86.Tests/Dos/Structures/DosPathBuilderTests.cs
@@ -16,7 +16,13 @@ public class DosPathBuilderTests {
     [InlineData(" foo", DosSpecialFileName.None)]
     [InlineData(".foo", DosSpecialFileName.None)]
     [InlineData("foo ", DosSpecialFileName.Invalid)]
-    [InlineData("foo.", DosSpecialFileName.Invalid)]
+    // DOS semantics: a single trailing dot means "no extension" (FreeDOS truename strips it).
+    // It is a valid file name, not an "Invalid"/reserved one. See kernel/kernel/newstuff.c "strip trailing dot".
+    [InlineData("foo.", DosSpecialFileName.None)]
+    [InlineData("foo.bar", DosSpecialFileName.None)]
+    // Two or more trailing dots are still ill-formed (matches FreeDOS PNE_DOT multi-dot rejection).
+    [InlineData("foo..", DosSpecialFileName.Invalid)]
+    [InlineData("foo...", DosSpecialFileName.Invalid)]
     [InlineData(".", DosSpecialFileName.CurrentDirectory)]
     [InlineData("..", DosSpecialFileName.ParentDirectory)]
     [InlineData("NUL", DosSpecialFileName.Null)]
@@ -102,6 +108,12 @@ public class DosPathBuilderTests {
     [InlineData('B', null, null, "'[f00]_", @"B:\'[f00]_")]
     [InlineData('B', null, "'[f00]_", null, @"B:\'[f00]_")]
     [InlineData('r', "foo;bar", null, null, @"R:\foo;bar")]
+    // DOS semantics: a single trailing dot on a path segment means "no extension"
+    // and is stripped during canonicalization (FreeDOS truename "strip trailing dot").
+    [InlineData('C', @"GAME\V.", null, null, @"C:\GAME\V")]
+    [InlineData('C', @"V.", null, null, @"C:\V")]
+    [InlineData('C', null, null, "V.", @"C:\V")]
+    [InlineData('C', @"FOO.\BAR.", null, null, @"C:\FOO\BAR")]
     public void BuildPath_Drive_Relative_Rooted_FileName(char driveLetter, string? appendRelativePath, string? appendRootedPathAfterRelative,
             string? appendFileName, string expectedPath) {
         // Arrange

--- a/tests/Spice86.Tests/Dos/Structures/DosPathBuilderTests.cs
+++ b/tests/Spice86.Tests/Dos/Structures/DosPathBuilderTests.cs
@@ -124,6 +124,7 @@ public class DosPathBuilderTests {
     [InlineData('C', null, null, "Info.cc1            ", @"C:\Info.cc1")]
     [InlineData('C', "GAME", null, "Info.cc1            ", @"C:\GAME\Info.cc1")]
     [InlineData('C', @"FOO  \BAR  ", null, null, @"C:\FOO\BAR")]
+    [InlineData('C', null, null, "foo .", @"C:\foo")]
     public void BuildPath_Drive_Relative_Rooted_FileName(char driveLetter, string? appendRelativePath, string? appendRootedPathAfterRelative,
             string? appendFileName, string expectedPath) {
         // Arrange
@@ -153,5 +154,38 @@ public class DosPathBuilderTests {
         resultFreeze2.Should().Be(DosPathBuilderResult.Success);
         resultPath.Should().Be(expectedPath);
         builder.IsFrozen.Should().BeTrue();
+    }
+
+    [Theory]
+    [InlineData("foo. .")]
+    [InlineData("foo.. .")]
+    public void AppendFileName_TrailingDotExposedByWhitespace_IsRejected(string fileName) {
+        // Arrange
+        using DosPathBuilder builder = new();
+        DosPathBuilderResult resultSetDriveLetter = builder.SetDriveLetter('C');
+
+        // Act
+        DosPathBuilderResult result = builder.AppendFileName(fileName);
+
+        // Assert
+        resultSetDriveLetter.Should().Be(DosPathBuilderResult.Success);
+        result.Should().Be(DosPathBuilderResult.InvalidReservedFileName);
+    }
+
+    [Theory]
+    [InlineData("foo. .")]
+    [InlineData("foo.. .")]
+    public void AppendRelativePath_TrailingDotExposedByWhitespace_IsRejected(string relativePath) {
+        // Arrange
+        using DosPathBuilder builder = new();
+        DosPathBuilderResult resultSetDriveLetter = builder.SetDriveLetter('C');
+
+        // Act
+        DosPathBuilderResult result = builder.AppendRelativePath(relativePath, out bool endsWithDirectorySeparator);
+
+        // Assert
+        resultSetDriveLetter.Should().Be(DosPathBuilderResult.Success);
+        result.Should().Be(DosPathBuilderResult.InvalidReservedFileName);
+        endsWithDirectorySeparator.Should().BeFalse();
     }
 }

--- a/tests/Spice86.Tests/Dos/Structures/DosPathBuilderTests.cs
+++ b/tests/Spice86.Tests/Dos/Structures/DosPathBuilderTests.cs
@@ -15,7 +15,12 @@ public class DosPathBuilderTests {
     [InlineData("foo", DosSpecialFileName.None)]
     [InlineData(" foo", DosSpecialFileName.None)]
     [InlineData(".foo", DosSpecialFileName.None)]
-    [InlineData("foo ", DosSpecialFileName.Invalid)]
+    // DOS semantics: trailing whitespace on a file name is silently stripped during canonicalization
+    // (FreeDOS 8.3 entries are space-padded; trailing spaces match naturally). It is a valid file name,
+    // not an "Invalid"/reserved one. AITD's TATOU.COM uses an FCB-padded buffer for AH=3Dh Open.
+    [InlineData("foo ", DosSpecialFileName.None)]
+    [InlineData("Info.cc1            ", DosSpecialFileName.None)]
+    [InlineData("FILE.EXT  ", DosSpecialFileName.None)]
     // DOS semantics: a single trailing dot means "no extension" (FreeDOS truename strips it).
     // It is a valid file name, not an "Invalid"/reserved one. See kernel/kernel/newstuff.c "strip trailing dot".
     [InlineData("foo.", DosSpecialFileName.None)]
@@ -114,6 +119,11 @@ public class DosPathBuilderTests {
     [InlineData('C', @"V.", null, null, @"C:\V")]
     [InlineData('C', null, null, "V.", @"C:\V")]
     [InlineData('C', @"FOO.\BAR.", null, null, @"C:\FOO\BAR")]
+    // DOS semantics: trailing whitespace on a path segment is stripped during canonicalization.
+    // AITD passes FCB-padded ASCIIZ filenames (e.g. "Info.cc1            ") to AH=3Dh Open.
+    [InlineData('C', null, null, "Info.cc1            ", @"C:\Info.cc1")]
+    [InlineData('C', "GAME", null, "Info.cc1            ", @"C:\GAME\Info.cc1")]
+    [InlineData('C', @"FOO  \BAR  ", null, null, @"C:\FOO\BAR")]
     public void BuildPath_Drive_Relative_Rooted_FileName(char driveLetter, string? appendRelativePath, string? appendRootedPathAfterRelative,
             string? appendFileName, string expectedPath) {
         // Arrange


### PR DESCRIPTION
### Description of Changes

Two bug fixes and standards compliance: aligns DOS path and file name handling with authentic DOS/FreeDOS canonicalization rules.

First commit fixes regression from 424217c085765c96e40550bbb01b78aa3a1a2758 and was fixed with TDD and checked against FreeDOS. It made The Summonning work again.

Second commit fixes regression from 53b9fe4fd88a682acc7d80c431dca5521b1d5f86 and was fixed with TDD and checked against FreeDOS. It made Alone in the Dark intro launch again.

### Rationale behind Changes

This PR updates DOS path and file name parsing to correctly handle trailing whitespace and dots, matching real DOS/FreeDOS behavior, and adds comprehensive tests for these cases.
- DosPathBuilder.cs: Implements stripping of trailing whitespace and single trailing dots, rejects multiple trailing dots, and updates special file name parsing.
- DosFileManagerTests.cs: Adds tests for trailing dot/space handling and double-dot rejection.
- DosPathBuilderTests.cs: Updates and expands tests to cover new canonicalization logic.

### Suggested Testing Steps

Already tested. Unit tests and integration tests in place. They were failing before the fixes.

Each commit was not done until the corresponding game worked again.
