### PR TITLE
fix: failing tests in Linux CI environment

### DIFF
--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -4,10 +4,10 @@
     <CentralPackageTransitivePinningEnabled>true</CentralPackageTransitivePinningEnabled>
   </PropertyGroup>
   <ItemGroup>
-    <PackageVersion Include="Avalonia" Version="12.0.2" />
-    <PackageVersion Include="Avalonia.Desktop" Version="12.0.2" />
-    <PackageVersion Include="Avalonia.Fonts.Inter" Version="12.0.2" />
-    <PackageVersion Include="Avalonia.Headless" Version="12.0.2" />
+    <PackageVersion Include="Avalonia" Version="12.0.3" />
+    <PackageVersion Include="Avalonia.Desktop" Version="12.0.3" />
+    <PackageVersion Include="Avalonia.Fonts.Inter" Version="12.0.3" />
+    <PackageVersion Include="Avalonia.Headless" Version="12.0.3" />
     <PackageVersion Include="AvaloniaUI.DiagnosticsSupport" Version="2.2.1" />
     <PackageVersion Include="AvaloniaGraphControl" Version="0.8.0" />
     <PackageVersion Include="AvaloniaHex" Version="0.1.13" />
@@ -32,7 +32,7 @@
     <PackageVersion Include="MeltySynth" Version="2.4.1" />
     <PackageVersion Include="ModelContextProtocol.AspNetCore" Version="1.3.0" />
     <PackageVersion Include="ModelContextProtocol.Core" Version="1.3.0" />
-    <PackageVersion Include="Microsoft.AspNetCore.OpenApi" Version="10.0.7" />
+    <PackageVersion Include="Microsoft.AspNetCore.OpenApi" Version="10.0.8" />
     <PackageVersion Include="Mt32emu.net" Version="1.0.0" />
     <PackageVersion Include="NSubstitute" Version="5.3.0" />
     <PackageVersion Include="NSubstitute.Analyzers.CSharp" Version="1.0.17" />

--- a/tests/Directory.Packages.props
+++ b/tests/Directory.Packages.props
@@ -1,30 +1,30 @@
 <Project>
-	<PropertyGroup>
-		<ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
-		<CentralPackageTransitivePinningEnabled>true</CentralPackageTransitivePinningEnabled>
-	</PropertyGroup>
-	<ItemGroup>
-		<PackageVersion Include="coverlet.collector" Version="10.0.0" />
-		<PackageVersion Include="ErrorProne.NET.CoreAnalyzers" Version="0.1.2" />
-		<PackageVersion Include="FluentAssertions" Version="8.9.0" />
-		<PackageVersion Include="JetBrains.Annotations" Version="2025.2.4" />
-		<PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.5.1" />
-		<PackageVersion Include="NSubstitute" Version="5.3.0" />
-		<PackageVersion Include="NSubstitute.Analyzers.CSharp" Version="1.0.17" />
-		<PackageVersion Include="Roslynator.Analyzers" Version="4.15.0" />
-		<PackageVersion Include="Roslynator.CodeAnalysis.Analyzers" Version="4.15.0" />
-		<PackageVersion Include="SingleStepTests.Intel80386.00-65" Version="2025.11.5" />
-		<PackageVersion Include="SingleStepTests.Intel80386.66-66" Version="2025.11.5" />
-		<PackageVersion Include="SingleStepTests.Intel80386.67.00-67.7F" Version="2025.11.5" />
-		<PackageVersion Include="SingleStepTests.Intel80386.67.80-67.FF" Version="2025.11.5" />
-		<PackageVersion Include="SingleStepTests.Intel80386.68-FF" Version="2025.11.5" />
-		<PackageVersion Include="System.Text.Json" Version="10.0.0" />
-		<PackageVersion Include="Avalonia.Headless" Version="12.0.2" />
-		<PackageVersion Include="Avalonia.Headless.XUnit" Version="12.0.2" />
-		<PackageVersion Include="xunit" Version="2.9.3" />
-		<PackageVersion Include="xunit.v3" Version="3.2.2" />
-		<PackageVersion Include="xunit.runner.visualstudio" Version="3.1.5" />
-		<PackageVersion Include="Xunit.SkippableFact" Version="1.5.61" />
-		<PackageVersion Include="Tmds.DBus.Protocol" Version="0.92.0" />
-	</ItemGroup>
+  <PropertyGroup>
+    <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
+    <CentralPackageTransitivePinningEnabled>true</CentralPackageTransitivePinningEnabled>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageVersion Include="coverlet.collector" Version="10.0.0" />
+    <PackageVersion Include="ErrorProne.NET.CoreAnalyzers" Version="0.1.2" />
+    <PackageVersion Include="FluentAssertions" Version="8.10.0" />
+    <PackageVersion Include="JetBrains.Annotations" Version="2025.2.4" />
+    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.5.1" />
+    <PackageVersion Include="NSubstitute" Version="5.3.0" />
+    <PackageVersion Include="NSubstitute.Analyzers.CSharp" Version="1.0.17" />
+    <PackageVersion Include="Roslynator.Analyzers" Version="4.15.0" />
+    <PackageVersion Include="Roslynator.CodeAnalysis.Analyzers" Version="4.15.0" />
+    <PackageVersion Include="SingleStepTests.Intel80386.00-65" Version="2025.11.5" />
+    <PackageVersion Include="SingleStepTests.Intel80386.66-66" Version="2025.11.5" />
+    <PackageVersion Include="SingleStepTests.Intel80386.67.00-67.7F" Version="2025.11.5" />
+    <PackageVersion Include="SingleStepTests.Intel80386.67.80-67.FF" Version="2025.11.5" />
+    <PackageVersion Include="SingleStepTests.Intel80386.68-FF" Version="2025.11.5" />
+    <PackageVersion Include="System.Text.Json" Version="10.0.0" />
+    <PackageVersion Include="Avalonia.Headless" Version="12.0.3" />
+    <PackageVersion Include="Avalonia.Headless.XUnit" Version="12.0.3" />
+    <PackageVersion Include="xunit" Version="2.9.3" />
+    <PackageVersion Include="xunit.v3" Version="3.2.2" />
+    <PackageVersion Include="xunit.runner.visualstudio" Version="3.1.5" />
+    <PackageVersion Include="Xunit.SkippableFact" Version="1.5.61" />
+    <PackageVersion Include="Tmds.DBus.Protocol" Version="0.92.0" />
+  </ItemGroup>
 </Project>

--- a/tests/Spice86.Tests/UI/ExpressionEvaluatorUITests.cs
+++ b/tests/Spice86.Tests/UI/ExpressionEvaluatorUITests.cs
@@ -1,7 +1,5 @@
 namespace Spice86.Tests.UI;
 
-using Avalonia.Headless.XUnit;
-
 using FluentAssertions;
 
 using Iced.Intel;
@@ -59,7 +57,7 @@ public class ExpressionEvaluatorUITests : BreakpointUiTestBase {
     /// Verifies that register operands are evaluated for MOV reg, reg.
     /// ASM: mov ax, bx (opcode 89 D8)
     /// </summary>
-    [AvaloniaFact]
+    [Fact]
     public void EvaluateOperands_MovAxBx_ShowsBothRegisterValues() {
         // Arrange
         State state = CreateState();
@@ -95,7 +93,7 @@ public class ExpressionEvaluatorUITests : BreakpointUiTestBase {
     /// Verifies that memory operands are evaluated for MOV reg, [mem].
     /// ASM: mov ax, [bx] (opcode 8B 07) with DS:BX pointing to 0xABCD.
     /// </summary>
-    [AvaloniaFact]
+    [Fact]
     public void EvaluateOperands_MovAxMemBx_ShowsMemoryValue() {
         // Arrange
         State state = CreateState();
@@ -134,7 +132,7 @@ public class ExpressionEvaluatorUITests : BreakpointUiTestBase {
     /// Verifies that immediates are NOT evaluated (they are already visible in disassembly text).
     /// ASM: mov ax, 0x1234 (opcode B8 34 12) - only AX should appear in evaluation.
     /// </summary>
-    [AvaloniaFact]
+    [Fact]
     public void EvaluateOperands_MovAxImm_OnlyShowsDestRegister() {
         // Arrange
         State state = CreateState();
@@ -165,7 +163,7 @@ public class ExpressionEvaluatorUITests : BreakpointUiTestBase {
     /// Verifies that memory with displacement is correctly evaluated.
     /// ASM: mov ax, word ptr [bx+0x10] (opcode 8B 47 10)
     /// </summary>
-    [AvaloniaFact]
+    [Fact]
     public void EvaluateOperands_MovAxMemBxDisp_ShowsMemoryValue() {
         // Arrange
         State state = CreateState();
@@ -203,7 +201,7 @@ public class ExpressionEvaluatorUITests : BreakpointUiTestBase {
     /// Verifies that LEA computes the effective address instead of reading memory.
     /// ASM: lea ax, [bp-8] (opcode 8D 46 F8) - should show computed address, not memory contents.
     /// </summary>
-    [AvaloniaFact]
+    [Fact]
     public void EvaluateOperands_LeaAxBpMinus8_ShowsEffectiveAddress() {
         // Arrange
         State state = CreateState();
@@ -244,7 +242,7 @@ public class ExpressionEvaluatorUITests : BreakpointUiTestBase {
     /// Verifies LEA with base+index computes the effective address.
     /// ASM: lea ax, [bx+si] (opcode 8D 00)
     /// </summary>
-    [AvaloniaFact]
+    [Fact]
     public void EvaluateOperands_LeaAxBxSi_ShowsEffectiveAddress() {
         // Arrange
         State state = CreateState();
@@ -277,7 +275,7 @@ public class ExpressionEvaluatorUITests : BreakpointUiTestBase {
     /// Verifies that LDS evaluates the far pointer memory operand (dword containing offset:segment).
     /// ASM: lds si, ss:[bp+0x10] (opcode C5 76 10) - should show the dword value at memory.
     /// </summary>
-    [AvaloniaFact]
+    [Fact]
     public void EvaluateOperands_LdsSiBpPlus10_ShowsFarPointerValue() {
         // Arrange
         State state = CreateState();
@@ -318,7 +316,7 @@ public class ExpressionEvaluatorUITests : BreakpointUiTestBase {
     /// ASM: div word [bp-0xE] (opcode F7 76 F2) with SS=0, BP=0x0100 and divisor 0xE4C3 at SS:BP-0xE.
     /// The display label must show BP-0xE, not BP+0xFFF2.
     /// </summary>
-    [AvaloniaFact]
+    [Fact]
     public void EvaluateOperands_DivWordBpMinusE_ShowsNegativeDisplacementAndCorrectValue() {
         // Arrange
         State state = CreateState();
@@ -359,7 +357,7 @@ public class ExpressionEvaluatorUITests : BreakpointUiTestBase {
     /// Verifies that CALL dword ptr [mem] evaluates the far pointer memory operand.
     /// ASM: call dword ptr ss:[bp-4] (opcode FF 5E FC) - should show the target address.
     /// </summary>
-    [AvaloniaFact]
+    [Fact]
     public void EvaluateOperands_CallFarPtrBpMinus4_ShowsFarPointerValue() {
         // Arrange
         State state = CreateState();


### PR DESCRIPTION
### Description of Changes

Replaces AvaloniaFact with Fact on ExpressionEvaluatorService tests in the Spice86 UI tests.

Updates Nuget packages for Avalonia, FluentAssertions, and ASP .NET Core OpenAPI.

### Rationale behind Changes

Makes CI on Linux useful again.
