### PR TITLE
fix: Put correct types for far pointers in structs

### DIFF
--- a/src/Spice86.Core/Emulator/Devices/Video/VideoFunctionalityInfo.cs
+++ b/src/Spice86.Core/Emulator/Devices/Video/VideoFunctionalityInfo.cs
@@ -2,6 +2,7 @@
 
 using Spice86.Core.Emulator.Memory.ReaderWriter;
 using Spice86.Core.Emulator.ReverseEngineer.DataStructure;
+using Spice86.Shared.Emulator.Memory;
 
 using System.ComponentModel.DataAnnotations;
 
@@ -21,7 +22,7 @@ public class VideoFunctionalityInfo : MemoryBasedDataStructure {
     /// <summary>
     ///     Gets or sets the address of the Saved Functionality Table (SFT) in memory.
     /// </summary>
-    public uint SftAddress { get => UInt32[0x00]; set => UInt32[0x00] = value; }
+    public SegmentedAddress SftAddress { get => SegmentedAddress16[0x00]; set => SegmentedAddress16[0x00] = value; }
 
     /// <summary>
     ///     Gets or sets the current video mode.

--- a/src/Spice86.Core/Emulator/InterruptHandlers/VGA/VgaBios.cs
+++ b/src/Spice86.Core/Emulator/InterruptHandlers/VGA/VgaBios.cs
@@ -670,7 +670,7 @@ public class VgaBios : InterruptHandler, IVideoInt10Handler {
 
         uint address = MemoryUtils.ToPhysicalAddress(segment, offset);
         var info = new VideoFunctionalityInfo(Memory, address) {
-            SftAddress = MemoryMap.StaticFunctionalityTableSegment << 16,
+            SftAddress = new SegmentedAddress(MemoryMap.StaticFunctionalityTableSegment, 0),
             VideoMode = _biosDataArea.VideoMode,
             ScreenColumns = _biosDataArea.ScreenColumns,
             VideoBufferLength = _biosDataArea.VideoPageSize,

--- a/src/Spice86.Core/Emulator/OperatingSystem/Dos.cs
+++ b/src/Spice86.Core/Emulator/OperatingSystem/Dos.cs
@@ -192,9 +192,10 @@ public sealed class Dos {
         DosSysVars = new DosSysVars(configuration, (NullDevice)dosDevices[0], memory,
             MemoryUtils.ToPhysicalAddress(DosSysVars.Segment, 0x0));
 
-        DosSysVars.ConsoleDeviceHeaderPointer = ((IVirtualDevice)dosDevices[1]).Header.BaseAddress;
+        // Item 1 of devices array
+        DosSysVars.ConsoleDeviceHeaderPointer = new SegmentedAddress(MemoryMap.DeviceDriversSegment, (ushort)(1 * DosDeviceHeader.HeaderLength));
         SegmentedAddress cdsAddress = DosTables.CdsSegmentedAddress;
-        DosSysVars.CurrentDirectoryStructureListPointer = (uint)(cdsAddress.Segment << 16 | cdsAddress.Offset);
+        DosSysVars.CurrentDirectoryStructureListPointer = cdsAddress;
         DosSysVars.CurrentDirectoryStructureCount = 26;
 
         DosSwappableDataArea = new(_memory,

--- a/src/Spice86.Core/Emulator/OperatingSystem/DosProcessManager.cs
+++ b/src/Spice86.Core/Emulator/OperatingSystem/DosProcessManager.cs
@@ -268,26 +268,26 @@ public class DosProcessManager : IDosBatchExecutionHost, ICurrentProcessNameProv
 
         // Root PSP: parent points to itself
         rootPsp.ParentProgramSegmentPrefix = CommandComSegment;
-        rootPsp.PreviousPspAddress = MemoryUtils.To32BitAddress(SentinelSegment, SentinelOffset);
+        rootPsp.PreviousPspAddress = new SegmentedAddress(SentinelSegment, SentinelOffset);
 
         rootPsp.FarCall = FarCallOpcode;
-        rootPsp.CpmServiceRequestAddress = MemoryUtils.To32BitAddress(CommandComSegment, Call5StubOffset);
+        rootPsp.CpmServiceRequestAddress = new SegmentedAddress(CommandComSegment, Call5StubOffset);
         rootPsp.Service[0] = IntOpcode;
         rootPsp.Service[1] = Int21Number;
         rootPsp.Service[2] = RetfOpcode;
 
         // Initialize interrupt vectors from IVT so child PSPs inherit proper addresses
         SegmentedAddress int22 = _interruptVectorTable[TerminateVectorNumber];
-        rootPsp.TerminateAddress = MemoryUtils.To32BitAddress(int22.Segment, int22.Offset);
+        rootPsp.TerminateAddress = int22;
 
         SegmentedAddress int23 = _interruptVectorTable[CtrlBreakVectorNumber];
-        rootPsp.BreakAddress = MemoryUtils.To32BitAddress(int23.Segment, int23.Offset);
+        rootPsp.BreakAddress = int23;
 
         SegmentedAddress int24 = _interruptVectorTable[CriticalErrorVectorNumber];
-        rootPsp.CriticalErrorAddress = MemoryUtils.To32BitAddress(int24.Segment, int24.Offset);
+        rootPsp.CriticalErrorAddress = int24;
 
         rootPsp.MaximumOpenFiles = DosFileManager.MaxOpenFilesPerProcess;
-        rootPsp.FileTableAddress = MemoryUtils.To32BitAddress(CommandComSegment, FileTableOffset);
+        rootPsp.FileTableAddress = new SegmentedAddress(CommandComSegment, FileTableOffset);
 
         rootPsp.DosVersionMajor = DefaultDosVersionMajor;
         rootPsp.DosVersionMinor = DefaultDosVersionMinor;
@@ -434,7 +434,7 @@ public class DosProcessManager : IDosBatchExecutionHost, ICurrentProcessNameProv
         // FreeDOS: parent PSP's ps_stack field stores the parent's current iregs frame (only for LoadAndExecute).
         if (loadType == DosExecLoadType.LoadAndExecute) {
             DosProgramSegmentPrefix parentPsp = new(_memory, MemoryUtils.ToPhysicalAddress(parentPspSegment, 0));
-            parentPsp.StackPointer = MemoryUtils.To32BitAddress(parentSS, parentReservedSP);
+            parentPsp.StackPointer = new SegmentedAddress(parentSS, parentReservedSP);
         }
         CopyFcbFromPointer(paramBlock.FirstFcbPointer, exePsp.FirstFileControlBlock);
         CopyFcbFromPointer(paramBlock.SecondFcbPointer, exePsp.SecondFileControlBlock);
@@ -492,7 +492,7 @@ public class DosProcessManager : IDosBatchExecutionHost, ICurrentProcessNameProv
         // FreeDOS: parent PSP's ps_stack field stores the parent's current iregs frame (only for LoadAndExecute).
         if (loadType == DosExecLoadType.LoadAndExecute) {
             DosProgramSegmentPrefix parentPspForCom = new(_memory, MemoryUtils.ToPhysicalAddress(parentPspSegment, 0));
-            parentPspForCom.StackPointer = MemoryUtils.To32BitAddress(parentSS, parentReservedSP);
+            parentPspForCom.StackPointer = new SegmentedAddress(parentSS, parentReservedSP);
         }
         CopyFcbFromPointer(paramBlock.FirstFcbPointer, comPsp.FirstFileControlBlock);
         CopyFcbFromPointer(paramBlock.SecondFcbPointer, comPsp.SecondFileControlBlock);
@@ -647,9 +647,9 @@ public class DosProcessManager : IDosBatchExecutionHost, ICurrentProcessNameProv
         }
 
         // Get interrupt vectors from current PSP before PopCurrentPspSegment call
-        uint terminateAddr = currentPsp.TerminateAddress;
-        uint breakAddr = currentPsp.BreakAddress;
-        uint criticalErrorAddr = currentPsp.CriticalErrorAddress;
+        SegmentedAddress terminateAddr = currentPsp.TerminateAddress;
+        SegmentedAddress breakAddr = currentPsp.BreakAddress;
+        SegmentedAddress criticalErrorAddr = currentPsp.CriticalErrorAddress;
         // Restore interrupt vectors from those values
         RestoreInterruptVector(TerminateVectorNumber, terminateAddr);
         RestoreInterruptVector(CtrlBreakVectorNumber, breakAddr);
@@ -666,12 +666,12 @@ public class DosProcessManager : IDosBatchExecutionHost, ICurrentProcessNameProv
         }
 
         // FreeDOS return_user: restore SS:SP from parent's ps_stack, patch with child's ps_isv22.
-        uint parentStackPtr = parentPsp.StackPointer;
-        _state.SS = (ushort)(parentStackPtr >> 16);
-        _state.SP = (ushort)(parentStackPtr & 0xFFFF);
+        SegmentedAddress parentStackPtr = parentPsp.StackPointer;
+        _state.SS = parentStackPtr.Segment;
+        _state.SP = parentStackPtr.Offset;
         // Patch the iregs frame with child's TerminateAddress (INT 22h vector).
-        _stack.Poke16(0, (ushort)(terminateAddr & 0xFFFF));
-        _stack.Poke16(2, (ushort)(terminateAddr >> 16));
+        _stack.Poke16(0, terminateAddr.Offset);
+        _stack.Poke16(2, terminateAddr.Segment);
 
         if (_loggerService.IsEnabled(LogEventLevel.Information)) {
             _loggerService.Information("TERMINATE: restored parent context SS:SP={0:X4}:{1:X4}, return CS:IP={2:X4}:{3:X4}",
@@ -748,14 +748,9 @@ public class DosProcessManager : IDosBatchExecutionHost, ICurrentProcessNameProv
         newPsp.ParentProgramSegmentPrefix = currentPspSegment;
         newPsp.EnvironmentTableSegment = currentPsp.EnvironmentTableSegment;
 
-        SegmentedAddress int22 = _interruptVectorTable[TerminateVectorNumber];
-        newPsp.TerminateAddress = MemoryUtils.To32BitAddress(int22.Segment, int22.Offset);
-
-        SegmentedAddress int23 = _interruptVectorTable[CtrlBreakVectorNumber];
-        newPsp.BreakAddress = MemoryUtils.To32BitAddress(int23.Segment, int23.Offset);
-
-        SegmentedAddress int24 = _interruptVectorTable[CriticalErrorVectorNumber];
-        newPsp.CriticalErrorAddress = MemoryUtils.To32BitAddress(int24.Segment, int24.Offset);
+        newPsp.TerminateAddress = _interruptVectorTable[TerminateVectorNumber];
+        newPsp.BreakAddress = _interruptVectorTable[CtrlBreakVectorNumber];
+        newPsp.CriticalErrorAddress = _interruptVectorTable[CriticalErrorVectorNumber];
 
         newPsp.DosVersionMajor = DefaultDosVersionMajor;
         newPsp.DosVersionMinor = DefaultDosVersionMinor;
@@ -780,14 +775,14 @@ public class DosProcessManager : IDosBatchExecutionHost, ICurrentProcessNameProv
 
         // Parent/previous links.
         childPsp.ParentProgramSegmentPrefix = parentPspSegment;
-        childPsp.PreviousPspAddress = MemoryUtils.To32BitAddress(parentPspSegment, 0);
+        childPsp.PreviousPspAddress = new SegmentedAddress(parentPspSegment, 0);
 
         // Size/next segment (ps_size in FreeDOS).
         childPsp.CurrentSize = sizeInParagraphs;
 
         // File table layout and cloning (start unused then clone handles).
         childPsp.MaximumOpenFiles = DosFileManager.MaxOpenFilesPerProcess;
-        childPsp.FileTableAddress = MemoryUtils.To32BitAddress(childSegment, FileTableOffset);
+        childPsp.FileTableAddress = new SegmentedAddress(childSegment, FileTableOffset);
         for (int i = 0; i < JobFileTableLength; i++) {
             childPsp.Files[i] = UnusedFileHandle;
         }
@@ -806,29 +801,22 @@ public class DosProcessManager : IDosBatchExecutionHost, ICurrentProcessNameProv
 
         // Keep INT 21h entry and CP/M far call consistent with FreeDOS child_psp.
         childPsp.FarCall = FarCallOpcode;
-        childPsp.CpmServiceRequestAddress = MemoryUtils.To32BitAddress(childSegment, Call5StubOffset);
+        childPsp.CpmServiceRequestAddress = new SegmentedAddress(childSegment, Call5StubOffset);
         childPsp.Service[0] = IntOpcode;
         childPsp.Service[1] = Int21Number;
         childPsp.Service[2] = RetfOpcode;
     }
 
-    private void RestoreInterruptVector(byte vectorNumber, uint storedFarPointer) {
-        if (storedFarPointer != 0) {
-            ushort offset = (ushort)(storedFarPointer & 0xFFFF);
-            ushort segment = (ushort)(storedFarPointer >> 16);
-            _interruptVectorTable[vectorNumber] = new SegmentedAddress(segment, offset);
+    private void RestoreInterruptVector(byte vectorNumber, SegmentedAddress storedFarPointer) {
+        if (storedFarPointer != SegmentedAddress.ZERO) {
+            _interruptVectorTable[vectorNumber] = storedFarPointer;
         }
     }
 
     private void SaveInterruptVectors(DosProgramSegmentPrefix psp) {
-        SegmentedAddress int22 = _interruptVectorTable[TerminateVectorNumber];
-        psp.TerminateAddress = MemoryUtils.To32BitAddress(int22.Segment, int22.Offset);
-
-        SegmentedAddress int23 = _interruptVectorTable[CtrlBreakVectorNumber];
-        psp.BreakAddress = MemoryUtils.To32BitAddress(int23.Segment, int23.Offset);
-
-        SegmentedAddress int24 = _interruptVectorTable[CriticalErrorVectorNumber];
-        psp.CriticalErrorAddress = MemoryUtils.To32BitAddress(int24.Segment, int24.Offset);
+        psp.TerminateAddress = _interruptVectorTable[TerminateVectorNumber];
+        psp.BreakAddress = _interruptVectorTable[CtrlBreakVectorNumber];
+        psp.CriticalErrorAddress = _interruptVectorTable[CriticalErrorVectorNumber];
     }
 
     private void CopyFileTableFromParent(DosProgramSegmentPrefix childPsp, DosProgramSegmentPrefix parentPsp) {
@@ -992,7 +980,7 @@ public class DosProcessManager : IDosBatchExecutionHost, ICurrentProcessNameProv
         psp.CurrentSize = (ushort)(pspSegment + blockSizeInParagraphs);
 
         psp.FarCall = FarCallOpcode;
-        psp.CpmServiceRequestAddress = MemoryUtils.To32BitAddress(pspSegment, Call5StubOffset);
+        psp.CpmServiceRequestAddress = new SegmentedAddress(pspSegment, Call5StubOffset);
         psp.Service[0] = IntOpcode;
         psp.Service[1] = Int21Number;
         psp.Service[2] = RetfOpcode;
@@ -1000,18 +988,16 @@ public class DosProcessManager : IDosBatchExecutionHost, ICurrentProcessNameProv
         psp.DosVersionMinor = DefaultDosVersionMinor;
 
         // This sets INT 22h to point to the CALLER'S return address
-        psp.TerminateAddress = MemoryUtils.To32BitAddress(callerCS, callerIP);
+        psp.TerminateAddress = new SegmentedAddress(callerCS, callerIP);
 
-        SegmentedAddress breakVector = _interruptVectorTable[CtrlBreakVectorNumber];
-        SegmentedAddress criticalErrorVector = _interruptVectorTable[CriticalErrorVectorNumber];
-        psp.BreakAddress = MemoryUtils.To32BitAddress(breakVector.Segment, breakVector.Offset);
-        psp.CriticalErrorAddress = MemoryUtils.To32BitAddress(criticalErrorVector.Segment, criticalErrorVector.Offset);
+        psp.BreakAddress = _interruptVectorTable[CtrlBreakVectorNumber];
+        psp.CriticalErrorAddress = _interruptVectorTable[CriticalErrorVectorNumber];
 
         psp.ParentProgramSegmentPrefix = parentPspSegment;
         psp.MaximumOpenFiles = DosFileManager.MaxOpenFilesPerProcess;
         // file table address points to file table at offset FileTableOffset inside this PSP
-        psp.FileTableAddress = MemoryUtils.To32BitAddress(pspSegment, FileTableOffset);
-        psp.PreviousPspAddress = MemoryUtils.To32BitAddress(parentPspSegment, 0);
+        psp.FileTableAddress = new SegmentedAddress(pspSegment, FileTableOffset);
+        psp.PreviousPspAddress = new SegmentedAddress(parentPspSegment, 0);
 
         for (int i = 0; i < psp.Files.Count; i++) {
             psp.Files[i] = (byte)Enums.DosPspFileTableEntry.Unused;

--- a/src/Spice86.Core/Emulator/OperatingSystem/Structures/DosProgramSegmentPrefix.cs
+++ b/src/Spice86.Core/Emulator/OperatingSystem/Structures/DosProgramSegmentPrefix.cs
@@ -3,6 +3,7 @@
 using Spice86.Core.Emulator.Memory.ReaderWriter;
 using Spice86.Core.Emulator.ReverseEngineer.DataStructure;
 using Spice86.Core.Emulator.ReverseEngineer.DataStructure.Array;
+using Spice86.Shared.Emulator.Memory;
 
 using System.Diagnostics;
 
@@ -51,22 +52,22 @@ public sealed class DosProgramSegmentPrefix : MemoryBasedDataStructure {
     /// </summary>
     public byte FarCall { get => UInt8[0x5]; set => UInt8[0x5] = value; }
 
-    public uint CpmServiceRequestAddress { get => UInt32[0x6]; set => UInt32[0x6] = value; }
+    public SegmentedAddress CpmServiceRequestAddress { get => SegmentedAddress16[0x6]; set => SegmentedAddress16[0x6] = value; }
 
     /// <summary>
     /// On exit, DOS copies this to the INT 0x22 vector.
     /// </summary>
-    public uint TerminateAddress { get => UInt32[0x0A]; set => UInt32[0x0A] = value; }
+    public SegmentedAddress TerminateAddress { get => SegmentedAddress16[0x0A]; set => SegmentedAddress16[0x0A] = value; }
 
     /// <summary>
     /// On exit, DOS copies this to the INT 0x23 vector.
     /// </summary>
-    public uint BreakAddress { get => UInt32[0x0E]; set => UInt32[0x0E] = value; }
+    public SegmentedAddress BreakAddress { get => SegmentedAddress16[0x0E]; set => SegmentedAddress16[0x0E] = value; }
 
     /// <summary>
     /// On exit, DOS copies this to the INT 0x24 vector.
     /// </summary>
-    public uint CriticalErrorAddress { get => UInt32[0x12]; set => UInt32[0x12] = value; }
+    public SegmentedAddress CriticalErrorAddress { get => SegmentedAddress16[0x12]; set => SegmentedAddress16[0x12] = value; }
 
     /// <summary>
     /// Segment of PSP of parent program.
@@ -77,13 +78,13 @@ public sealed class DosProgramSegmentPrefix : MemoryBasedDataStructure {
 
     public ushort EnvironmentTableSegment { get => UInt16[0x2C]; set => UInt16[0x2C] = value; }
 
-    public uint StackPointer { get => UInt32[0x2E]; set => UInt32[0x2E] = value; }
+    public SegmentedAddress StackPointer { get => SegmentedAddress16[0x2E]; set => SegmentedAddress16[0x2E] = value; }
 
     public ushort MaximumOpenFiles { get => UInt16[0x32]; set => UInt16[0x32] = value; }
 
-    public uint FileTableAddress { get => UInt32[0x34]; set => UInt32[0x34] = value; }
+    public SegmentedAddress FileTableAddress { get => SegmentedAddress16[0x34]; set => SegmentedAddress16[0x34] = value; }
 
-    public uint PreviousPspAddress { get => UInt32[0x38]; set => UInt32[0x38] = value; }
+    public SegmentedAddress PreviousPspAddress { get => SegmentedAddress16[0x38]; set => SegmentedAddress16[0x38] = value; }
 
     public byte InterimFlag { get => UInt8[0x3C]; set => UInt8[0x3C] = value; }
 

--- a/src/Spice86.Core/Emulator/OperatingSystem/Structures/DosSwappableDataArea.cs
+++ b/src/Spice86.Core/Emulator/OperatingSystem/Structures/DosSwappableDataArea.cs
@@ -2,6 +2,7 @@
 
 using Spice86.Core.Emulator.Memory.ReaderWriter;
 using Spice86.Core.Emulator.ReverseEngineer.DataStructure;
+using Spice86.Shared.Emulator.Memory;
 
 /// <summary>
 /// Represents a DOS SDA (Swappable Data Area) in emulated memory.
@@ -71,17 +72,17 @@ public sealed class DosSwappableDataArea : MemoryBasedDataStructure {
     /// <summary>
     /// Gets or sets the ES:DI pointer for the last error.
     /// </summary>
-    public uint LastErrorPointer {
-        get => UInt32[0x8];
-        set => UInt32[0x8] = value;
+    public SegmentedAddress LastErrorPointer {
+        get => SegmentedAddress16[0x8];
+        set => SegmentedAddress16[0x8] = value;
     }
 
     /// <summary>
     /// Gets or sets the current DTA (Disk Transfer Area).
     /// </summary>
-    public uint CurrentDiskTransferArea {
-        get => UInt32[0xC];
-        set => UInt32[0xC] = value;
+    public SegmentedAddress CurrentDiskTransferArea {
+        get => SegmentedAddress16[0xC];
+        set => SegmentedAddress16[0xC] = value;
     }
 
     /// <summary>

--- a/src/Spice86.Core/Emulator/OperatingSystem/Structures/DosSysVars.cs
+++ b/src/Spice86.Core/Emulator/OperatingSystem/Structures/DosSysVars.cs
@@ -6,6 +6,7 @@ using Spice86.Core.Emulator.Memory.ReaderWriter;
 using Spice86.Core.Emulator.OperatingSystem.Devices;
 using Spice86.Core.Emulator.ReverseEngineer.DataStructure;
 using Spice86.Core.Emulator.ReverseEngineer.DataStructure.Array;
+using Spice86.Shared.Emulator.Memory;
 using Spice86.Shared.Utils;
 
 /// <summary>
@@ -37,7 +38,7 @@ public class DosSysVars : MemoryBasedDataStructure {
         : base(byteReaderWriter, baseAddress) {
         _nullDeviceHeader = nullDevice.Header;
         CopyArray(_nullDeviceHeader, OfficialOffset + 0x22);
-        ClockDeviceHeaderPointer = 0x0;
+        ClockDeviceHeaderPointer = SegmentedAddress.ZERO;
         MagicWord = 0x1;
         BootDrive = 0x0;
         if (configuration.Xms is not false) {
@@ -58,20 +59,20 @@ public class DosSysVars : MemoryBasedDataStructure {
         PtrCONInput = 0x0;
         FirstMCB = FirstMcbSegment;
         DirtyDiskBuffers = 0x0;
-        LookaheadBufPt = 0x0;
+        LookaheadBufPt = SegmentedAddress.ZERO;
         LookaheadBufNumber = 0x0;
         BufferLocation = 0x0;
-        WorkspaceBuffer = 0x0;
+        WorkspaceBuffer = SegmentedAddress.ZERO;
         StartOfUMBChain = 0xFFFF;
         ChainingUMB = 0x0;
         DwordMoveFlag386 = 0x1;
         LastProgramPspSegment = 0x0;
         NumberOfBuffers = 0x50;
         NumberOfLookaheadBuffers = 0x50;
-        SetVerTablePointer = 0x0;
+        SetVerTablePointer = SegmentedAddress.ZERO;
         JoinedDriveCount = 0x0;
         DiskParameterBlockCount = 0x1;
-        DiskBufferPointer = 0x0;
+        DiskBufferPointer = SegmentedAddress.ZERO;
         SpecialCodeSegment = 0x0;
     }
 
@@ -123,9 +124,9 @@ public class DosSysVars : MemoryBasedDataStructure {
     /// <summary>
     /// Gets or sets pointer to disk buffer
     /// </summary>
-    public uint DiskBufferPointer {
-        get => UInt32[OfficialOffset - 0x08];
-        set => UInt32[OfficialOffset - 0x08] = value;
+    public SegmentedAddress DiskBufferPointer {
+        get => SegmentedAddress16[OfficialOffset - 0x08];
+        set => SegmentedAddress16[OfficialOffset - 0x08] = value;
     }
 
     /// <summary>
@@ -147,33 +148,33 @@ public class DosSysVars : MemoryBasedDataStructure {
     /// <summary>
     /// Gets or sets the pointer to the Disk Parameter Block (DPB) chain.
     /// </summary>
-    public uint DiskParameterBlockChainPointer {
-        get => UInt32[OfficialOffset + 0x00];
-        set => UInt32[OfficialOffset + 0x00] = value;
+    public SegmentedAddress DiskParameterBlockChainPointer {
+        get => SegmentedAddress16[OfficialOffset + 0x00];
+        set => SegmentedAddress16[OfficialOffset + 0x00] = value;
     }
 
     /// <summary>
     /// Gets or sets the pointer to the System File Table (SFT) chain.
     /// </summary>
-    public uint SystemFileTableChainPointer {
-        get => UInt32[OfficialOffset + 0x04];
-        set => UInt32[OfficialOffset + 0x04] = value;
+    public SegmentedAddress SystemFileTableChainPointer {
+        get => SegmentedAddress16[OfficialOffset + 0x04];
+        set => SegmentedAddress16[OfficialOffset + 0x04] = value;
     }
 
     /// <summary>
     /// Gets or sets the pointer to the CLOCK device header.
     /// </summary>
-    public uint ClockDeviceHeaderPointer {
-        get => UInt32[OfficialOffset + 0x08];
-        set => UInt32[OfficialOffset + 0x08] = value;
+    public SegmentedAddress ClockDeviceHeaderPointer {
+        get => SegmentedAddress16[OfficialOffset + 0x08];
+        set => SegmentedAddress16[OfficialOffset + 0x08] = value;
     }
 
     /// <summary>
     /// Gets or sets the pointer to the CON device header.
     /// </summary>
-    public uint ConsoleDeviceHeaderPointer {
-        get => UInt32[OfficialOffset + 0x0C];
-        set => UInt32[OfficialOffset + 0x0C] = value;
+    public SegmentedAddress ConsoleDeviceHeaderPointer {
+        get => SegmentedAddress16[OfficialOffset + 0x0C];
+        set => SegmentedAddress16[OfficialOffset + 0x0C] = value;
     }
 
     /// <summary>
@@ -187,25 +188,25 @@ public class DosSysVars : MemoryBasedDataStructure {
     /// <summary>
     /// Gets or sets the pointer to the buffer descriptor.
     /// </summary>
-    public uint BufferDescriptorPointer {
-        get => UInt32[OfficialOffset + 0x12];
-        set => UInt32[OfficialOffset + 0x12] = value;
+    public SegmentedAddress BufferDescriptorPointer {
+        get => SegmentedAddress16[OfficialOffset + 0x12];
+        set => SegmentedAddress16[OfficialOffset + 0x12] = value;
     }
 
     /// <summary>
     /// Gets or sets the pointer to the Current Directory Structure (CDS) list.
     /// </summary>
-    public uint CurrentDirectoryStructureListPointer {
-        get => UInt32[OfficialOffset + 0x16];
-        set => UInt32[OfficialOffset + 0x16] = value;
+    public SegmentedAddress CurrentDirectoryStructureListPointer {
+        get => SegmentedAddress16[OfficialOffset + 0x16];
+        set => SegmentedAddress16[OfficialOffset + 0x16] = value;
     }
 
     /// <summary>
     /// Gets or sets the pointer to the FCB System File Table chain.
     /// </summary>
-    public uint FcbSystemFileTableChainPointer {
-        get => UInt32[OfficialOffset + 0x1A];
-        set => UInt32[OfficialOffset + 0x1A] = value;
+    public SegmentedAddress FcbSystemFileTableChainPointer {
+        get => SegmentedAddress16[OfficialOffset + 0x1A];
+        set => SegmentedAddress16[OfficialOffset + 0x1A] = value;
     }
 
     /// <summary>
@@ -270,9 +271,9 @@ public class DosSysVars : MemoryBasedDataStructure {
     /// <remarks>
     /// pointer to SETVER program list or 0000h:0000h
     /// </remarks>>
-    public uint SetVerTablePointer {
-        get => UInt32[OfficialOffset + 0x37];
-        set => UInt32[OfficialOffset + 0x37] = value;
+    public SegmentedAddress SetVerTablePointer {
+        get => SegmentedAddress16[OfficialOffset + 0x37];
+        set => SegmentedAddress16[OfficialOffset + 0x37] = value;
     }
 
     /// <summary>
@@ -340,9 +341,9 @@ public class DosSysVars : MemoryBasedDataStructure {
     /// <summary>
     /// Gets or sets the pointer to least-recently used buffer header
     /// </summary>
-    public uint DiskBufferHeadPt {
-        get => UInt32[OfficialOffset + 0x47];
-        set => UInt32[OfficialOffset + 0x47] = value;
+    public SegmentedAddress DiskBufferHeadPt {
+        get => SegmentedAddress16[OfficialOffset + 0x47];
+        set => SegmentedAddress16[OfficialOffset + 0x47] = value;
     }
 
     /// <summary>
@@ -356,9 +357,9 @@ public class DosSysVars : MemoryBasedDataStructure {
     /// <summary>
     /// Gets or sets the pointer to lookahead buffer
     /// </summary>
-    public uint LookaheadBufPt {
-        get => UInt32[OfficialOffset + 0x4D];
-        set => UInt32[OfficialOffset + 0x4D] = value;
+    public SegmentedAddress LookaheadBufPt {
+        get => SegmentedAddress16[OfficialOffset + 0x4D];
+        set => SegmentedAddress16[OfficialOffset + 0x4D] = value;
     }
 
     /// <summary>
@@ -380,9 +381,9 @@ public class DosSysVars : MemoryBasedDataStructure {
     /// <summary>
     /// Gets or sets the pointer to workspace buffer
     /// </summary>
-    public uint WorkspaceBuffer {
-        get => UInt32[OfficialOffset + 0x54];
-        set => UInt32[OfficialOffset + 0x54] = value;
+    public SegmentedAddress WorkspaceBuffer {
+        get => SegmentedAddress16[OfficialOffset + 0x54];
+        set => SegmentedAddress16[OfficialOffset + 0x54] = value;
     }
 
     /// <summary>

--- a/tests/Spice86.Tests/Dos/DosProcessManagerTests.cs
+++ b/tests/Spice86.Tests/Dos/DosProcessManagerTests.cs
@@ -20,6 +20,7 @@ using Spice86.Core.Emulator.OperatingSystem.Structures;
 using Spice86.Core.Emulator.IOPorts;
 using Spice86.Core.Emulator.VM.Breakpoint;
 using Spice86.Core.Emulator.VM;
+using Spice86.Shared.Emulator.Memory;
 using Spice86.Shared.Interfaces;
 using Spice86.Shared.Utils;
 using Spice86.Tests.Utility;
@@ -84,7 +85,7 @@ public class DosProcessManagerTests {
         context.ProcessManager.CreateRootCommandComPsp();
 
         DosProgramSegmentPrefix rootPsp = GetRootPsp(context);
-        rootPsp.StackPointer = 0x12345678;
+        rootPsp.StackPointer = new SegmentedAddress(0x1234, 0x5678);
 
         context.State.SS = 0x3000;
         context.State.SP = 0x00FE;
@@ -101,7 +102,7 @@ public class DosProcessManagerTests {
             environmentSegment: 0);
 
         result.Success.Should().BeTrue();
-        rootPsp.StackPointer.Should().Be(0x12345678);
+        rootPsp.StackPointer.Should().Be(new SegmentedAddress(0x1234, 0x5678));
     }
 
     [Fact]


### PR DESCRIPTION
### Description of Changes
Far pointers should be segmented addresses, not uint32