### PR TITLE
refactor: Optimized & improved DosExecResult and DosFileOperationResult.

### DIFF
--- a/src/Spice86.Core/Emulator/OperatingSystem/Structures/DosExecResult.cs
+++ b/src/Spice86.Core/Emulator/OperatingSystem/Structures/DosExecResult.cs
@@ -40,8 +40,11 @@ public sealed class DosExecResult : IEquatable<DosExecResult?> {
     public static DosExecResult Fail(DosErrorCode code) {
         // Use cache for common error codes.
         if ((int)code is >= 0 and < ErrorCacheLength) {
-            ref DosExecResult? errorCacheEntry = ref s_errorCache[(uint)code];
-            errorCacheEntry ??= NewErrorResult(code);
+            DosExecResult? errorCacheEntry = s_errorCache[(int)code];
+            if (errorCacheEntry is null) {
+                errorCacheEntry = NewErrorResult(code);
+                s_errorCache[(int)code] = errorCacheEntry;
+            }
             return errorCacheEntry;
         }
 

--- a/src/Spice86.Core/Emulator/OperatingSystem/Structures/DosExecResult.cs
+++ b/src/Spice86.Core/Emulator/OperatingSystem/Structures/DosExecResult.cs
@@ -1,12 +1,15 @@
 namespace Spice86.Core.Emulator.OperatingSystem.Structures;
 
 using Spice86.Core.Emulator.OperatingSystem.Enums;
-using Spice86.Shared.Emulator.Errors;
 
 /// <summary>
 /// Result of an INT 21h EXEC operation.
 /// </summary>
-public sealed class DosExecResult {
+public sealed class DosExecResult : IEquatable<DosExecResult?> {
+    // Cache the most common error codes into a fast lookup array.
+    private const int ErrorCacheLength = 20;
+    private static readonly DosExecResult?[] s_errorCache = new DosExecResult[ErrorCacheLength];
+
     private DosExecResult(bool success, DosErrorCode errorCode,
         ushort cs, ushort ip, ushort ss, ushort sp, ushort? ax = null, ushort? dx = null) {
         Success = success;
@@ -34,14 +37,46 @@ public sealed class DosExecResult {
     /// </summary>
     public ushort? DX { get; }
 
-    public static DosExecResult Fail(DosErrorCode code) => new(false, code, 0, 0, 0, 0);
+    public static DosExecResult Fail(DosErrorCode code) {
+        // Use cache for common error codes.
+        if ((int)code is >= 0 and < ErrorCacheLength) {
+            ref DosExecResult? errorCacheEntry = ref s_errorCache[(uint)code];
+            errorCacheEntry ??= NewErrorResult(code);
+            return errorCacheEntry;
+        }
+
+        return NewErrorResult(code);
+
+        static DosExecResult NewErrorResult(DosErrorCode errorCode)
+            => new(success: false, errorCode: errorCode, cs: 0, ip: 0, ss: 0, sp: 0);
+    }
 
     public static DosExecResult SuccessExecute(ushort cs, ushort ip, ushort ss, ushort sp)
-        => new(true, DosErrorCode.NoError, cs, ip, ss, sp);
+        => new(success: true, DosErrorCode.NoError, cs, ip, ss, sp);
 
     public static DosExecResult SuccessLoadOnly(ushort cs, ushort ip, ushort ss, ushort sp)
-        => new(true, DosErrorCode.NoError, cs, ip, ss, sp);
+        => new(success: true, DosErrorCode.NoError, cs, ip, ss, sp);
     
     public static DosExecResult SuccessLoadOverlay()
-        => new(true, DosErrorCode.NoError, 0, 0, 0, 0, ax: 0, dx: 0);
+        => new(success: true, DosErrorCode.NoError, cs: 0, ip: 0, ss: 0, sp: 0, ax: 0, dx: 0);
+
+    public override bool Equals(object? obj) {
+        return Equals(obj as DosExecResult);
+    }
+
+    public bool Equals(DosExecResult? other) {
+        return other is not null &&
+               Success == other.Success &&
+               ErrorCode == other.ErrorCode &&
+               InitialCS == other.InitialCS &&
+               InitialIP == other.InitialIP &&
+               InitialSS == other.InitialSS &&
+               InitialSP == other.InitialSP &&
+               AX == other.AX &&
+               DX == other.DX;
+    }
+
+    public override int GetHashCode() {
+        return HashCode.Combine(Success, ErrorCode, InitialCS, InitialIP, InitialSS, InitialSP, AX, DX);
+    }
 }

--- a/src/Spice86.Core/Emulator/OperatingSystem/Structures/DosFileOperationResult.cs
+++ b/src/Spice86.Core/Emulator/OperatingSystem/Structures/DosFileOperationResult.cs
@@ -2,6 +2,8 @@
 
 using Spice86.Core.Emulator.OperatingSystem.Enums;
 
+using System.Diagnostics;
+
 /// <summary>
 /// Represents the result of a DOS file operation, which could be an error or a value.
 /// </summary>
@@ -12,6 +14,9 @@ public sealed class DosFileOperationResult : IEquatable<DosFileOperationResult?>
 
     // Cache the common "no value" result to avoid extra allocations.
     private static readonly DosFileOperationResult s_noValue = new(error: false, valueIsUint32: false, value: null);
+
+    // Cache the last UInt16 result (no error, reference count zero).
+    private static DosFileOperationResult? s_lastResult16;
 
     private readonly uint? _value;
     private readonly bool _error;
@@ -42,8 +47,11 @@ public sealed class DosFileOperationResult : IEquatable<DosFileOperationResult?>
     public static DosFileOperationResult Error(DosErrorCode errorCode) {
         // Use cache for common error codes.
         if ((int)errorCode is >= 0 and < ErrorCacheLength) {
-            ref DosFileOperationResult? errorCacheEntry = ref s_errorCache[(uint)errorCode];
-            errorCacheEntry ??= NewErrorResult(errorCode);
+            DosFileOperationResult? errorCacheEntry = s_errorCache[(int)errorCode];
+            if (errorCacheEntry is null) {
+                errorCacheEntry = NewErrorResult(errorCode);
+                s_errorCache[(int)errorCode] = errorCacheEntry;
+            }
             return errorCacheEntry;
         }
 
@@ -67,7 +75,17 @@ public sealed class DosFileOperationResult : IEquatable<DosFileOperationResult?>
     /// <param name="value">The 16-bit value.</param>
     /// <returns>A new instance of the class with a 16-bit value.</returns>
     public static DosFileOperationResult Value16(ushort value) {
-        return new DosFileOperationResult(error: false, valueIsUint32: false, value);
+        // Use last cached 16-bit result if possible.
+        DosFileOperationResult? lastResult = s_lastResult16;
+        if (lastResult?.Value == value) {
+            Debug.Assert(!lastResult.IsError);
+            Debug.Assert(!lastResult.IsValueIsUint32);
+            return lastResult;
+        }
+
+        lastResult = new DosFileOperationResult(error: false, valueIsUint32: false, value);
+        s_lastResult16 = lastResult;
+        return lastResult;
     }
 
     /// <summary>

--- a/src/Spice86.Core/Emulator/OperatingSystem/Structures/DosFileOperationResult.cs
+++ b/src/Spice86.Core/Emulator/OperatingSystem/Structures/DosFileOperationResult.cs
@@ -5,9 +5,16 @@ using Spice86.Core.Emulator.OperatingSystem.Enums;
 /// <summary>
 /// Represents the result of a DOS file operation, which could be an error or a value.
 /// </summary>
-public class DosFileOperationResult {
-    private readonly bool _error;
+public sealed class DosFileOperationResult : IEquatable<DosFileOperationResult?> {
+    // Cache the most common error codes into a fast lookup array.
+    private const int ErrorCacheLength = 20;
+    private static readonly DosFileOperationResult?[] s_errorCache = new DosFileOperationResult[ErrorCacheLength];
+
+    // Cache the common "no value" result to avoid extra allocations.
+    private static readonly DosFileOperationResult s_noValue = new(error: false, valueIsUint32: false, value: null);
+
     private readonly uint? _value;
+    private readonly bool _error;
     private readonly bool _valueIsUint32;
     private readonly byte _refCount;
 
@@ -33,7 +40,17 @@ public class DosFileOperationResult {
     /// <param name="errorCode">The error code.</param>
     /// <returns>A new instance of the class indicating an error.</returns>
     public static DosFileOperationResult Error(DosErrorCode errorCode) {
-        return new DosFileOperationResult(true, false, (uint?)errorCode);
+        // Use cache for common error codes.
+        if ((int)errorCode is >= 0 and < ErrorCacheLength) {
+            ref DosFileOperationResult? errorCacheEntry = ref s_errorCache[(uint)errorCode];
+            errorCacheEntry ??= NewErrorResult(errorCode);
+            return errorCacheEntry;
+        }
+
+        return NewErrorResult(errorCode);
+
+        static DosFileOperationResult NewErrorResult(DosErrorCode errorCode)
+            => new(error: true, valueIsUint32: false, value: (uint?)errorCode);
     }
 
     /// <summary>
@@ -41,7 +58,7 @@ public class DosFileOperationResult {
     /// </summary>
     /// <returns>A new instance of the class indicating no value.</returns>
     public static DosFileOperationResult NoValue() {
-        return new DosFileOperationResult(false, false, null);
+        return s_noValue;
     }
 
     /// <summary>
@@ -50,7 +67,7 @@ public class DosFileOperationResult {
     /// <param name="value">The 16-bit value.</param>
     /// <returns>A new instance of the class with a 16-bit value.</returns>
     public static DosFileOperationResult Value16(ushort value) {
-        return new DosFileOperationResult(false, false, value);
+        return new DosFileOperationResult(error: false, valueIsUint32: false, value);
     }
 
     /// <summary>
@@ -59,7 +76,7 @@ public class DosFileOperationResult {
     /// <param name="value">The 32-bit value.</param>
     /// <returns>A new instance of the class with a 32-bit value.</returns>
     public static DosFileOperationResult Value32(uint value) {
-        return new DosFileOperationResult(false, true, value);
+        return new DosFileOperationResult(error: false, valueIsUint32: true, value);
     }
 
     /// <summary>
@@ -68,7 +85,7 @@ public class DosFileOperationResult {
     /// <param name="refCount">The reference count from the System File Table.</param>
     /// <returns>A new instance of the class with a reference count.</returns>
     public static DosFileOperationResult NoValueWithRefCount(byte refCount) {
-        return new DosFileOperationResult(false, false, null, refCount);
+        return new DosFileOperationResult(error: false, valueIsUint32: false, value: null, refCount);
     }
 
     /// <summary>
@@ -90,4 +107,20 @@ public class DosFileOperationResult {
     /// The number of handles associated with the file or device after a successful <see cref="DosFileManager.CloseFileOrDevice(ushort)"/> operation. Defaults to 0 for other DOS operations.
     /// </summary>
     public byte RefCount => _refCount;
+
+    public override bool Equals(object? obj) {
+        return Equals(obj as DosFileOperationResult);
+    }
+
+    public bool Equals(DosFileOperationResult? other) {
+        return other is not null &&
+               Value == other.Value &&
+               IsError == other.IsError &&
+               IsValueIsUint32 == other.IsValueIsUint32 &&
+               RefCount == other.RefCount;
+    }
+
+    public override int GetHashCode() {
+        return HashCode.Combine(Value, IsError, IsValueIsUint32, RefCount);
+    }
 }


### PR DESCRIPTION
### Description of Changes
- `DosExecResult` now implements `IEquatable<T>` interface and overrides `Equals(object?)` and `GetHashCode()`.
- `DosExecResult` added static cache for storing a subset of common error results.
- `DosFileOperationResult` now implements `IEquatable<T>` interface and overrides `Equals(object?)` and `GetHashCode()`.
- `DosFileOperationResult` added static cache for storing a subset of common error results, `NoValue()` result, and repeated `Value16()` results (with the same value).
- `DosFileOperationResult` class is now sealed (was not possible to inherit before with private constructor anyways).
- Added parameter names to a few calls to make it more obvious what parameter values are being passed into the constructors.

### Rationale behind Changes
Minor performance improvements for fixed/common/repeated operation results (reduces heap allocations).

It would also be possible to easily cache the fixed result from `DosExecResult.SuccessLoadOverlay()`, but this is most likely not called often enough to need that optimization.

**NOTE:** It would be better/more efficient to change `DosExecResult` and `DosFileOperationResult` from `class` (reference type) to `readonly struct` (value type), as there would then be no need to apply these caching optimizations. (This would further reduce heap allocations, may slightly improve memory accesses as the results would generally be stored in the thread stack rather than the GC heap, would potentially avoid an extra pointer dereference, and would have the minor benefit of being able to safely implement the `==` and `!=` operators). However, these are public APIs and changing the fundamental object types would be a breaking change.

### Suggested Testing Steps
Tested against project unit tests.