### PR TITLE
Feature: DOS Memory information: Used and free memory, PSPs, MCBs, and PSP chain graph

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -116,6 +116,7 @@ Variants: `MemoryBasedDataStructureWithCsBaseAddress`, `MemoryBasedDataStructure
 - **Use `tmp/` for temporary files** - if a temporary file must be written (e.g., captured command output, intermediate data), place it inside the `tmp/` folder at the root of the repository. Never write to `/tmp` or any path outside the workspace.
 - **Avoid complexity** - keep cyclomatic complexity low, prefer simple, linear code over nested conditionals
 - **No optional parameters** - avoid nullable or optional parameters in new code
+- **No ternary expressions** - avoid `condition ? whenTrue : whenFalse`; always use explicit `if/else`
 - **Minimal comments** - write self-documenting code with clear names; avoid obvious comments
 - **Test before submit** - always run tests after code changes to verify functionality
 - **Rebuild and verify** - For any task that changes code or tests, rebuild the project and run the full test suite; do not stop until all tests are green.
@@ -123,6 +124,7 @@ Variants: `MemoryBasedDataStructureWithCsBaseAddress`, `MemoryBasedDataStructure
 - **Ignore Machine class** - this is a legacy aggregator class; work directly with specific components (`CfgCpu`, `Memory`, `Stack`, etc.) instead
 - **Enforce TDD** - ensure integration tests are present and not passing at first, then make them pass by updating the implementation.
 - **Clear test code style** use explicit Arrange/Act/Assert structure, avoid long setup blocks, and reduce duplication with small helpers.
+- **Pause-refresh rule for new ViewModels** - view models that refresh from a dispatcher timer must refresh at most once per pause cycle. Gate updates on `IPauseHandler.IsPaused`, track a per-pause boolean flag, and reset it on resume.
 
 ### Avalonia Telemetry
 - **Avalonia telemetry must be disabled** when working on the codebase.
@@ -180,6 +182,7 @@ Variants: `MemoryBasedDataStructureWithCsBaseAddress`, `MemoryBasedDataStructure
   - **Avoid non-ASCII Unicode characters**: Prefer plain ASCII in source code and documentation; only use Unicode when necessary for languages that require characters outside the ASCII range (for example, Chinese). Some editors or tools may not assume UTF-8 and can render or save these characters incorrectly.
 - **Do not use `#region`**: Avoid `#region`/`#endregion` blocks; keep code organized via clear structure and namespaces
 - **Do not suppress warnings with pragmas**: Never disable warnings using preprocessor directives (e.g., `#pragma warning disable`). Fix the underlying issue instead.
+- **No ternary operator**: Do not use the ternary conditional operator (`?:`). Use explicit `if/else` blocks for all conditional assignments and returns.
 - **Async usage restrictions**:
   - **Do NOT let async "infect" the `Spice86.Core` assembly**
   - Keep async code in the UI layer (`Spice86` project) only

--- a/NOTICE
+++ b/NOTICE
@@ -5,7 +5,9 @@ Authors:
 - Alberto Marnetto
 - Ales Teska
 - Artjom Vejsel
+- Bruno Martinez
 - Edu Garcia
+- Ievgenii Meshcheriakov
 - Ivan Kuzmenko
 - John Källén
 - Joris van Eijden
@@ -13,6 +15,7 @@ Authors:
 - LowLevelMahn
 - Maximilien Noal
 - Stefan Hueg
+- Thomas Kaiser
 
 Third party authors:
 - Greg Divis (Aeon project: https://github.com/gregdivis/Aeon)

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -16,13 +16,13 @@
 	</PropertyGroup>
 	<!-- Nuget package info-->
 	<PropertyGroup>
-		<Version>14.1</Version>
+		<Version>14.2</Version>
 		<PackageReleaseNotes>
             <![CDATA[
             # Release Notes - https://github.com/OpenRakis/Spice86/wiki/Spice86-v14-release-notes
             ]]>
 		</PackageReleaseNotes>
-		<Authors>Alberto Marnetto, Ales Teska, Artjom Vejsel, Edu Garcia, Ivan Kuzmenko, John Källén, Joris van Eijden, Karl Lenz, Kevin Ferrare, LowLevelMahn, Maximilien Noal, Stefan Hueg</Authors>
+		<Authors>Alberto Marnetto, Ales Teska, Artjom Vejsel, Bruno Martinez, Edu Garcia, Ievgenii Meshcheriakov, Ivan Kuzmenko, John Källén, Joris van Eijden, Karl Lenz, Kevin Ferrare, LowLevelMahn, Maximilien Noal, Stefan Hueg, Thomas Kaiser</Authors>
 		<PackageTags>reverse-engineering;avalonia;debugger;assembly;emulator;cross-platform</PackageTags>
 		<Description>Reverse engineer and rewrite real mode dos programs</Description>
 		<PackageProjectUrl>https://github.com/OpenRakis/Spice86</PackageProjectUrl>

--- a/src/Spice86.Core/Emulator/OperatingSystem/DosMemoryManager.cs
+++ b/src/Spice86.Core/Emulator/OperatingSystem/DosMemoryManager.cs
@@ -141,7 +141,11 @@ public class DosMemoryManager {
             .MaxBy(block => block.Size) ?? _start;
     }
 
-    private IEnumerable<DosMemoryControlBlock> EnumerateBlocks() {
+    /// <summary>
+    /// Walks the MCB chain starting from the first block, yielding each MCB in order
+    /// until the last block is reached. Intended for read-only inspection.
+    /// </summary>
+    public IEnumerable<DosMemoryControlBlock> EnumerateBlocks() {
         DosMemoryControlBlock? current = _start;
         while (current != null) {
             yield return current;

--- a/src/Spice86/Spice86DependencyInjection.cs
+++ b/src/Spice86/Spice86DependencyInjection.cs
@@ -96,6 +96,7 @@ public class Spice86DependencyInjection : IDisposable {
     private readonly McpHttpHost? _mcpHttpTransport;
     private readonly DeviceSchedulerThread? _vgaTimingThread;
     private readonly CfgNodeExecutionCompiler _cfgNodeExecutionCompiler;
+    private readonly DebuggerTabRegistry _debuggerTabRegistry;
     private bool _disposed;
     private bool _machineDisposedAfterRun;
 
@@ -704,6 +705,7 @@ public class Spice86DependencyInjection : IDisposable {
             loggerService.Information("BIOS and DOS interrupt handlers created...");
         }
 
+        _debuggerTabRegistry = new DebuggerTabRegistry();
         Machine = machine;
         ProgramExecutor = programExecutor;
         McpServices = emulatorMcpServices;
@@ -713,31 +715,34 @@ public class Spice86DependencyInjection : IDisposable {
         if (mainWindow != null && uiDispatcher != null &&
             hostStorageProvider != null && textClipboard != null) {
             IMessenger messenger = WeakReferenceMessenger.Default;
-            IDebuggerTabRegistry debuggerTabRegistry = new DebuggerTabRegistry();
 
             BreakpointsTabPlugin breakpointsTabPlugin = new(state, pauseHandler, messenger,
                 emulatorBreakpointsManager, uiDispatcher, textClipboard, memory);
-            breakpointsTabPlugin.Register(debuggerTabRegistry);
+            breakpointsTabPlugin.Register(_debuggerTabRegistry);
 
-            BreakpointsViewModel breakpointsViewModel = debuggerTabRegistry.Get<BreakpointsViewModel>(DebuggerTabId.Breakpoints);
+            BreakpointsViewModel breakpointsViewModel = _debuggerTabRegistry.Get<BreakpointsViewModel>(DebuggerTabId.Breakpoints);
             breakpointsViewModel.RestoreBreakpoints(deserializedUserBreakpoints);
 
             DisassemblyTabPlugin disassemblyTabPlugin = new(emulatorBreakpointsManager, memory,
                 state, functionCatalogue.FunctionInformations, breakpointsViewModel, pauseHandler,
                 uiDispatcher, messenger, textClipboard, loggerService);
-            disassemblyTabPlugin.Register(debuggerTabRegistry);
+            disassemblyTabPlugin.Register(_debuggerTabRegistry);
 
             DevicesTabPlugin devicesTabPlugin = new(videoState.DacRegisters.ArgbPalette,
                 uiDispatcher, vgaRenderer, videoState, vgaTimingEngine, hostStorageProvider, midiDevice);
-            devicesTabPlugin.Register(debuggerTabRegistry);
+            devicesTabPlugin.Register(_debuggerTabRegistry);
+
+            DosTabPlugin dosTabPlugin = new(dos.MemoryManager, dos.Ems, dos.Xms,
+                dos.DosSwappableDataArea, memory, pauseHandler);
+            dosTabPlugin.Register(_debuggerTabRegistry);
 
             CpuTabPlugin cpuTabPlugin = new(state, memory, pauseHandler, uiDispatcher);
-            cpuTabPlugin.Register(debuggerTabRegistry);
+            cpuTabPlugin.Register(_debuggerTabRegistry);
 
             CfgCpuTabPlugin cfgCpuTabPlugin = new(uiDispatcher,
                 cfgCpu.ExecutionContextManager, pauseHandler, nodeToString, asmRenderingConfig,
                 cfgBlockGraphExporter);
-            cfgCpuTabPlugin.Register(debuggerTabRegistry);
+            cfgCpuTabPlugin.Register(_debuggerTabRegistry);
 
             StructureViewModelFactory structureViewModelFactory = new(configuration,
                 state, loggerService, pauseHandler);
@@ -745,10 +750,10 @@ public class Spice86DependencyInjection : IDisposable {
             MemoryTabPlugin memoryTabPlugin = new(memory, memoryDataExporter, state, stack,
                 breakpointsViewModel, pauseHandler, messenger, uiDispatcher,
                 textClipboard, hostStorageProvider, structureViewModelFactory, dos.Ems, dos.Xms);
-            memoryTabPlugin.Register(debuggerTabRegistry);
+            memoryTabPlugin.Register(_debuggerTabRegistry);
 
             DebugWindowViewModel debugWindowViewModel = new(
-                WeakReferenceMessenger.Default, uiDispatcher, pauseHandler, debuggerTabRegistry);
+                WeakReferenceMessenger.Default, uiDispatcher, pauseHandler, _debuggerTabRegistry);
 
             SoftwareMixerViewModel mixerViewModel = new(mixer, soundBlaster, opl);
 
@@ -850,6 +855,7 @@ public class Spice86DependencyInjection : IDisposable {
         if (!_disposed) {
             if (disposing) {
                 ProgramExecutor.EmulationStopped -= OnProgramExecutorEmulationStopped;
+                _debuggerTabRegistry.Dispose();
                 _mcpHttpTransport?.Dispose();
 
                 ProgramExecutor.Dispose();

--- a/src/Spice86/ViewModels/BreakpointsViewModel.cs
+++ b/src/Spice86/ViewModels/BreakpointsViewModel.cs
@@ -15,6 +15,7 @@ using Spice86.Core.Emulator.VM.Breakpoint;
 using Spice86.Shared.Emulator.VM.Breakpoint;
 using Spice86.Shared.Emulator.VM.Breakpoint.Serializable;
 using Spice86.Shared.Utils;
+using Spice86.ViewModels.DataModels;
 using Spice86.ViewModels.Messages;
 using Spice86.ViewModels.Services;
 

--- a/src/Spice86/ViewModels/CfgCpuViewModel.cs
+++ b/src/Spice86/ViewModels/CfgCpuViewModel.cs
@@ -21,6 +21,8 @@ using Spice86.Core.Emulator.CPU.CfgCpu.ParsedInstruction.SelfModifying;
 using Spice86.Core.Emulator.StateSerialization.ControlFlow;
 using Spice86.Core.Emulator.VM;
 using Spice86.Shared.Emulator.Memory;
+using Spice86.ViewModels.DataModels;
+using Spice86.ViewModels.Enums;
 using Spice86.ViewModels.Services;
 using Spice86.ViewModels.TextPresentation;
 

--- a/src/Spice86/ViewModels/CpuViewModel.cs
+++ b/src/Spice86/ViewModels/CpuViewModel.cs
@@ -1,7 +1,5 @@
 namespace Spice86.ViewModels;
 
-using Avalonia.Threading;
-
 using CommunityToolkit.Mvvm.ComponentModel;
 
 using Spice86.Core.Emulator.CPU;
@@ -15,7 +13,7 @@ using System.Reflection;
 using Spice86.ViewModels.PropertiesMappers;
 using Spice86.ViewModels.Services;
 
-public partial class CpuViewModel : ViewModelBase, IEmulatorObjectViewModel
+public partial class CpuViewModel : TimerRefreshViewModelBase
 {
     private readonly State _cpuState;
     private readonly IMemory _memory;
@@ -30,6 +28,7 @@ public partial class CpuViewModel : ViewModelBase, IEmulatorObjectViewModel
     private RegistersViewModel _registers;
 
     public CpuViewModel(State state, IMemory memory, IPauseHandler pauseHandler, IUIDispatcher uiDispatcher)
+        : base(400)
     {
         _cpuState = state;
         _memory = memory;
@@ -37,17 +36,11 @@ public partial class CpuViewModel : ViewModelBase, IEmulatorObjectViewModel
         pauseHandler.Paused += () => uiDispatcher.Post(() => _isPaused = pauseHandler.IsPaused);
         _isPaused = pauseHandler.IsPaused;
         pauseHandler.Resumed += () => uiDispatcher.Post(() => _isPaused = pauseHandler.IsPaused);
-        DispatcherTimerStarter.StartNewDispatcherTimer(TimeSpan.FromMilliseconds(400), DispatcherPriority.Background, UpdateValues);
     }
 
-    public bool IsVisible { get; set; }
+    public override string Header => "CPU";
 
-    public void UpdateValues(object? sender, EventArgs e)
-    {
-        if (!IsVisible)
-        {
-            return;
-        }
+    protected override void RefreshCore() {
         VisitCpuState(_cpuState);
     }
 

--- a/src/Spice86/ViewModels/DataModels/CfgGraphEdgeLabel.cs
+++ b/src/Spice86/ViewModels/DataModels/CfgGraphEdgeLabel.cs
@@ -1,4 +1,6 @@
-namespace Spice86.ViewModels;
+namespace Spice86.ViewModels.DataModels;
+
+using Spice86.ViewModels.Enums;
 
 /// <summary>
 /// View model representing an edge label in the CFG graph, carrying display text

--- a/src/Spice86/ViewModels/DataModels/ConventionalMemorySegment.cs
+++ b/src/Spice86/ViewModels/DataModels/ConventionalMemorySegment.cs
@@ -1,0 +1,21 @@
+namespace Spice86.ViewModels.DataModels;
+
+/// <summary>
+/// Single segment of the conventional memory bar.
+/// </summary>
+public sealed class ConventionalMemorySegment {
+    /// <summary>Starting segment address.</summary>
+    public ushort StartSegment { get; init; }
+
+    /// <summary>Size of the block, in bytes (used for relative bar width).</summary>
+    public long SizeBytes { get; init; }
+
+    /// <summary>True when the block is free, false when allocated.</summary>
+    public bool IsFree { get; init; }
+
+    /// <summary>Owner display label (PSP segment or owner name).</summary>
+    public string Owner { get; init; } = string.Empty;
+
+    /// <summary>Whether this block is the last MCB in the chain.</summary>
+    public bool IsLast { get; init; }
+}

--- a/src/Spice86/ViewModels/DataModels/DosGraphNode.cs
+++ b/src/Spice86/ViewModels/DataModels/DosGraphNode.cs
@@ -1,0 +1,50 @@
+namespace Spice86.ViewModels.DataModels;
+
+using Spice86.ViewModels.Enums;
+
+/// <summary>
+/// Graph node used by DOS graph tabs.
+/// </summary>
+public sealed class DosGraphNode : IEquatable<DosGraphNode> {
+    /// <summary>
+    /// Stable node identifier used for equality in graph rendering.
+    /// </summary>
+    public int NodeId { get; init; }
+
+    /// <summary>
+    /// Primary line of text.
+    /// </summary>
+    public string Title { get; init; } = string.Empty;
+
+    /// <summary>
+    /// Secondary line of text.
+    /// </summary>
+    public string Subtitle { get; init; } = string.Empty;
+
+    /// <summary>
+    /// Semantic kind for theme and rendering decisions.
+    /// </summary>
+    public DosGraphNodeKind Kind { get; init; } = DosGraphNodeKind.Psp;
+
+    public bool Equals(DosGraphNode? other) {
+        if (other is null) {
+            return false;
+        }
+        return NodeId == other.NodeId;
+    }
+
+    public override bool Equals(object? obj) {
+        return Equals(obj as DosGraphNode);
+    }
+
+    public override int GetHashCode() {
+        return NodeId;
+    }
+
+    public override string ToString() {
+        if (string.IsNullOrEmpty(Subtitle)) {
+            return Title;
+        }
+        return Title + System.Environment.NewLine + Subtitle;
+    }
+}

--- a/src/Spice86/ViewModels/DataModels/DosMcbBarItem.cs
+++ b/src/Spice86/ViewModels/DataModels/DosMcbBarItem.cs
@@ -1,0 +1,18 @@
+namespace Spice86.ViewModels.DataModels;
+
+/// <summary>
+/// One block in the conventional memory bar: a single MCB sized by <see cref="SizeBytes"/>.
+/// </summary>
+/// <param name="HeaderSegment">MCB header segment as a hex string (e.g. <c>0x0800</c>).</param>
+/// <param name="SizeBytes">Total size of the block (header excluded) in bytes.</param>
+/// <param name="IsFree">True if the block is free.</param>
+/// <param name="IsLast">True if the block is the final (Z) block of the chain.</param>
+/// <param name="OwnerName">Owner program name (empty for free blocks).</param>
+/// <param name="Tooltip">Human-readable tooltip shown when hovering this block.</param>
+public sealed record DosMcbBarItem(
+    string HeaderSegment,
+    long SizeBytes,
+    bool IsFree,
+    bool IsLast,
+    string OwnerName,
+    string Tooltip);

--- a/src/Spice86/ViewModels/DataModels/KnownBreakpointSuggestion.cs
+++ b/src/Spice86/ViewModels/DataModels/KnownBreakpointSuggestion.cs
@@ -1,4 +1,4 @@
-namespace Spice86.ViewModels;
+namespace Spice86.ViewModels.DataModels;
 
 /// <summary>
 /// An autocomplete suggestion for a breakpoint targeting a specific interrupt vector or

--- a/src/Spice86/ViewModels/DataModels/KnownBreakpointSuggestions.cs
+++ b/src/Spice86/ViewModels/DataModels/KnownBreakpointSuggestions.cs
@@ -1,4 +1,4 @@
-namespace Spice86.ViewModels;
+namespace Spice86.ViewModels.DataModels;
 
 /// <summary>
 /// Static catalog of well-known interrupt vectors and I/O port ranges used to populate

--- a/src/Spice86/ViewModels/DebugWindowViewModel.cs
+++ b/src/Spice86/ViewModels/DebugWindowViewModel.cs
@@ -12,8 +12,7 @@ using Spice86.ViewModels.Services;
 
 public partial class DebugWindowViewModel : ViewModelBase,
     IRecipient<AddViewModelMessage<DisassemblyViewModel>>, IRecipient<AddViewModelMessage<MemoryViewModel>>,
-    IRecipient<RemoveViewModelMessage<DisassemblyViewModel>>, IRecipient<RemoveViewModelMessage<MemoryViewModel>>
-{
+    IRecipient<RemoveViewModelMessage<DisassemblyViewModel>>, IRecipient<RemoveViewModelMessage<MemoryViewModel>> {
 
     private readonly IMessenger _messenger;
     private readonly IUIDispatcher _uiDispatcher;
@@ -27,6 +26,12 @@ public partial class DebugWindowViewModel : ViewModelBase,
 
     [ObservableProperty]
     private DebuggerSubTabViewModel? _selectedDeviceSubTab;
+
+    [ObservableProperty]
+    private AvaloniaList<DebuggerSubTabViewModel> _dosSubTabs = new();
+
+    [ObservableProperty]
+    private DebuggerSubTabViewModel? _selectedDosSubTab;
 
     [ObservableProperty]
     private AvaloniaList<IDebuggerTabContentViewModel> _memoryViews = new();
@@ -52,8 +57,7 @@ public partial class DebugWindowViewModel : ViewModelBase,
     private readonly IPauseHandler _pauseHandler;
 
     public DebugWindowViewModel(IMessenger messenger, IUIDispatcher uiDispatcher,
-        IPauseHandler pauseHandler, IDebuggerTabRegistry tabRegistry)
-    {
+        IPauseHandler pauseHandler, IDebuggerTabRegistry tabRegistry) {
         messenger.Register<AddViewModelMessage<DisassemblyViewModel>>(this);
         messenger.Register<AddViewModelMessage<MemoryViewModel>>(this);
         messenger.Register<RemoveViewModelMessage<DisassemblyViewModel>>(this);
@@ -74,11 +78,12 @@ public partial class DebugWindowViewModel : ViewModelBase,
         CfgCpuViewModel = tabRegistry.Get<CfgCpuViewModel>(DebuggerTabId.CfgCpu);
         DeviceSubTabs.AddRange(tabRegistry.GetSubTabs(DebuggerTabId.DevicesGroup));
         SelectedDeviceSubTab = DeviceSubTabs.FirstOrDefault();
+        DosSubTabs.AddRange(tabRegistry.GetSubTabs(DebuggerTabId.DosGroup));
+        SelectedDosSubTab = DosSubTabs.FirstOrDefault();
     }
 
     [RelayCommand]
-    private void Pause() => _uiDispatcher.Post(() =>
-    {
+    private void Pause() => _uiDispatcher.Post(() => {
         _pauseHandler.RequestPause("Pause button pressed in debug window");
     });
 
@@ -86,17 +91,14 @@ public partial class DebugWindowViewModel : ViewModelBase,
     private void Continue() => _uiDispatcher.Post(_pauseHandler.Resume);
 
     public void Receive(AddViewModelMessage<DisassemblyViewModel> message) => DisassemblyViewModels.Add(message.ViewModel);
-    public void Receive(AddViewModelMessage<MemoryViewModel> message)
-    {
+    public void Receive(AddViewModelMessage<MemoryViewModel> message) {
         MemoryViews.Add(message.ViewModel);
         SelectedMemoryView = message.ViewModel;
     }
     public void Receive(RemoveViewModelMessage<DisassemblyViewModel> message) => DisassemblyViewModels.Remove(message.ViewModel);
-    public void Receive(RemoveViewModelMessage<MemoryViewModel> message)
-    {
+    public void Receive(RemoveViewModelMessage<MemoryViewModel> message) {
         MemoryViews.Remove(message.ViewModel);
-        if (ReferenceEquals(SelectedMemoryView, message.ViewModel))
-        {
+        if (ReferenceEquals(SelectedMemoryView, message.ViewModel)) {
             SelectedMemoryView = MemoryViews.FirstOrDefault();
         }
     }

--- a/src/Spice86/ViewModels/DosMcbsViewModel.cs
+++ b/src/Spice86/ViewModels/DosMcbsViewModel.cs
@@ -1,0 +1,132 @@
+namespace Spice86.ViewModels;
+
+using CommunityToolkit.Mvvm.ComponentModel;
+
+using Spice86.Core.Emulator.OperatingSystem;
+using Spice86.Core.Emulator.OperatingSystem.Structures;
+using Spice86.Core.Emulator.VM;
+using Spice86.ViewModels.DataModels;
+using Spice86.ViewModels.PropertiesMappers;
+using Spice86.ViewModels.ValueViewModels.Debugging;
+
+using System.Collections.ObjectModel;
+
+/// <summary>
+/// DOS MCB (Memory Control Block) inspector.
+/// </summary>
+public sealed partial class DosMcbsViewModel : TimerRefreshViewModelBase {
+    private readonly DosMemoryManager _memoryManager;
+
+    /// <inheritdoc />
+    public override string Header => "DOS MCBs";
+
+    /// <summary>All MCBs in enumeration order.</summary>
+    public ObservableCollection<DosMcbInfo> Items { get; } = new();
+
+    /// <summary>Bar-graph blocks mirroring <see cref="Items"/>, suitable for proportional rendering.</summary>
+    public ObservableCollection<DosMcbBarItem> Blocks { get; } = new();
+
+    [ObservableProperty]
+    private DosMcbInfo? _selectedItem;
+
+    [ObservableProperty]
+    private long _totalConventionalBytes;
+
+    [ObservableProperty]
+    private long _freeConventionalBytes;
+
+    [ObservableProperty]
+    private long _usedConventionalBytes;
+
+    [ObservableProperty]
+    private long _largestFreeBlockBytes;
+
+    [ObservableProperty]
+    private int _totalMcbCount;
+
+    [ObservableProperty]
+    private int _freeMcbCount;
+
+    /// <summary>One-line layout summary suitable for a status header.</summary>
+    public string LayoutSummary =>
+        $"Total: {TotalConventionalBytes:N0} bytes / Used: {UsedConventionalBytes:N0} / Free: {FreeConventionalBytes:N0} / Largest free MCB: {LargestFreeBlockBytes:N0} / MCBs: {TotalMcbCount} (free: {FreeMcbCount})";
+
+    /// <summary>Initializes a new <see cref="DosMcbsViewModel"/>.</summary>
+    public DosMcbsViewModel(DosMemoryManager memoryManager, IPauseHandler pauseHandler) : base(400, pauseHandler) {
+        _memoryManager = memoryManager;
+    }
+
+    /// <inheritdoc />
+    protected override void RefreshCore() {
+        List<DosMcbInfo> built = new();
+        List<DosMcbBarItem> blocks = new();
+        long total = 0;
+        long free = 0;
+        long used = 0;
+        long largestFree = 0;
+        int freeCount = 0;
+        foreach (DosMemoryControlBlock block in _memoryManager.EnumerateBlocks()) {
+            DosMcbInfo info = new();
+            block.CopyToDosMcbInfo(info);
+            built.Add(info);
+            if (block.IsValid) {
+                long sizeBytes = info.SizeBytes;
+                total += sizeBytes;
+                if (info.IsFree) {
+                    free += sizeBytes;
+                    freeCount++;
+                    if (sizeBytes > largestFree) {
+                        largestFree = sizeBytes;
+                    }
+                } else {
+                    used += sizeBytes;
+                }
+                string ownerLabel;
+                if (info.IsFree) {
+                    ownerLabel = "(free)";
+                } else if (string.IsNullOrEmpty(info.OwnerName)) {
+                    ownerLabel = info.OwnerPspSegment;
+                } else {
+                    ownerLabel = info.OwnerName;
+                }
+                string tip = $"seg:{info.HeaderSegment}  size={sizeBytes:N0} bytes  owner={ownerLabel}";
+                blocks.Add(new DosMcbBarItem(info.HeaderSegment, sizeBytes, info.IsFree, info.IsLast, info.OwnerName, tip));
+            }
+            if (!block.IsValid) {
+                break;
+            }
+        }
+        string? previouslySelected = SelectedItem?.HeaderSegment;
+        Items.Clear();
+        foreach (DosMcbInfo info in built) {
+            Items.Add(info);
+        }
+        Blocks.Clear();
+        foreach (DosMcbBarItem block in blocks) {
+            Blocks.Add(block);
+        }
+        TotalConventionalBytes = total;
+        FreeConventionalBytes = free;
+        UsedConventionalBytes = used;
+        LargestFreeBlockBytes = largestFree;
+        TotalMcbCount = blocks.Count;
+        FreeMcbCount = freeCount;
+        OnPropertyChanged(nameof(LayoutSummary));
+        if (previouslySelected is null) {
+            if (Items.Count > 0) {
+                SelectedItem = Items[0];
+            } else {
+                SelectedItem = null;
+            }
+        } else {
+            DosMcbInfo? found = Items.FirstOrDefault(i => i.HeaderSegment == previouslySelected);
+            if (found is not null) {
+                SelectedItem = found;
+            } else if (Items.Count > 0) {
+                SelectedItem = Items[0];
+            } else {
+                SelectedItem = null;
+            }
+        }
+    }
+}

--- a/src/Spice86/ViewModels/DosMemoryOverviewViewModel.cs
+++ b/src/Spice86/ViewModels/DosMemoryOverviewViewModel.cs
@@ -1,0 +1,268 @@
+namespace Spice86.ViewModels;
+
+using CommunityToolkit.Mvvm.ComponentModel;
+
+using Spice86.Core.Emulator.InterruptHandlers.Dos.Ems;
+using Spice86.Core.Emulator.InterruptHandlers.Dos.Xms;
+using Spice86.Core.Emulator.OperatingSystem;
+using Spice86.Core.Emulator.OperatingSystem.Structures;
+using Spice86.Core.Emulator.VM;
+using Spice86.ViewModels.DataModels;
+using Spice86.ViewModels.Services;
+
+using System.Collections.ObjectModel;
+
+/// <summary>
+/// Combined DOS memory overview: MCB bar graph + structured table summary
+/// covering Conventional, HMA, XMS and EMS.
+/// </summary>
+public sealed partial class DosMemoryOverviewViewModel : TimerRefreshViewModelBase {
+    private const int HmaSizeBytes = 65520;
+    private const int EmsPageSizeBytes = 16 * 1024;
+
+    private readonly DosMemoryManager _memoryManager;
+    private readonly ExpandedMemoryManager? _ems;
+    private readonly ExtendedMemoryManager? _xms;
+
+    /// <inheritdoc />
+    public override string Header => "Memory Overview";
+
+    /// <summary>MCBs as bar-graph segments.</summary>
+    public List<ConventionalMemorySegment> Segments { get; private set; } = new();
+
+    /// <summary>Bumped whenever <see cref="Segments"/> is rebuilt.</summary>
+    [ObservableProperty]
+    private int _segmentsVersion;
+
+    /// <summary>Table rows for the structured memory summary.</summary>
+    public ObservableCollection<MemoryReportRow> Rows { get; } = new();
+
+    [ObservableProperty]
+    private string _conventionalSummary = string.Empty;
+
+    [ObservableProperty]
+    private long _largestFreeConventionalBytes;
+
+    [ObservableProperty]
+    private long _largestFreeXmsBytes;
+
+    [ObservableProperty]
+    private int _mcbCount;
+
+    [ObservableProperty]
+    private int _freeMcbCount;
+
+    [ObservableProperty]
+    private int _xmsHandlesAllocated;
+
+    [ObservableProperty]
+    private int _emsHandlesAllocated;
+
+    [ObservableProperty]
+    private bool _xmsLoaded;
+
+    [ObservableProperty]
+    private bool _emsLoaded;
+
+    [ObservableProperty]
+    private bool _hmaPresent;
+
+    [ObservableProperty]
+    private bool _hmaClaimed;
+
+    /// <summary>Human-friendly HMA status (present + claimed/available, or absent).</summary>
+    public string HmaStatus {
+        get {
+            if (!HmaPresent) {
+                return "Not present";
+            }
+            if (HmaClaimed) {
+                return "Claimed by program";
+            }
+            return "Available";
+        }
+    }
+
+    partial void OnHmaPresentChanged(bool value) {
+        OnPropertyChanged(nameof(HmaStatus));
+    }
+
+    partial void OnHmaClaimedChanged(bool value) {
+        OnPropertyChanged(nameof(HmaStatus));
+    }
+
+    /// <summary>Initializes a new <see cref="DosMemoryOverviewViewModel"/>.</summary>
+    public DosMemoryOverviewViewModel(DosMemoryManager memoryManager,
+        ExpandedMemoryManager? ems, ExtendedMemoryManager? xms,
+        IPauseHandler pauseHandler) : base(400, pauseHandler) {
+        _memoryManager = memoryManager;
+        _ems = ems;
+        _xms = xms;
+    }
+
+    /// <inheritdoc />
+    protected override void RefreshCore() {
+        RefreshConventional(out long convTotal, out long convUsed, out long convFree);
+
+        long xmsTotal = 0;
+        long xmsFree = 0;
+        long xmsLargestFree = 0;
+        int xmsHandles = 0;
+        bool xmsEnabled = _xms is not null;
+        bool hmaPresent = false;
+        bool hmaClaimed = false;
+        if (_xms is not null) {
+            xmsTotal = (long)ExtendedMemoryManager.XmsMemorySize * 1024L;
+            xmsFree = _xms.TotalFreeMemory;
+            xmsLargestFree = _xms.LargestFreeBlockLength;
+            xmsHandles = _xms.HandlesSnapshot.Count;
+            hmaPresent = true;
+            hmaClaimed = _xms.IsHighMemoryAreaClaimed;
+        }
+
+        long emsTotal = 0;
+        long emsFree = 0;
+        int emsHandles = 0;
+        bool emsEnabled = _ems is not null;
+        if (_ems is not null) {
+            emsTotal = (long)EmmMemory.TotalPages * EmsPageSizeBytes;
+            emsFree = (long)_ems.GetFreePageCount() * EmsPageSizeBytes;
+            emsHandles = _ems.EmmHandles.Count;
+        }
+
+        Rows.Clear();
+        Rows.Add(new MemoryReportRow {
+            Category = "Conventional",
+            TotalBytes = convTotal,
+            UsedBytes = convUsed,
+            FreeBytes = convFree,
+            Notes = $"Largest free MCB: {LargestFreeConventionalBytes:N0} bytes"
+        });
+
+        long hmaUsed;
+        long hmaFree;
+        string hmaNotes;
+        long hmaTotal;
+        if (hmaPresent) {
+            hmaTotal = HmaSizeBytes;
+            if (hmaClaimed) {
+                hmaUsed = HmaSizeBytes;
+                hmaFree = 0;
+                hmaNotes = "Claimed by program";
+            } else {
+                hmaUsed = 0;
+                hmaFree = HmaSizeBytes;
+                hmaNotes = "Available";
+            }
+        } else {
+            hmaTotal = 0;
+            hmaUsed = 0;
+            hmaFree = 0;
+            hmaNotes = "No XMS driver";
+        }
+        Rows.Add(new MemoryReportRow {
+            Category = "HMA",
+            TotalBytes = hmaTotal,
+            UsedBytes = hmaUsed,
+            FreeBytes = hmaFree,
+            Notes = hmaNotes
+        });
+
+        string xmsNotes;
+        if (xmsEnabled) {
+            xmsNotes = $"Handles: {xmsHandles} / Largest free: {xmsLargestFree:N0} bytes";
+        } else {
+            xmsNotes = "Driver not loaded";
+        }
+        Rows.Add(new MemoryReportRow {
+            Category = "Extended (XMS)",
+            TotalBytes = xmsTotal,
+            UsedBytes = xmsTotal - xmsFree,
+            FreeBytes = xmsFree,
+            Notes = xmsNotes
+        });
+
+        string emsNotes;
+        if (emsEnabled) {
+            emsNotes = $"Handles: {emsHandles} / Page size: {EmsPageSizeBytes:N0} bytes";
+        } else {
+            emsNotes = "Driver not loaded";
+        }
+        Rows.Add(new MemoryReportRow {
+            Category = "Expanded (EMS)",
+            TotalBytes = emsTotal,
+            UsedBytes = emsTotal - emsFree,
+            FreeBytes = emsFree,
+            Notes = emsNotes
+        });
+
+        long allTotal = convTotal + hmaTotal + xmsTotal + emsTotal;
+        long allFree = convFree + hmaFree + xmsFree + emsFree;
+        Rows.Add(new MemoryReportRow {
+            Category = "Total",
+            TotalBytes = allTotal,
+            UsedBytes = allTotal - allFree,
+            FreeBytes = allFree,
+            Notes = string.Empty
+        });
+
+        XmsLoaded = xmsEnabled;
+        EmsLoaded = emsEnabled;
+        HmaPresent = hmaPresent;
+        HmaClaimed = hmaClaimed;
+        XmsHandlesAllocated = xmsHandles;
+        EmsHandlesAllocated = emsHandles;
+        LargestFreeXmsBytes = xmsLargestFree;
+    }
+
+    private void RefreshConventional(out long total, out long used, out long free) {
+        List<ConventionalMemorySegment> segments = new();
+        total = 0;
+        free = 0;
+        long largestFree = 0;
+        int mcbs = 0;
+        int frees = 0;
+
+        foreach (DosMemoryControlBlock block in _memoryManager.EnumerateBlocks()) {
+            if (!block.IsValid) {
+                break;
+            }
+            mcbs++;
+            long sizeBytes = block.AllocationSizeInBytes;
+            total += sizeBytes;
+
+            string owner;
+            if (block.IsFree) {
+                frees++;
+                free += sizeBytes;
+                if (sizeBytes > largestFree) {
+                    largestFree = sizeBytes;
+                }
+                owner = "(free)";
+            } else {
+                if (string.IsNullOrEmpty(block.Owner)) {
+                    owner = "PSP 0x" + block.PspSegment.ToString("X4");
+                } else {
+                    owner = block.Owner;
+                }
+            }
+
+            segments.Add(new ConventionalMemorySegment {
+                StartSegment = block.DataBlockSegment,
+                SizeBytes = sizeBytes,
+                IsFree = block.IsFree,
+                Owner = owner,
+                IsLast = block.IsLast
+            });
+        }
+
+        Segments = segments;
+        used = total - free;
+        LargestFreeConventionalBytes = largestFree;
+        McbCount = mcbs;
+        FreeMcbCount = frees;
+        ConventionalSummary =
+            $"MCBs: {mcbs} ({frees} free) / Total: {total:N0} B / Used: {used:N0} B / Free: {free:N0} B / Largest free: {largestFree:N0} B";
+        SegmentsVersion++;
+    }
+}

--- a/src/Spice86/ViewModels/DosMemorySummaryViewModel.cs
+++ b/src/Spice86/ViewModels/DosMemorySummaryViewModel.cs
@@ -1,0 +1,33 @@
+namespace Spice86.ViewModels;
+
+using Spice86.Core.Emulator.InterruptHandlers.Dos.Ems;
+using Spice86.Core.Emulator.InterruptHandlers.Dos.Xms;
+using Spice86.Core.Emulator.OperatingSystem;
+using Spice86.Core.Emulator.VM;
+using Spice86.ViewModels.PropertiesMappers;
+using Spice86.ViewModels.ValueViewModels.Debugging;
+
+/// <summary>
+/// DOS memory map summary inspector.
+/// </summary>
+public sealed partial class DosMemorySummaryViewModel : InspectorViewModelBase<DosMemorySummaryInfo> {
+    private readonly DosMemoryManager _memoryManager;
+    private readonly ExpandedMemoryManager? _ems;
+    private readonly ExtendedMemoryManager? _xms;
+
+    /// <inheritdoc />
+    public override string Header => "DOS Memory Summary";
+
+    /// <summary>Initializes a new <see cref="DosMemorySummaryViewModel"/>.</summary>
+    public DosMemorySummaryViewModel(DosMemoryManager memoryManager,
+        ExpandedMemoryManager? ems, ExtendedMemoryManager? xms, IPauseHandler pauseHandler) : base(400, pauseHandler) {
+        _memoryManager = memoryManager;
+        _ems = ems;
+        _xms = xms;
+    }
+
+    /// <inheritdoc />
+    protected override void RefreshInfo(DosMemorySummaryInfo info) {
+        _memoryManager.CopyToDosMemorySummaryInfo(info, _ems, _xms);
+    }
+}

--- a/src/Spice86/ViewModels/DosPspChainViewModel.cs
+++ b/src/Spice86/ViewModels/DosPspChainViewModel.cs
@@ -1,0 +1,125 @@
+namespace Spice86.ViewModels;
+
+using CommunityToolkit.Mvvm.ComponentModel;
+
+using Spice86.Core.Emulator.Memory.ReaderWriter;
+using Spice86.Core.Emulator.OperatingSystem;
+using Spice86.Core.Emulator.OperatingSystem.Structures;
+using Spice86.Core.Emulator.VM;
+using Spice86.Shared.Utils;
+using Spice86.ViewModels.PropertiesMappers;
+using Spice86.ViewModels.Services;
+using Spice86.ViewModels.ValueViewModels.Debugging;
+
+using System.Collections.ObjectModel;
+
+/// <summary>
+/// DOS PSP chain inspector. Walks PSPs reachable from the current PSP via <see cref="DosProgramSegmentPrefix.ParentProgramSegmentPrefix"/>.
+/// </summary>
+public sealed partial class DosPspChainViewModel : TimerRefreshViewModelBase {
+    private readonly DosMemoryManager _memoryManager;
+    private readonly DosSwappableDataArea _sda;
+    private readonly IByteReaderWriter _memory;
+
+    /// <inheritdoc />
+    public override string Header => "DOS PSP Chain";
+
+    /// <summary>All PSPs in the chain from current to root.</summary>
+    public ObservableCollection<DosPspInfo> Items { get; } = new();
+
+    [ObservableProperty]
+    private DosPspInfo? _selectedItem;
+
+    /// <summary>Initializes a new <see cref="DosPspChainViewModel"/>.</summary>
+    public DosPspChainViewModel(DosMemoryManager memoryManager, DosSwappableDataArea sda, IByteReaderWriter memory,
+        IPauseHandler pauseHandler) : base(400, pauseHandler) {
+        _memoryManager = memoryManager;
+        _sda = sda;
+        _memory = memory;
+    }
+
+    /// <inheritdoc />
+    protected override void RefreshCore() {
+        ushort currentPsp = _sda.CurrentProgramSegmentPrefix;
+        Dictionary<ushort, string> mcbOwnerNameByPsp = BuildMcbOwnerNameByPsp();
+        List<DosPspInfo> chain = new();
+        HashSet<ushort> visited = new();
+        ushort segment = currentPsp;
+        int guard = 0;
+        while (segment != 0 && guard < 64 && visited.Add(segment)) {
+            DosProgramSegmentPrefix psp = new(_memory, MemoryUtils.ToPhysicalAddress(segment, 0));
+            DosPspInfo info = new();
+            string ownerName = string.Empty;
+            if (mcbOwnerNameByPsp.TryGetValue(segment, out string? ownerNameFromMcb)) {
+                ownerName = ownerNameFromMcb;
+            }
+            psp.CopyToDosPspInfo(info, segment, currentPsp, ownerName);
+            chain.Add(info);
+            ushort parent = psp.ParentProgramSegmentPrefix;
+            if (parent == segment) {
+                break;
+            }
+            segment = parent;
+            guard++;
+        }
+        ushort? previouslySelected;
+        if (SelectedItem is null) {
+            previouslySelected = null;
+        } else {
+            previouslySelected = TryParseSegment(SelectedItem.Segment);
+        }
+        Items.Clear();
+        foreach (DosPspInfo info in chain) {
+            Items.Add(info);
+        }
+        if (previouslySelected is null) {
+            if (Items.Count > 0) {
+                SelectedItem = Items[0];
+            } else {
+                SelectedItem = null;
+            }
+        } else {
+            DosPspInfo? found = Items.FirstOrDefault(i => TryParseSegment(i.Segment) == previouslySelected);
+            if (found is not null) {
+                SelectedItem = found;
+            } else if (Items.Count > 0) {
+                SelectedItem = Items[0];
+            } else {
+                SelectedItem = null;
+            }
+        }
+    }
+
+    private Dictionary<ushort, string> BuildMcbOwnerNameByPsp() {
+        Dictionary<ushort, string> ownerNameByPsp = new();
+        foreach (DosMemoryControlBlock block in _memoryManager.EnumerateBlocks()) {
+            if (!block.IsValid || block.IsFree || ownerNameByPsp.ContainsKey(block.PspSegment)) {
+                continue;
+            }
+
+            string owner = block.Owner.Trim();
+            if (!string.IsNullOrEmpty(owner)) {
+                ownerNameByPsp[block.PspSegment] = owner;
+            }
+        }
+
+        return ownerNameByPsp;
+    }
+
+    private static ushort? TryParseSegment(string text) {
+        if (string.IsNullOrEmpty(text)) {
+            return null;
+        }
+        string trimmed;
+        if (text.StartsWith("0x", StringComparison.OrdinalIgnoreCase)) {
+            trimmed = text[2..];
+        } else {
+            trimmed = text;
+        }
+        if (ushort.TryParse(trimmed, System.Globalization.NumberStyles.HexNumber,
+            System.Globalization.CultureInfo.InvariantCulture, out ushort value)) {
+            return value;
+        }
+        return null;
+    }
+}

--- a/src/Spice86/ViewModels/DosPspGraphViewModel.cs
+++ b/src/Spice86/ViewModels/DosPspGraphViewModel.cs
@@ -1,0 +1,237 @@
+namespace Spice86.ViewModels;
+
+using AvaloniaGraphControl;
+
+using CommunityToolkit.Mvvm.ComponentModel;
+
+using Spice86.Core.Emulator.Memory.ReaderWriter;
+using Spice86.Core.Emulator.OperatingSystem;
+using Spice86.Core.Emulator.OperatingSystem.Structures;
+using Spice86.Core.Emulator.VM;
+using Spice86.Shared.Utils;
+using Spice86.ViewModels.DataModels;
+using Spice86.ViewModels.Enums;
+using Spice86.ViewModels.PropertiesMappers;
+using Spice86.ViewModels.Services;
+using Spice86.ViewModels.ValueViewModels.Debugging;
+
+using System;
+using System.Linq;
+
+/// <summary>
+/// DOS PSP parent chain graph view.
+/// </summary>
+public sealed partial class DosPspGraphViewModel : TimerRefreshViewModelBase {
+    private readonly DosMemoryManager _memoryManager;
+    private readonly DosSwappableDataArea _sda;
+    private readonly IByteReaderWriter _memory;
+
+    /// <inheritdoc />
+    public override string Header => "DOS PSP Graph";
+
+    [ObservableProperty]
+    private Graph? _graph;
+
+    [ObservableProperty]
+    private string _statusMessage = string.Empty;
+
+    /// <summary>
+    /// Initializes a new <see cref="DosPspGraphViewModel"/>.
+    /// </summary>
+    public DosPspGraphViewModel(DosMemoryManager memoryManager, DosSwappableDataArea sda, IByteReaderWriter memory,
+        IPauseHandler pauseHandler) : base(400, pauseHandler) {
+        _memoryManager = memoryManager;
+        _sda = sda;
+        _memory = memory;
+    }
+
+    /// <inheritdoc />
+    protected override void RefreshCore() {
+        ushort currentPsp = _sda.CurrentProgramSegmentPrefix;
+        Dictionary<int, DosGraphNode> nodes = new();
+        List<(int Child, int Parent)> links = new();
+        Dictionary<ushort, List<ushort>> mcbHeaderSegmentsByPsp = new();
+        Dictionary<ushort, int> mcbBytesByPsp = new();
+        Dictionary<ushort, string> mcbOwnerNameByPsp = new();
+        List<(ushort OwnerPspSegment, ushort HeaderSegment, int SizeBytes, string OwnerName)> mcbNodeInfos = new();
+
+        foreach (DosMemoryControlBlock block in _memoryManager.EnumerateBlocks()) {
+            if (!block.IsValid || block.IsFree) {
+                continue;
+            }
+
+            ushort pspSegment = block.PspSegment;
+            if (!mcbHeaderSegmentsByPsp.TryGetValue(pspSegment, out List<ushort>? headerSegments)) {
+                headerSegments = new List<ushort>();
+                mcbHeaderSegmentsByPsp[pspSegment] = headerSegments;
+                mcbBytesByPsp[pspSegment] = 0;
+            }
+
+            headerSegments.Add((ushort)(block.DataBlockSegment - 1));
+            mcbBytesByPsp[pspSegment] = mcbBytesByPsp[pspSegment] + block.AllocationSizeInBytes;
+
+            mcbNodeInfos.Add((pspSegment, (ushort)(block.DataBlockSegment - 1), block.AllocationSizeInBytes, block.Owner));
+
+            if (!mcbOwnerNameByPsp.ContainsKey(pspSegment)) {
+                string owner = block.Owner.Trim();
+                if (!string.IsNullOrEmpty(owner)) {
+                    mcbOwnerNameByPsp[pspSegment] = owner;
+                }
+            }
+        }
+
+        HashSet<ushort> visited = new();
+        ushort segment = currentPsp;
+        int guard = 0;
+        while (segment != 0 && guard < 64 && visited.Add(segment)) {
+            DosProgramSegmentPrefix psp = new(_memory, MemoryUtils.ToPhysicalAddress(segment, 0));
+            DosPspInfo info = new();
+            string ownerName = string.Empty;
+            if (mcbOwnerNameByPsp.TryGetValue(segment, out string? ownerNameFromMcb)) {
+                ownerName = ownerNameFromMcb;
+            }
+            psp.CopyToDosPspInfo(info, segment, currentPsp, ownerName);
+
+            int nodeId = segment;
+            nodes[nodeId] = CreateNodeFromInfo(nodeId, info, segment, mcbHeaderSegmentsByPsp, mcbBytesByPsp);
+
+            ushort parent = psp.ParentProgramSegmentPrefix;
+            if (parent != 0 && parent != segment) {
+                int parentId = parent;
+                links.Add((nodeId, parentId));
+                if (!nodes.ContainsKey(parentId)) {
+                    nodes[parentId] = CreatePlaceholderNode(parentId);
+                }
+            }
+
+            if (parent == segment) {
+                break;
+            }
+
+            segment = parent;
+            guard++;
+        }
+
+        HashSet<int> pspNodeIds = new(nodes.Keys);
+        foreach ((ushort ownerPspSegment, ushort headerSegment, int sizeBytes, string ownerName) in mcbNodeInfos) {
+            int ownerNodeId = ownerPspSegment;
+            if (!nodes.ContainsKey(ownerNodeId)) {
+                continue;
+            }
+
+            int mcbNodeId = GetMcbNodeId(headerSegment);
+            if (!nodes.ContainsKey(mcbNodeId)) {
+                nodes[mcbNodeId] = CreateMcbNode(mcbNodeId, headerSegment, ownerPspSegment, sizeBytes, ownerName);
+            }
+
+            links.Add((mcbNodeId, ownerNodeId));
+        }
+
+        Graph graph = new();
+        HashSet<int> nodesWithEdges = new();
+        foreach ((int childId, int parentId) in links) {
+            if (!nodes.TryGetValue(childId, out DosGraphNode? childNode)) {
+                continue;
+            }
+            if (!nodes.TryGetValue(parentId, out DosGraphNode? parentNode)) {
+                continue;
+            }
+
+            string edgeText = "parent";
+            if (pspNodeIds.Contains(parentId) && !pspNodeIds.Contains(childId)) {
+                edgeText = "owned by";
+            }
+            CfgGraphEdgeLabel edgeLabel = new() { Text = edgeText, EdgeType = CfgEdgeType.Normal };
+            graph.Edges.Add(new Edge(childNode, parentNode, edgeLabel));
+            nodesWithEdges.Add(childId);
+            nodesWithEdges.Add(parentId);
+        }
+
+        foreach (KeyValuePair<int, DosGraphNode> entry in nodes) {
+            if (!nodesWithEdges.Contains(entry.Key)) {
+                CfgGraphEdgeLabel edgeLabel = new() { Text = string.Empty, EdgeType = CfgEdgeType.IsolatedNodeLoop };
+                graph.Edges.Add(new Edge(entry.Value, entry.Value, edgeLabel, Edge.Symbol.None, Edge.Symbol.None));
+            }
+        }
+
+        Graph = graph;
+        int pspNodesWithOwnedMcbs = pspNodeIds.Count(nodeId => mcbHeaderSegmentsByPsp.ContainsKey((ushort)nodeId));
+        StatusMessage = $"PSP nodes: {pspNodeIds.Count} / MCB nodes: {mcbNodeInfos.Count} / Links: {links.Count} / PSPs with owned MCBs: {pspNodesWithOwnedMcbs}";
+    }
+
+    private static DosGraphNode CreateNodeFromInfo(int nodeId, DosPspInfo info, ushort pspSegment,
+        IReadOnlyDictionary<ushort, List<ushort>> mcbHeaderSegmentsByPsp,
+        IReadOnlyDictionary<ushort, int> mcbBytesByPsp) {
+        string title = "PSP " + info.Segment;
+        string ownerName = info.OwnerName;
+        string subtitle = BuildMcbSummary(pspSegment, mcbHeaderSegmentsByPsp, mcbBytesByPsp);
+        if (!string.IsNullOrWhiteSpace(ownerName)) {
+            subtitle = ownerName + Environment.NewLine + subtitle;
+        }
+        if (info.IsCurrent) {
+            subtitle = subtitle + Environment.NewLine + "current";
+        }
+
+        return new DosGraphNode {
+            NodeId = nodeId,
+            Title = title,
+            Subtitle = subtitle,
+            Kind = DosGraphNodeKind.Psp,
+        };
+    }
+
+    private static string BuildMcbSummary(ushort pspSegment, IReadOnlyDictionary<ushort, List<ushort>> mcbHeaderSegmentsByPsp,
+        IReadOnlyDictionary<ushort, int> mcbBytesByPsp) {
+        if (!mcbHeaderSegmentsByPsp.TryGetValue(pspSegment, out List<ushort>? headerSegments) || headerSegments.Count == 0) {
+            return "Owned MCBs: none";
+        }
+
+        IReadOnlyList<ushort> orderedHeaderSegments = headerSegments
+            .OrderBy(static segment => segment)
+            .ToArray();
+        int previewCount = Math.Min(4, orderedHeaderSegments.Count);
+        string headersText = string.Join(",", orderedHeaderSegments
+            .Take(previewCount)
+            .Select(static segment => ConvertUtils.ToHex16(segment)));
+        if (orderedHeaderSegments.Count > previewCount) {
+            headersText = headersText + ",...";
+        }
+
+        if (!mcbBytesByPsp.TryGetValue(pspSegment, out int totalBytes)) {
+            totalBytes = 0;
+        }
+
+        return $"Owned MCBs: {headerSegments.Count} ({totalBytes} B), headers: {headersText}";
+    }
+
+    private static DosGraphNode CreatePlaceholderNode(int nodeId) {
+        string hex = ConvertUtils.ToHex16((ushort)nodeId);
+        return new DosGraphNode {
+            NodeId = nodeId,
+            Title = "PSP " + hex,
+            Subtitle = "(referenced parent)",
+            Kind = DosGraphNodeKind.Psp,
+        };
+    }
+
+    private static int GetMcbNodeId(ushort headerSegment) {
+        return 0x10000 + headerSegment;
+    }
+
+    private static DosGraphNode CreateMcbNode(int nodeId, ushort headerSegment, ushort ownerPspSegment, int sizeBytes,
+        string ownerName) {
+        string subtitle = "Owner PSP: " + ConvertUtils.ToHex16(ownerPspSegment) + Environment.NewLine +
+            "Size: " + sizeBytes + " B";
+        string trimmedOwnerName = ownerName.Trim();
+        if (!string.IsNullOrEmpty(trimmedOwnerName)) {
+            subtitle = subtitle + Environment.NewLine + "Owner: " + trimmedOwnerName;
+        }
+
+        return new DosGraphNode {
+            NodeId = nodeId,
+            Title = "MCB " + ConvertUtils.ToHex16(headerSegment),
+            Subtitle = subtitle,
+            Kind = DosGraphNodeKind.Mcb,
+        };
+    }
+}

--- a/src/Spice86/ViewModels/EmsViewModel.cs
+++ b/src/Spice86/ViewModels/EmsViewModel.cs
@@ -12,27 +12,22 @@ using Spice86.Core.Emulator.VM;
 using Spice86.Shared.Emulator.Memory;
 using Spice86.Shared.Utils;
 using Spice86.ViewModels.DataModels;
+using Spice86.ViewModels.Enums;
 using Spice86.ViewModels.Services;
 
 using System.Text;
 using System.Windows.Input;
 
-public partial class EmsViewModel : ViewModelBase, IEmulatorObjectViewModel, IMemorySearchViewModel, IDebuggerTabContentViewModel {
+public partial class EmsViewModel : TimerRefreshViewModelBase, IMemorySearchViewModel {
     private readonly ExpandedMemoryManager _ems;
-    private readonly IPauseHandler _pauseHandler;
-    private List<EmsHandleEntryViewModel> _allHandles = new();
-    private List<EmsPhysicalPageEntryViewModel> _allPhysicalPages = new();
+    private readonly List<EmsHandleEntryViewModel> _allHandles = new();
+    private readonly List<EmsPhysicalPageEntryViewModel> _allPhysicalPages = new();
 
-    public EmsViewModel(ExpandedMemoryManager ems, IPauseHandler pauseHandler) {
+    public EmsViewModel(ExpandedMemoryManager ems, IPauseHandler pauseHandler) : base(400, pauseHandler) {
         _ems = ems;
-        _pauseHandler = pauseHandler;
-        Refresh();
     }
 
-    public bool IsVisible { get; set; }
-
-    [ObservableProperty]
-    private string _header = "EMS";
+    public override string Header => "EMS";
 
     [ObservableProperty]
     private ushort _totalPages;
@@ -51,11 +46,6 @@ public partial class EmsViewModel : ViewModelBase, IEmulatorObjectViewModel, IMe
 
     [ObservableProperty]
     private string _logicalPageSearchText = string.Empty;
-
-    public enum MemorySearchDataType {
-        Binary,
-        Ascii,
-    }
 
     [ObservableProperty]
     private MemorySearchDataType _searchDataType = MemorySearchDataType.Binary;
@@ -114,13 +104,9 @@ public partial class EmsViewModel : ViewModelBase, IEmulatorObjectViewModel, IMe
 
     public ICommand OpenFoundOccurrenceAction => OpenFoundOccurrenceCommand;
 
-    private enum SearchDirection {
-        FirstOccurence,
-        Forward,
-        Backward,
-    }
-
     private SearchDirection _searchDirection;
+    private ushort? _lastSelectedHandleNumber;
+    private (ushort HandleNumber, int LogicalPageIndex, ushort PageNumber)? _lastSelectedLogicalPage;
 
     [ObservableProperty]
     private AvaloniaList<EmsHandleEntryViewModel> _handles = new();
@@ -157,7 +143,7 @@ public partial class EmsViewModel : ViewModelBase, IEmulatorObjectViewModel, IMe
 
     [RelayCommand]
     private async Task FirstOccurrence() {
-        _searchDirection = SearchDirection.FirstOccurence;
+        _searchDirection = SearchDirection.FirstOccurrence;
         await SearchSelectedPageCommand.ExecuteAsync(null);
     }
 
@@ -188,19 +174,34 @@ public partial class EmsViewModel : ViewModelBase, IEmulatorObjectViewModel, IMe
         ApplyLogicalPageFilter(selectedPageNumber);
     }
 
-    public void UpdateValues(object? sender, EventArgs e) {
-        if (!IsVisible || !_pauseHandler.IsPaused) {
-            return;
-        }
+    protected override void RefreshCore() {
         Refresh();
     }
 
     partial void OnSelectedHandleChanged(EmsHandleEntryViewModel? value) {
+        ushort? selectedHandleNumber = value?.HandleNumber;
+        if (selectedHandleNumber == _lastSelectedHandleNumber) {
+            return;
+        }
+
+        _lastSelectedHandleNumber = selectedHandleNumber;
         ushort? selectedPageNumber = SelectedLogicalPage?.PageNumber;
         ApplyLogicalPageFilter(selectedPageNumber);
     }
 
     partial void OnSelectedLogicalPageChanged(EmsLogicalPageEntryViewModel? value) {
+        (ushort HandleNumber, int LogicalPageIndex, ushort PageNumber)? selectedLogicalPage;
+        if (value is null) {
+            selectedLogicalPage = null;
+        } else {
+            selectedLogicalPage = (value.HandleNumber, value.LogicalPageIndex, value.PageNumber);
+        }
+
+        if (selectedLogicalPage == _lastSelectedLogicalPage) {
+            return;
+        }
+
+        _lastSelectedLogicalPage = selectedLogicalPage;
         RefreshSelectedPageDocument();
     }
 
@@ -219,21 +220,21 @@ public partial class EmsViewModel : ViewModelBase, IEmulatorObjectViewModel, IMe
         PageSize = ExpandedMemoryManager.EmmPageSize;
         PageFrameSegment = ConvertUtils.ToHex16(ExpandedMemoryManager.EmmPageFrameSegment);
 
-        _allHandles = _ems.EmmHandles
+        _allHandles.Clear();
+        _allHandles.AddRange(_ems.EmmHandles
             .OrderBy(static x => x.Key)
             .Select(static x => new EmsHandleEntryViewModel(
                 (ushort)x.Key,
                 x.Value.ToString(),
                 x.Value.LogicalPages.Count,
-                x.Value.SavedPageMap))
-            .ToList();
+                x.Value.SavedPageMap)));
 
-        _allPhysicalPages = _ems.EmmPageFrame
+        _allPhysicalPages.Clear();
+        _allPhysicalPages.AddRange(_ems.EmmPageFrame
             .OrderBy(static x => x.Key)
-            .Select(x => CreatePhysicalPageEntry(x.Key, x.Value))
-            .ToList();
+            .Select(x => CreatePhysicalPageEntry(x.Key, x.Value)));
 
-        PhysicalPages = new AvaloniaList<EmsPhysicalPageEntryViewModel>(_allPhysicalPages);
+        ReplaceItems(PhysicalPages, _allPhysicalPages);
         ApplyHandleFilter(selectedHandleNumber);
         ApplyLogicalPageFilter(selectedPageNumber);
     }
@@ -245,13 +246,13 @@ public partial class EmsViewModel : ViewModelBase, IEmulatorObjectViewModel, IMe
             filteredHandles = filteredHandles.Where(x => HandleMatchesSearch(x, trimmedSearch));
         }
 
-        Handles = new AvaloniaList<EmsHandleEntryViewModel>(filteredHandles);
+        ReplaceItems(Handles, filteredHandles);
         SelectedHandle = Handles.FirstOrDefault(x => x.HandleNumber == selectedHandleNumber) ?? Handles.FirstOrDefault();
     }
 
     private void ApplyLogicalPageFilter(ushort? selectedPageNumber) {
         if (SelectedHandle is null || !_ems.EmmHandles.TryGetValue(SelectedHandle.HandleNumber, out EmmHandle? emmHandle)) {
-            LogicalPages = new AvaloniaList<EmsLogicalPageEntryViewModel>();
+            LogicalPages.Clear();
             SelectedLogicalPage = null;
             RefreshSelectedPageDocument();
             return;
@@ -265,9 +266,14 @@ public partial class EmsViewModel : ViewModelBase, IEmulatorObjectViewModel, IMe
             logicalPages = logicalPages.Where(x => LogicalPageMatchesSearch(x, trimmedSearch));
         }
 
-        LogicalPages = new AvaloniaList<EmsLogicalPageEntryViewModel>(logicalPages);
+        ReplaceItems(LogicalPages, logicalPages);
 
         SelectedLogicalPage = LogicalPages.FirstOrDefault(x => x.PageNumber == selectedPageNumber) ?? LogicalPages.FirstOrDefault();
+    }
+
+    private static void ReplaceItems<T>(AvaloniaList<T> target, IEnumerable<T> items) {
+        target.Clear();
+        target.AddRange(items);
     }
 
     private void RefreshSelectedPageDocument() {
@@ -328,10 +334,18 @@ public partial class EmsViewModel : ViewModelBase, IEmulatorObjectViewModel, IMe
 
     private EmsPhysicalPageEntryViewModel CreatePhysicalPageEntry(ushort physicalPageNumber, EmmRegister emmRegister) {
         int? owningHandleNumber = FindOwningHandleNumber(emmRegister.PhysicalPage);
-        string handleNumber = owningHandleNumber is null ? "Unmapped" : ConvertUtils.ToHex16((ushort)owningHandleNumber.Value);
-        string logicalPageNumber = emmRegister.PhysicalPage.PageNumber == ExpandedMemoryManager.EmmNullPage
-            ? "Unmapped"
-            : ConvertUtils.ToHex16(emmRegister.PhysicalPage.PageNumber);
+        string handleNumber;
+        if (owningHandleNumber is null) {
+            handleNumber = "Unmapped";
+        } else {
+            handleNumber = ConvertUtils.ToHex16((ushort)owningHandleNumber.Value);
+        }
+        string logicalPageNumber;
+        if (emmRegister.PhysicalPage.PageNumber == ExpandedMemoryManager.EmmNullPage) {
+            logicalPageNumber = "Unmapped";
+        } else {
+            logicalPageNumber = ConvertUtils.ToHex16(emmRegister.PhysicalPage.PageNumber);
+        }
         SegmentedAddress pageAddress = new(ExpandedMemoryManager.EmmPageFrameSegment,
             (ushort)(physicalPageNumber * ExpandedMemoryManager.EmmPageSize));
         return new EmsPhysicalPageEntryViewModel(

--- a/src/Spice86/ViewModels/Enums/CfgEdgeType.cs
+++ b/src/Spice86/ViewModels/Enums/CfgEdgeType.cs
@@ -1,4 +1,4 @@
-namespace Spice86.ViewModels;
+namespace Spice86.ViewModels.Enums;
 
 /// <summary>
 /// Classifies CFG graph edges for automatic color assignment.

--- a/src/Spice86/ViewModels/Enums/CfgNodeType.cs
+++ b/src/Spice86/ViewModels/Enums/CfgNodeType.cs
@@ -1,4 +1,4 @@
-namespace Spice86.ViewModels;
+namespace Spice86.ViewModels.Enums;
 
 /// <summary>
 /// Classifies CFG graph nodes by instruction type for visual styling.

--- a/src/Spice86/ViewModels/Enums/DosGraphNodeKind.cs
+++ b/src/Spice86/ViewModels/Enums/DosGraphNodeKind.cs
@@ -1,0 +1,16 @@
+namespace Spice86.ViewModels.Enums;
+
+/// <summary>
+/// Node kind used by DOS graph views.
+/// </summary>
+public enum DosGraphNodeKind {
+    /// <summary>
+    /// Program Segment Prefix node.
+    /// </summary>
+    Psp,
+
+    /// <summary>
+    /// Memory Control Block node.
+    /// </summary>
+    Mcb,
+}

--- a/src/Spice86/ViewModels/Enums/JumpSegmentType.cs
+++ b/src/Spice86/ViewModels/Enums/JumpSegmentType.cs
@@ -1,4 +1,4 @@
-namespace Spice86.ViewModels;
+namespace Spice86.ViewModels.Enums;
 
 /// <summary>
 /// Describes the role of a jump arc segment at a specific disassembly line.

--- a/src/Spice86/ViewModels/Enums/MemorySearchDataType.cs
+++ b/src/Spice86/ViewModels/Enums/MemorySearchDataType.cs
@@ -1,0 +1,6 @@
+namespace Spice86.ViewModels.Enums;
+
+public enum MemorySearchDataType {
+    Binary,
+    Ascii,
+}

--- a/src/Spice86/ViewModels/Enums/SearchDirection.cs
+++ b/src/Spice86/ViewModels/Enums/SearchDirection.cs
@@ -1,0 +1,7 @@
+namespace Spice86.ViewModels.Enums;
+
+internal enum SearchDirection {
+    FirstOccurrence,
+    Forward,
+    Backward,
+}

--- a/src/Spice86/ViewModels/InspectorViewModelBase.cs
+++ b/src/Spice86/ViewModels/InspectorViewModelBase.cs
@@ -1,0 +1,43 @@
+namespace Spice86.ViewModels;
+
+using CommunityToolkit.Mvvm.ComponentModel;
+
+using Spice86.Core.Emulator.VM;
+using Spice86.ViewModels.ValueViewModels.Debugging;
+
+/// <summary>
+/// Base class for read-only inspector sub-tabs: one Info object rendered by a PropertyGrid, refreshed by a dispatcher timer while visible.
+/// </summary>
+/// <typeparam name="TInfo">The Info POCO type rendered by this view-model.</typeparam>
+public abstract partial class InspectorViewModelBase<TInfo> : TimerRefreshViewModelBase
+    where TInfo : InspectorInfoBase, new() {
+    [ObservableProperty]
+    private TInfo _info = new();
+
+    /// <summary>
+    /// Initializes the dispatcher timer that refreshes <see cref="Info"/> while the panel is visible.
+    /// </summary>
+    /// <param name="refreshIntervalMs">Polling period in milliseconds.</param>
+    protected InspectorViewModelBase(int refreshIntervalMs) : base(refreshIntervalMs) {
+    }
+
+    /// <summary>
+    /// Initializes the dispatcher timer that refreshes <see cref="Info"/> while the panel is visible,
+    /// and applies once-per-pause refresh semantics.
+    /// </summary>
+    /// <param name="refreshIntervalMs">Polling period in milliseconds.</param>
+    /// <param name="pauseHandler">Pause state source.</param>
+    protected InspectorViewModelBase(int refreshIntervalMs, IPauseHandler pauseHandler) : base(refreshIntervalMs, pauseHandler) {
+    }
+
+    /// <inheritdoc />
+    protected sealed override void RefreshCore() {
+        RefreshInfo(Info);
+    }
+
+    /// <summary>
+    /// Implementers copy current emulator state into <paramref name="info"/>.
+    /// </summary>
+    /// <param name="info">The Info instance to update in-place.</param>
+    protected abstract void RefreshInfo(TInfo info);
+}

--- a/src/Spice86/ViewModels/JumpArcSegment.cs
+++ b/src/Spice86/ViewModels/JumpArcSegment.cs
@@ -1,5 +1,7 @@
 namespace Spice86.ViewModels;
 
+using Spice86.ViewModels.Enums;
+
 /// <summary>
 /// Represents a segment of a jump arc that passes through a specific disassembly line.
 /// </summary>

--- a/src/Spice86/ViewModels/MemoryReportRow.cs
+++ b/src/Spice86/ViewModels/MemoryReportRow.cs
@@ -1,0 +1,21 @@
+namespace Spice86.ViewModels;
+
+/// <summary>
+/// One row of the DOS memory summary table (Conventional / HMA / XMS / EMS / total).
+/// </summary>
+public sealed class MemoryReportRow {
+    /// <summary>Memory category label (e.g. "Conventional").</summary>
+    public string Category { get; init; } = string.Empty;
+
+    /// <summary>Total bytes available for the category.</summary>
+    public long TotalBytes { get; init; }
+
+    /// <summary>Used bytes.</summary>
+    public long UsedBytes { get; init; }
+
+    /// <summary>Free bytes.</summary>
+    public long FreeBytes { get; init; }
+
+    /// <summary>Optional remark (driver status, HMA flag, etc.).</summary>
+    public string Notes { get; init; } = string.Empty;
+}

--- a/src/Spice86/ViewModels/MemoryViewModel.cs
+++ b/src/Spice86/ViewModels/MemoryViewModel.cs
@@ -15,6 +15,7 @@ using Spice86.Shared.Emulator.Memory;
 using Spice86.Shared.Emulator.VM.Breakpoint;
 using Spice86.Shared.Utils;
 using Spice86.ViewModels.DataModels;
+using Spice86.ViewModels.Enums;
 using Spice86.ViewModels.Messages;
 using Spice86.ViewModels.Services;
 using Spice86.Views;
@@ -66,11 +67,6 @@ public partial class MemoryViewModel : ViewModelWithErrorDialogAndMemoryBreakpoi
 
     partial void OnTitleChanged(string? value) {
         UpdateHeaderPresentation();
-    }
-
-    public enum MemorySearchDataType {
-        Binary,
-        Ascii,
     }
 
     [ObservableProperty]
@@ -131,12 +127,26 @@ public partial class MemoryViewModel : ViewModelWithErrorDialogAndMemoryBreakpoi
     private void UpdateHeaderPresentation() {
         string addressRange = BuildAddressRange();
         HeaderToolTip = addressRange;
-        Header = string.IsNullOrWhiteSpace(Title) ? addressRange : Title;
+        if (string.IsNullOrWhiteSpace(Title)) {
+            Header = addressRange;
+        } else {
+            Header = Title;
+        }
     }
 
     private string BuildAddressRange() {
-        string start = string.IsNullOrWhiteSpace(StartAddress) ? "?" : StartAddress;
-        string end = string.IsNullOrWhiteSpace(EndAddress) ? "?" : EndAddress;
+        string start;
+        if (string.IsNullOrWhiteSpace(StartAddress)) {
+            start = "?";
+        } else {
+            start = StartAddress;
+        }
+        string end;
+        if (string.IsNullOrWhiteSpace(EndAddress)) {
+            end = "?";
+        } else {
+            end = EndAddress;
+        }
         return $"{start} - {end}";
     }
 
@@ -204,12 +214,6 @@ public partial class MemoryViewModel : ViewModelWithErrorDialogAndMemoryBreakpoi
     [ObservableProperty]
     private string? _memorySearchValue;
 
-    private enum SearchDirection {
-        FirstOccurence,
-        Forward,
-        Backward,
-    }
-
     private SearchDirection _searchDirection;
 
     [RelayCommand]
@@ -231,7 +235,7 @@ public partial class MemoryViewModel : ViewModelWithErrorDialogAndMemoryBreakpoi
     [RelayCommand]
     private async Task FirstOccurrence() {
         if (SearchMemoryCommand.CanExecute(null)) {
-            _searchDirection = SearchDirection.FirstOccurence;
+            _searchDirection = SearchDirection.FirstOccurrence;
             await SearchMemoryCommand.ExecuteAsync(null);
         }
     }
@@ -266,7 +270,14 @@ public partial class MemoryViewModel : ViewModelWithErrorDialogAndMemoryBreakpoi
     [NotifyCanExecuteChangedFor(nameof(GoToFoundOccurenceCommand))]
     private bool _isAddressOfFoundOccurrenceValid;
 
-    public string FoundOccurrenceDisplay => AddressOFoundOccurence is null ? "-" : ConvertUtils.ToHex32(AddressOFoundOccurence.Value);
+    public string FoundOccurrenceDisplay {
+        get {
+            if (AddressOFoundOccurence is null) {
+                return "-";
+            }
+            return ConvertUtils.ToHex32(AddressOFoundOccurence.Value);
+        }
+    }
 
     public ICommand SearchCancelCommand => SearchMemoryCancelCommand;
 

--- a/src/Spice86/ViewModels/MidiViewModel.cs
+++ b/src/Spice86/ViewModels/MidiViewModel.cs
@@ -1,33 +1,23 @@
 namespace Spice86.ViewModels;
 
-using Avalonia.Threading;
-
 using CommunityToolkit.Mvvm.ComponentModel;
 
 using Spice86.Core.Emulator.Devices.Sound.Midi;
 using Spice86.ViewModels.PropertiesMappers;
-using Spice86.ViewModels.Services;
 using Spice86.ViewModels.ValueViewModels.Debugging;
 
-public partial class MidiViewModel : ViewModelBase, IEmulatorObjectViewModel, IDebuggerTabContentViewModel {
-    public string Header => "General MIDI / MT-32";
+public partial class MidiViewModel : TimerRefreshViewModelBase {
+    public override string Header => "General MIDI / MT-32";
     [ObservableProperty]
     private MidiInfo _midi = new();
 
     private readonly Midi _externalMidiDevice;
 
-    public MidiViewModel(Midi externalMidiDevice) {
+    public MidiViewModel(Midi externalMidiDevice) : base(400) {
         _externalMidiDevice = externalMidiDevice;
-        DispatcherTimerStarter.StartNewDispatcherTimer(TimeSpan.FromMilliseconds(400), DispatcherPriority.Background, UpdateValues);
     }
 
-    public bool IsVisible { get; set; }
-
-
-    public void UpdateValues(object? sender, EventArgs e) {
-        if (!IsVisible) {
-            return;
-        }
+    protected override void RefreshCore() {
         _externalMidiDevice.CopyToMidiInfo(Midi);
     }
 }

--- a/src/Spice86/ViewModels/PaletteViewModel.cs
+++ b/src/Spice86/ViewModels/PaletteViewModel.cs
@@ -3,7 +3,6 @@ namespace Spice86.ViewModels;
 using Avalonia.Collections;
 using Avalonia.Controls.Shapes;
 using Avalonia.Media;
-using Avalonia.Threading;
 
 using CommunityToolkit.Mvvm.ComponentModel;
 
@@ -11,23 +10,16 @@ using Spice86.Core.Emulator.Devices.Video;
 using Spice86.Shared.Emulator.Video;
 using Spice86.ViewModels.Services;
 
-public partial class PaletteViewModel : ViewModelBase, IEmulatorObjectViewModel, IDebuggerTabContentViewModel {
-    public string Header => "Color Palette";
+public partial class PaletteViewModel : TimerRefreshViewModelBase {
+    public override string Header => "Color Palette";
     private readonly ArgbPalette _argbPalette;
 
     private readonly Dictionary<uint, Color> ColorsCache = new();
-    public PaletteViewModel(ArgbPalette argbPalette, IUIDispatcher uiDispatcher) {
+    public PaletteViewModel(ArgbPalette argbPalette, IUIDispatcher uiDispatcher) : base(1000) {
         _argbPalette = argbPalette;
-        DispatcherTimerStarter.StartNewDispatcherTimer(TimeSpan.FromMilliseconds(1000), DispatcherPriority.Background, UpdateValues);
     }
 
-    public bool IsVisible { get; set; }
-
-
-    public void UpdateValues(object? sender, EventArgs e) {
-        if (!IsVisible) {
-            return;
-        }
+    protected override void RefreshCore() {
         UpdateColors(_argbPalette);
     }
 

--- a/src/Spice86/ViewModels/PropertiesMappers/DosMapperExtensions.cs
+++ b/src/Spice86/ViewModels/PropertiesMappers/DosMapperExtensions.cs
@@ -1,0 +1,249 @@
+namespace Spice86.ViewModels.PropertiesMappers;
+
+using Spice86.Core.Emulator.InterruptHandlers.Dos.Ems;
+using Spice86.Core.Emulator.InterruptHandlers.Dos.Xms;
+using Spice86.Core.Emulator.OperatingSystem;
+using Spice86.Core.Emulator.OperatingSystem.Structures;
+using Spice86.Shared.Utils;
+using Spice86.ViewModels.ValueViewModels.Debugging;
+
+using System;
+using System.IO;
+using System.Linq;
+using System.Text;
+
+/// <summary>
+/// Mapping helpers for DOS Info POCOs. Pure read-only snapshots.
+/// </summary>
+internal static class DosMapperExtensions {
+    private const int EnvironmentPreviewMaxBytes = 512;
+    private const int EnvironmentScanMaxBytes = 4096;
+    private const int EnvironmentProgramPathMaxBytes = 260;
+
+    public static void CopyToDosMemorySummaryInfo(this DosMemoryManager memoryManager,
+        DosMemorySummaryInfo info,
+        ExpandedMemoryManager? ems,
+        ExtendedMemoryManager? xms) {
+        long freeBytes = 0;
+        long usedBytes = 0;
+        long largestFreeBytes = 0;
+        int mcbCount = 0;
+        int freeMcbCount = 0;
+        foreach (DosMemoryControlBlock block in memoryManager.EnumerateBlocks()) {
+            if (!block.IsValid) {
+                break;
+            }
+            mcbCount++;
+            long sizeBytes = block.AllocationSizeInBytes;
+            if (block.IsFree) {
+                freeMcbCount++;
+                freeBytes += sizeBytes;
+                if (sizeBytes > largestFreeBytes) {
+                    largestFreeBytes = sizeBytes;
+                }
+            } else {
+                usedBytes += sizeBytes;
+            }
+        }
+        info.ConventionalFreeBytes = freeBytes;
+        info.ConventionalUsedBytes = usedBytes;
+        info.LargestFreeBlockBytes = largestFreeBytes;
+        info.McbCount = mcbCount;
+        info.FreeMcbCount = freeMcbCount;
+
+        info.EmsEnabled = ems is not null;
+        if (ems is not null) {
+            info.EmsTotalPages = EmmMemory.TotalPages;
+            info.EmsFreePages = ems.GetFreePageCount();
+            info.EmsAllocatedHandles = ems.EmmHandles.Count;
+        } else {
+            info.EmsTotalPages = 0;
+            info.EmsFreePages = 0;
+            info.EmsAllocatedHandles = 0;
+        }
+
+        info.XmsEnabled = xms is not null;
+        if (xms is not null) {
+            info.XmsTotalBytes = (long)ExtendedMemoryManager.XmsMemorySize * 1024L;
+            info.XmsFreeBytes = xms.TotalFreeMemory;
+            info.XmsAllocatedHandles = xms.HandlesSnapshot.Count;
+        } else {
+            info.XmsTotalBytes = 0;
+            info.XmsFreeBytes = 0;
+            info.XmsAllocatedHandles = 0;
+        }
+    }
+
+    public static void CopyToDosPspInfo(this DosProgramSegmentPrefix psp, DosPspInfo info,
+        ushort pspSegment, ushort currentPspSegment, string ownerName) {
+        info.Segment = FormatSegment(pspSegment);
+        info.IsCurrent = pspSegment == currentPspSegment;
+        info.ParentSegment = FormatSegment(psp.ParentProgramSegmentPrefix);
+        info.PreviousPspAddress = psp.PreviousPspAddress.ToString();
+        string resolvedOwnerName = ownerName;
+        if (string.IsNullOrWhiteSpace(resolvedOwnerName)) {
+            resolvedOwnerName = ReadEnvironmentProgramName(psp);
+        }
+        info.OwnerName = resolvedOwnerName;
+        info.CurrentSizeParagraphs = psp.CurrentSize;
+        info.EnvironmentSegment = FormatSegment(psp.EnvironmentTableSegment);
+        info.StackPointer = psp.StackPointer.ToString();
+        info.MaxOpenFiles = psp.MaximumOpenFiles;
+        info.FileTableAddress = psp.FileTableAddress.ToString();
+        info.TerminateAddress = psp.TerminateAddress.ToString();
+        info.BreakAddress = psp.BreakAddress.ToString();
+        info.CriticalErrorAddress = psp.CriticalErrorAddress.ToString();
+        info.DosVersionMajor = psp.DosVersionMajor;
+        info.DosVersionMinor = psp.DosVersionMinor;
+
+        DosCommandTail tail = psp.DosCommandTail;
+        info.CommandTailLength = tail.Length;
+        info.CommandTailText = tail.Command ?? string.Empty;
+
+        info.EnvironmentVariablesPreview = ReadEnvironment(psp);
+    }
+
+    public static void CopyToDosMcbInfo(this DosMemoryControlBlock block, DosMcbInfo info) {
+        ushort headerSegment = (ushort)(block.DataBlockSegment - 1);
+        info.HeaderSegment = FormatSegment(headerSegment);
+        info.DataSegment = FormatSegment(block.DataBlockSegment);
+        info.TypeByte = block.TypeField;
+        if (block.IsLast) {
+            info.Type = "Last (Z)";
+        } else if (block.IsNonLast) {
+            info.Type = "Non-last (M)";
+        } else {
+            info.Type = "Invalid";
+        }
+        if (block.IsFree) {
+            info.OwnerPspSegment = "(free)";
+        } else {
+            info.OwnerPspSegment = FormatSegment(block.PspSegment);
+        }
+        if (block.IsValid) {
+            if (block.Owner is null) {
+                info.OwnerName = string.Empty;
+            } else {
+                info.OwnerName = block.Owner;
+            }
+        } else {
+            info.OwnerName = string.Empty;
+        }
+        info.IsFree = block.IsFree;
+        info.IsLast = block.IsLast;
+        info.IsValid = block.IsValid;
+        info.SizeParagraphs = block.Size;
+        info.SizeBytes = block.AllocationSizeInBytes;
+    }
+
+    private static string FormatSegment(ushort segment) {
+        return "0x" + segment.ToString("X4");
+    }
+
+    private static string ReadEnvironment(DosProgramSegmentPrefix psp) {
+        ushort envSegment = psp.EnvironmentTableSegment;
+        if (envSegment == 0) {
+            return string.Empty;
+        }
+        uint envAddress = MemoryUtils.ToPhysicalAddress(envSegment, 0);
+        long memoryLength = psp.ByteReaderWriter.Length;
+        if (envAddress >= memoryLength) {
+            return string.Empty;
+        }
+
+        long readableBytes = memoryLength - envAddress;
+        int capacity = (int)Math.Min(readableBytes, EnvironmentPreviewMaxBytes);
+        if (capacity <= 0) {
+            return string.Empty;
+        }
+
+        StringBuilder builder = new();
+        int count = 0;
+        while (count < capacity) {
+            byte first = psp.ByteReaderWriter[envAddress + (uint)count];
+            if (first == 0) {
+                break;
+            }
+            int entryStart = count;
+            while (count < capacity &&
+                psp.ByteReaderWriter[envAddress + (uint)count] != 0) {
+                count++;
+            }
+            int length = count - entryStart;
+            if (length > 0) {
+                for (int i = 0; i < length; i++) {
+                    builder.Append((char)psp.ByteReaderWriter[envAddress + (uint)(entryStart + i)]);
+                }
+                builder.Append(';');
+            }
+            count++;
+        }
+        return builder.ToString();
+    }
+
+    private static string ReadEnvironmentProgramName(DosProgramSegmentPrefix psp) {
+        ushort envSegment = psp.EnvironmentTableSegment;
+        if (envSegment == 0) {
+            return string.Empty;
+        }
+
+        uint envAddress = MemoryUtils.ToPhysicalAddress(envSegment, 0);
+        long memoryLength = psp.ByteReaderWriter.Length;
+        if (envAddress >= memoryLength) {
+            return string.Empty;
+        }
+
+        long readableBytes = memoryLength - envAddress;
+        int capacity = (int)Math.Min(readableBytes, EnvironmentScanMaxBytes);
+        if (capacity < 4) {
+            return string.Empty;
+        }
+
+        int index = 0;
+        bool foundDoubleNull = false;
+        while (index + 1 < capacity) {
+            byte current = psp.ByteReaderWriter[envAddress + (uint)index];
+            byte next = psp.ByteReaderWriter[envAddress + (uint)(index + 1)];
+            if (current == 0 && next == 0) {
+                index += 2;
+                foundDoubleNull = true;
+                break;
+            }
+            index++;
+        }
+
+        if (!foundDoubleNull || index + 2 > capacity) {
+            return string.Empty;
+        }
+
+        // Skip the WORD that stores the number of additional strings.
+        index += 2;
+        if (index >= capacity) {
+            return string.Empty;
+        }
+
+        StringBuilder pathBuilder = new();
+        int consumed = 0;
+        while (index < capacity && consumed < EnvironmentProgramPathMaxBytes) {
+            byte value = psp.ByteReaderWriter[envAddress + (uint)index];
+            if (value == 0) {
+                break;
+            }
+            pathBuilder.Append((char)value);
+            index++;
+            consumed++;
+        }
+
+        string path = pathBuilder.ToString();
+        if (string.IsNullOrEmpty(path)) {
+            return string.Empty;
+        }
+
+        string fileName = Path.GetFileName(path);
+        if (string.IsNullOrEmpty(fileName)) {
+            return path.ToUpperInvariant();
+        }
+
+        return fileName.ToUpperInvariant();
+    }
+}

--- a/src/Spice86/ViewModels/Services/DebuggerTabIds.cs
+++ b/src/Spice86/ViewModels/Services/DebuggerTabIds.cs
@@ -1,6 +1,7 @@
 namespace Spice86.ViewModels.Services;
 
-public enum DebuggerTabId {
+public enum DebuggerTabId
+{
     Disassembly,
     CfgCpu,
     Cpu,
@@ -9,5 +10,15 @@ public enum DebuggerTabId {
     DevicesGroup,
     DeviceVideoCard,
     DevicePalette,
-    DeviceMidi
+    DeviceMidi,
+    DeviceDualPic,
+    DevicePit,
+    DeviceCmos,
+    DeviceDma,
+    DosGroup,
+    DosMemorySummary,
+    DosPspChain,
+    DosMcbs,
+    DosPspGraph,
+    DosMemoryOverview
 }

--- a/src/Spice86/ViewModels/Services/DebuggerTabRegistry.cs
+++ b/src/Spice86/ViewModels/Services/DebuggerTabRegistry.cs
@@ -22,4 +22,26 @@ internal sealed class DebuggerTabRegistry : IDebuggerTabRegistry {
         }
         return Array.Empty<DebuggerSubTabViewModel>();
     }
+
+    /// <inheritdoc />
+    public void Dispose() {
+        foreach (object value in _items.Values) {
+            if (value is IDisposable disposable) {
+                disposable.Dispose();
+            } else if (value is IEnumerable<object> collection) {
+                foreach (object item in collection) {
+                    if (item is IDisposable disposableItem) {
+                        disposableItem.Dispose();
+                    }
+                }
+            }
+        }
+        foreach (List<DebuggerSubTabViewModel> subTabs in _subTabsByGroup.Values) {
+            foreach (DebuggerSubTabViewModel subTab in subTabs) {
+                if (subTab.ViewModel is IDisposable disposable) {
+                    disposable.Dispose();
+                }
+            }
+        }
+    }
 }

--- a/src/Spice86/ViewModels/Services/DosTabPlugin.cs
+++ b/src/Spice86/ViewModels/Services/DosTabPlugin.cs
@@ -1,0 +1,49 @@
+namespace Spice86.ViewModels.Services;
+
+using Spice86.Core.Emulator.InterruptHandlers.Dos.Ems;
+using Spice86.Core.Emulator.InterruptHandlers.Dos.Xms;
+using Spice86.Core.Emulator.Memory.ReaderWriter;
+using Spice86.Core.Emulator.OperatingSystem;
+using Spice86.Core.Emulator.OperatingSystem.Structures;
+using Spice86.Core.Emulator.VM;
+using Spice86.ViewModels;
+
+/// <summary>
+/// Registers DOS inspector sub-tabs (memory summary, PSP chain, MCBs).
+/// </summary>
+internal sealed class DosTabPlugin : IDebuggerTabPlugin {
+    private readonly DosMemoryManager _memoryManager;
+    private readonly ExpandedMemoryManager? _ems;
+    private readonly ExtendedMemoryManager? _xms;
+    private readonly DosSwappableDataArea _sda;
+    private readonly IByteReaderWriter _memory;
+    private readonly IPauseHandler _pauseHandler;
+
+    public DosTabPlugin(DosMemoryManager memoryManager,
+        ExpandedMemoryManager? ems,
+        ExtendedMemoryManager? xms,
+        DosSwappableDataArea sda,
+        IByteReaderWriter memory,
+        IPauseHandler pauseHandler) {
+        _memoryManager = memoryManager;
+        _ems = ems;
+        _xms = xms;
+        _sda = sda;
+        _memory = memory;
+        _pauseHandler = pauseHandler;
+    }
+
+    public void Register(IDebuggerTabRegistry registry) {
+        DosMemorySummaryViewModel summaryVm = new(_memoryManager, _ems, _xms, _pauseHandler);
+        DosPspChainViewModel pspVm = new(_memoryManager, _sda, _memory, _pauseHandler);
+        DosMcbsViewModel mcbsVm = new(_memoryManager, _pauseHandler);
+        DosPspGraphViewModel pspGraphVm = new(_memoryManager, _sda, _memory, _pauseHandler);
+        DosMemoryOverviewViewModel overviewVm = new(_memoryManager, _ems, _xms, _pauseHandler);
+
+        registry.AddSubTab(DebuggerTabId.DosGroup, new DebuggerSubTabViewModel(DebuggerTabId.DosMemorySummary, summaryVm));
+        registry.AddSubTab(DebuggerTabId.DosGroup, new DebuggerSubTabViewModel(DebuggerTabId.DosMemoryOverview, overviewVm));
+        registry.AddSubTab(DebuggerTabId.DosGroup, new DebuggerSubTabViewModel(DebuggerTabId.DosPspChain, pspVm));
+        registry.AddSubTab(DebuggerTabId.DosGroup, new DebuggerSubTabViewModel(DebuggerTabId.DosMcbs, mcbsVm));
+        registry.AddSubTab(DebuggerTabId.DosGroup, new DebuggerSubTabViewModel(DebuggerTabId.DosPspGraph, pspGraphVm));
+    }
+}

--- a/src/Spice86/ViewModels/Services/IDebuggerTabRegistry.cs
+++ b/src/Spice86/ViewModels/Services/IDebuggerTabRegistry.cs
@@ -1,6 +1,6 @@
 namespace Spice86.ViewModels.Services;
 
-public interface IDebuggerTabRegistry {
+public interface IDebuggerTabRegistry : IDisposable {
     void Add(DebuggerTabId tabId, object viewModel);
     void AddSubTab(DebuggerTabId groupId, DebuggerSubTabViewModel subTab);
     T Get<T>(DebuggerTabId tabId);

--- a/src/Spice86/ViewModels/Services/JumpLineCalculator.cs
+++ b/src/Spice86/ViewModels/Services/JumpLineCalculator.cs
@@ -1,6 +1,7 @@
 namespace Spice86.ViewModels.Services;
 
 using Spice86.Shared.Utils;
+using Spice86.ViewModels.Enums;
 
 using System.Collections.Generic;
 

--- a/src/Spice86/ViewModels/TimerRefreshViewModelBase.cs
+++ b/src/Spice86/ViewModels/TimerRefreshViewModelBase.cs
@@ -1,0 +1,116 @@
+namespace Spice86.ViewModels;
+
+using Avalonia.Threading;
+
+using Spice86.Core.Emulator.VM;
+using Spice86.ViewModels.Services;
+
+/// <summary>
+/// Base class for view-models refreshed by a dispatcher timer while visible.
+/// Supports optional once-per-pause refresh semantics when a pause handler is provided.
+/// </summary>
+public abstract class TimerRefreshViewModelBase : ViewModelBase,
+    IEmulatorObjectViewModel, IDebuggerTabContentViewModel, IDisposable {
+    private readonly DispatcherTimer _refreshTimer;
+    private readonly IPauseHandler? _pauseHandler;
+    private bool _isVisible;
+    private bool _hasRefreshedDuringCurrentPause;
+    private bool _isDisposed;
+
+    /// <inheritdoc />
+    public abstract string Header { get; }
+
+    /// <inheritdoc />
+    public bool IsVisible {
+        get => _isVisible;
+        set {
+            if (_isVisible == value) {
+                return;
+            }
+
+            _isVisible = value;
+
+            if (!_isVisible) {
+                _hasRefreshedDuringCurrentPause = false;
+                return;
+            }
+
+            if (_pauseHandler is not null && _pauseHandler.IsPaused) {
+                _hasRefreshedDuringCurrentPause = false;
+            }
+
+            UpdateValues(this, EventArgs.Empty);
+        }
+    }
+
+    /// <summary>
+    /// Initializes periodic refresh while visible.
+    /// </summary>
+    /// <param name="refreshIntervalMs">Polling period in milliseconds.</param>
+    protected TimerRefreshViewModelBase(int refreshIntervalMs) {
+        _pauseHandler = null;
+        _refreshTimer = DispatcherTimerStarter.StartNewDispatcherTimer(
+            TimeSpan.FromMilliseconds(refreshIntervalMs),
+            DispatcherPriority.Background,
+            UpdateValues);
+    }
+
+    /// <summary>
+    /// Initializes periodic refresh while visible with once-per-pause semantics.
+    /// </summary>
+    /// <param name="refreshIntervalMs">Polling period in milliseconds.</param>
+    /// <param name="pauseHandler">Pause state source.</param>
+    protected TimerRefreshViewModelBase(int refreshIntervalMs, IPauseHandler pauseHandler) {
+        _pauseHandler = pauseHandler;
+        _pauseHandler.Resumed += OnResumed;
+        _refreshTimer = DispatcherTimerStarter.StartNewDispatcherTimer(
+            TimeSpan.FromMilliseconds(refreshIntervalMs),
+            DispatcherPriority.Background,
+            UpdateValues);
+    }
+
+    /// <inheritdoc />
+    public void UpdateValues(object? sender, EventArgs e) {
+        if (!IsVisible) {
+            return;
+        }
+
+        if (_pauseHandler is null) {
+            RefreshCore();
+            return;
+        }
+
+        if (!_pauseHandler.IsPaused) {
+            _hasRefreshedDuringCurrentPause = false;
+            return;
+        }
+
+        if (_hasRefreshedDuringCurrentPause) {
+            return;
+        }
+
+        _hasRefreshedDuringCurrentPause = true;
+        RefreshCore();
+    }
+
+    private void OnResumed() {
+        _hasRefreshedDuringCurrentPause = false;
+    }
+
+    /// <inheritdoc />
+    public void Dispose() {
+        if (_isDisposed) {
+            return;
+        }
+        _isDisposed = true;
+        _refreshTimer.Stop();
+        if (_pauseHandler is not null) {
+            _pauseHandler.Resumed -= OnResumed;
+        }
+    }
+
+    /// <summary>
+    /// Updates the view-model state from the emulator state.
+    /// </summary>
+    protected abstract void RefreshCore();
+}

--- a/src/Spice86/ViewModels/ValueViewModels/Debugging/DosMcbInfo.cs
+++ b/src/Spice86/ViewModels/ValueViewModels/Debugging/DosMcbInfo.cs
@@ -1,0 +1,76 @@
+namespace Spice86.ViewModels.ValueViewModels.Debugging;
+
+using CommunityToolkit.Mvvm.ComponentModel;
+
+using System.ComponentModel;
+
+/// <summary>
+/// Read-only snapshot of a single DOS Memory Control Block (MCB).
+/// </summary>
+public partial class DosMcbInfo : InspectorInfoBase {
+    [ObservableProperty]
+    [property: ReadOnly(true)]
+    [property: Category("Identity")]
+    [property: DisplayName("Header segment")]
+    private string _headerSegment = string.Empty;
+
+    [ObservableProperty]
+    [property: ReadOnly(true)]
+    [property: Category("Identity")]
+    [property: DisplayName("Data segment")]
+    private string _dataSegment = string.Empty;
+
+    [ObservableProperty]
+    [property: ReadOnly(true)]
+    [property: Category("Identity")]
+    [property: DisplayName("Type")]
+    private string _type = string.Empty;
+
+    [ObservableProperty]
+    [property: ReadOnly(true)]
+    [property: Category("Identity")]
+    [property: DisplayName("Type byte")]
+    private byte _typeByte;
+
+    [ObservableProperty]
+    [property: ReadOnly(true)]
+    [property: Category("Ownership")]
+    [property: DisplayName("Owner PSP segment")]
+    private string _ownerPspSegment = string.Empty;
+
+    [ObservableProperty]
+    [property: ReadOnly(true)]
+    [property: Category("Ownership")]
+    [property: DisplayName("Owner program name")]
+    private string _ownerName = string.Empty;
+
+    [ObservableProperty]
+    [property: ReadOnly(true)]
+    [property: Category("Ownership")]
+    [property: DisplayName("Is free")]
+    private bool _isFree;
+
+    [ObservableProperty]
+    [property: ReadOnly(true)]
+    [property: Category("Ownership")]
+    [property: DisplayName("Is last block")]
+    private bool _isLast;
+
+    [ObservableProperty]
+    [property: ReadOnly(true)]
+    [property: Category("Ownership")]
+    [property: DisplayName("Is valid")]
+    private bool _isValid;
+
+    [ObservableProperty]
+    [property: ReadOnly(true)]
+    [property: Category("Size")]
+    [property: DisplayName("Size (paragraphs)")]
+    private int _sizeParagraphs;
+
+    [ObservableProperty]
+    [property: ReadOnly(true)]
+    [property: Category("Size")]
+    [property: DisplayName("Size (bytes)")]
+    private long _sizeBytes;
+}

--- a/src/Spice86/ViewModels/ValueViewModels/Debugging/DosMemorySummaryInfo.cs
+++ b/src/Spice86/ViewModels/ValueViewModels/Debugging/DosMemorySummaryInfo.cs
@@ -1,0 +1,88 @@
+namespace Spice86.ViewModels.ValueViewModels.Debugging;
+
+using CommunityToolkit.Mvvm.ComponentModel;
+
+using System.ComponentModel;
+
+/// <summary>
+/// Aggregate view of DOS memory availability across conventional, EMS and XMS pools.
+/// </summary>
+public partial class DosMemorySummaryInfo : InspectorInfoBase {
+    [ObservableProperty]
+    [property: ReadOnly(true)]
+    [property: Category("Conventional")]
+    [property: DisplayName("Free conventional (bytes)")]
+    private long _conventionalFreeBytes;
+
+    [ObservableProperty]
+    [property: ReadOnly(true)]
+    [property: Category("Conventional")]
+    [property: DisplayName("Used conventional (bytes)")]
+    private long _conventionalUsedBytes;
+
+    [ObservableProperty]
+    [property: ReadOnly(true)]
+    [property: Category("Conventional")]
+    [property: DisplayName("Largest free MCB (bytes)")]
+    private long _largestFreeBlockBytes;
+
+    [ObservableProperty]
+    [property: ReadOnly(true)]
+    [property: Category("Conventional")]
+    [property: DisplayName("Total MCBs")]
+    private int _mcbCount;
+
+    [ObservableProperty]
+    [property: ReadOnly(true)]
+    [property: Category("Conventional")]
+    [property: DisplayName("Free MCBs")]
+    private int _freeMcbCount;
+
+    [ObservableProperty]
+    [property: ReadOnly(true)]
+    [property: Category("EMS")]
+    [property: DisplayName("EMS enabled")]
+    private bool _emsEnabled;
+
+    [ObservableProperty]
+    [property: ReadOnly(true)]
+    [property: Category("EMS")]
+    [property: DisplayName("EMS total pages (16 KB)")]
+    private int _emsTotalPages;
+
+    [ObservableProperty]
+    [property: ReadOnly(true)]
+    [property: Category("EMS")]
+    [property: DisplayName("EMS free pages (16 KB)")]
+    private int _emsFreePages;
+
+    [ObservableProperty]
+    [property: ReadOnly(true)]
+    [property: Category("EMS")]
+    [property: DisplayName("EMS allocated handles")]
+    private int _emsAllocatedHandles;
+
+    [ObservableProperty]
+    [property: ReadOnly(true)]
+    [property: Category("XMS")]
+    [property: DisplayName("XMS enabled")]
+    private bool _xmsEnabled;
+
+    [ObservableProperty]
+    [property: ReadOnly(true)]
+    [property: Category("XMS")]
+    [property: DisplayName("XMS total (bytes)")]
+    private long _xmsTotalBytes;
+
+    [ObservableProperty]
+    [property: ReadOnly(true)]
+    [property: Category("XMS")]
+    [property: DisplayName("XMS free (bytes)")]
+    private long _xmsFreeBytes;
+
+    [ObservableProperty]
+    [property: ReadOnly(true)]
+    [property: Category("XMS")]
+    [property: DisplayName("XMS allocated handles")]
+    private int _xmsAllocatedHandles;
+}

--- a/src/Spice86/ViewModels/ValueViewModels/Debugging/DosPspInfo.cs
+++ b/src/Spice86/ViewModels/ValueViewModels/Debugging/DosPspInfo.cs
@@ -1,0 +1,118 @@
+namespace Spice86.ViewModels.ValueViewModels.Debugging;
+
+using CommunityToolkit.Mvvm.ComponentModel;
+
+using System.ComponentModel;
+
+/// <summary>
+/// Read-only snapshot of a DOS Program Segment Prefix (PSP).
+/// </summary>
+public partial class DosPspInfo : InspectorInfoBase {
+    [ObservableProperty]
+    [property: ReadOnly(true)]
+    [property: Category("Identity")]
+    [property: DisplayName("Segment")]
+    private string _segment = string.Empty;
+
+    [ObservableProperty]
+    [property: ReadOnly(true)]
+    [property: Category("Identity")]
+    [property: DisplayName("Is current PSP")]
+    private bool _isCurrent;
+
+    [ObservableProperty]
+    [property: ReadOnly(true)]
+    [property: Category("Identity")]
+    [property: DisplayName("Parent PSP segment")]
+    private string _parentSegment = string.Empty;
+
+    [ObservableProperty]
+    [property: ReadOnly(true)]
+    [property: Category("Identity")]
+    [property: DisplayName("Previous PSP address")]
+    private string _previousPspAddress = string.Empty;
+
+    [ObservableProperty]
+    [property: ReadOnly(true)]
+    [property: Category("Identity")]
+    [property: DisplayName("Owner program name")]
+    private string _ownerName = string.Empty;
+
+    [ObservableProperty]
+    [property: ReadOnly(true)]
+    [property: Category("Layout")]
+    [property: DisplayName("Current size (paragraphs)")]
+    private int _currentSizeParagraphs;
+
+    [ObservableProperty]
+    [property: ReadOnly(true)]
+    [property: Category("Layout")]
+    [property: DisplayName("Environment segment")]
+    private string _environmentSegment = string.Empty;
+
+    [ObservableProperty]
+    [property: ReadOnly(true)]
+    [property: Category("Layout")]
+    [property: DisplayName("Saved SS:SP")]
+    private string _stackPointer = string.Empty;
+
+    [ObservableProperty]
+    [property: ReadOnly(true)]
+    [property: Category("Layout")]
+    [property: DisplayName("Max open files (JFT size)")]
+    private int _maxOpenFiles;
+
+    [ObservableProperty]
+    [property: ReadOnly(true)]
+    [property: Category("Layout")]
+    [property: DisplayName("File table address")]
+    private string _fileTableAddress = string.Empty;
+
+    [ObservableProperty]
+    [property: ReadOnly(true)]
+    [property: Category("Exit vectors")]
+    [property: DisplayName("Terminate (INT 22h)")]
+    private string _terminateAddress = string.Empty;
+
+    [ObservableProperty]
+    [property: ReadOnly(true)]
+    [property: Category("Exit vectors")]
+    [property: DisplayName("Ctrl-Break (INT 23h)")]
+    private string _breakAddress = string.Empty;
+
+    [ObservableProperty]
+    [property: ReadOnly(true)]
+    [property: Category("Exit vectors")]
+    [property: DisplayName("Critical error (INT 24h)")]
+    private string _criticalErrorAddress = string.Empty;
+
+    [ObservableProperty]
+    [property: ReadOnly(true)]
+    [property: Category("DOS")]
+    [property: DisplayName("DOS version (major)")]
+    private byte _dosVersionMajor;
+
+    [ObservableProperty]
+    [property: ReadOnly(true)]
+    [property: Category("DOS")]
+    [property: DisplayName("DOS version (minor)")]
+    private byte _dosVersionMinor;
+
+    [ObservableProperty]
+    [property: ReadOnly(true)]
+    [property: Category("Command line")]
+    [property: DisplayName("Command tail length")]
+    private int _commandTailLength;
+
+    [ObservableProperty]
+    [property: ReadOnly(true)]
+    [property: Category("Command line")]
+    [property: DisplayName("Command tail text")]
+    private string _commandTailText = string.Empty;
+
+    [ObservableProperty]
+    [property: ReadOnly(true)]
+    [property: Category("Command line")]
+    [property: DisplayName("Environment variables preview")]
+    private string _environmentVariablesPreview = string.Empty;
+}

--- a/src/Spice86/ViewModels/ValueViewModels/Debugging/InspectorInfoBase.cs
+++ b/src/Spice86/ViewModels/ValueViewModels/Debugging/InspectorInfoBase.cs
@@ -1,0 +1,9 @@
+namespace Spice86.ViewModels.ValueViewModels.Debugging;
+
+using CommunityToolkit.Mvvm.ComponentModel;
+
+/// <summary>
+/// Convenience base class for Info POCOs
+/// </summary>
+public abstract class InspectorInfoBase : ObservableObject {
+}

--- a/src/Spice86/ViewModels/VideoCardViewModel.cs
+++ b/src/Spice86/ViewModels/VideoCardViewModel.cs
@@ -10,9 +10,9 @@ using Spice86.ViewModels.Services;
 
 using System.Text.Json;
 
-public partial class VideoCardViewModel : ViewModelBase, IEmulatorObjectViewModel, IDebuggerTabContentViewModel
+public partial class VideoCardViewModel : TimerRefreshViewModelBase
 {
-    public string Header => "Video Card";
+    public override string Header => "Video Card";
     [ObservableProperty]
     private VideoCardInfo _videoCard = new();
     private readonly IVgaRenderer _vgaRenderer;
@@ -22,6 +22,7 @@ public partial class VideoCardViewModel : ViewModelBase, IEmulatorObjectViewMode
 
     public VideoCardViewModel(IVgaRenderer vgaRenderer, IVideoState videoState,
         VgaTimingEngine vgaTimingEngine, IHostStorageProvider storageProvider)
+        : base(400)
     {
         _vgaRenderer = vgaRenderer;
         _videoState = videoState;
@@ -29,20 +30,13 @@ public partial class VideoCardViewModel : ViewModelBase, IEmulatorObjectViewMode
         _storageProvider = storageProvider;
     }
 
-    public bool IsVisible { get; set; }
-
     [RelayCommand]
     public async Task SaveVideoCardInfo()
     {
         await _storageProvider.SaveVideoCardInfoFile(JsonSerializer.Serialize(VideoCard));
     }
 
-    public void UpdateValues(object? sender, EventArgs e)
-    {
-        if (!IsVisible)
-        {
-            return;
-        }
+    protected override void RefreshCore() {
         VisitVgaRenderer(_vgaRenderer);
         VisitVideoState(_videoState);
         VideoCard.LastFrameDuration = _vgaTimingEngine.LastFrameDuration;

--- a/src/Spice86/ViewModels/XmsViewModel.cs
+++ b/src/Spice86/ViewModels/XmsViewModel.cs
@@ -11,28 +11,22 @@ using Spice86.Core.Emulator.InterruptHandlers.Dos.Xms;
 using Spice86.Core.Emulator.VM;
 using Spice86.Shared.Utils;
 using Spice86.ViewModels.DataModels;
+using Spice86.ViewModels.Enums;
 using Spice86.ViewModels.Services;
 
 using System.Text;
 using System.Windows.Input;
 
-public partial class XmsViewModel : ViewModelBase, IEmulatorObjectViewModel, IMemorySearchViewModel, IDebuggerTabContentViewModel {
-
+public partial class XmsViewModel : TimerRefreshViewModelBase, IMemorySearchViewModel {
     private readonly ExtendedMemoryManager _xms;
-    private readonly IPauseHandler _pauseHandler;
-    private List<XmsHandleEntryViewModel> _allHandles = new();
-    private List<XmsBlockEntryViewModel> _allBlocks = new();
+    private readonly List<XmsHandleEntryViewModel> _allHandles = new();
+    private readonly List<XmsBlockEntryViewModel> _allBlocks = new();
 
-    public XmsViewModel(ExtendedMemoryManager xms, IPauseHandler pauseHandler) {
+    public XmsViewModel(ExtendedMemoryManager xms, IPauseHandler pauseHandler) : base(400, pauseHandler) {
         _xms = xms;
-        _pauseHandler = pauseHandler;
-        Refresh();
     }
 
-    public bool IsVisible { get; set; }
-
-    [ObservableProperty]
-    private string _header = "XMS";
+    public override string Header => "XMS";
 
     [ObservableProperty]
     private uint _totalMemoryBytes;
@@ -60,11 +54,6 @@ public partial class XmsViewModel : ViewModelBase, IEmulatorObjectViewModel, IMe
 
     [ObservableProperty]
     private string _blockSearchText = string.Empty;
-
-    public enum MemorySearchDataType {
-        Binary,
-        Ascii,
-    }
 
     [ObservableProperty]
     private MemorySearchDataType _searchDataType = MemorySearchDataType.Binary;
@@ -123,13 +112,9 @@ public partial class XmsViewModel : ViewModelBase, IEmulatorObjectViewModel, IMe
 
     public ICommand OpenFoundOccurrenceAction => OpenFoundOccurrenceCommand;
 
-    private enum SearchDirection {
-        FirstOccurence,
-        Forward,
-        Backward,
-    }
-
     private SearchDirection _searchDirection;
+    private int? _lastSelectedHandle;
+    private (uint Offset, uint Length, int Handle, bool IsFree)? _lastSelectedBlock;
 
     [ObservableProperty]
     private AvaloniaList<XmsHandleEntryViewModel> _handles = new();
@@ -163,7 +148,7 @@ public partial class XmsViewModel : ViewModelBase, IEmulatorObjectViewModel, IMe
 
     [RelayCommand]
     private async Task FirstOccurrence() {
-        _searchDirection = SearchDirection.FirstOccurence;
+        _searchDirection = SearchDirection.FirstOccurrence;
         await SearchSelectedBlockCommand.ExecuteAsync(null);
     }
 
@@ -195,11 +180,29 @@ public partial class XmsViewModel : ViewModelBase, IEmulatorObjectViewModel, IMe
     }
 
     partial void OnSelectedHandleChanged(XmsHandleEntryViewModel? value) {
+        int? selectedHandle = value?.Handle;
+        if (selectedHandle == _lastSelectedHandle) {
+            return;
+        }
+
+        _lastSelectedHandle = selectedHandle;
         uint? selectedOffset = SelectedBlock?.Offset;
         ApplyBlockFilter(selectedOffset);
     }
 
     partial void OnSelectedBlockChanged(XmsBlockEntryViewModel? value) {
+        (uint Offset, uint Length, int Handle, bool IsFree)? selectedBlock;
+        if (value is null) {
+            selectedBlock = null;
+        } else {
+            selectedBlock = (value.Offset, value.Length, value.Handle, value.IsFree);
+        }
+
+        if (selectedBlock == _lastSelectedBlock) {
+            return;
+        }
+
+        _lastSelectedBlock = selectedBlock;
         RefreshSelectedBlockDocument();
     }
 
@@ -209,10 +212,7 @@ public partial class XmsViewModel : ViewModelBase, IEmulatorObjectViewModel, IMe
         OnPropertyChanged(nameof(SearchDataTypeIsAscii));
     }
 
-    public void UpdateValues(object? sender, EventArgs e) {
-        if (!IsVisible || !_pauseHandler.IsPaused) {
-            return;
-        }
+    protected override void RefreshCore() {
         Refresh();
     }
 
@@ -228,14 +228,14 @@ public partial class XmsViewModel : ViewModelBase, IEmulatorObjectViewModel, IMe
         IsA20GloballyEnabled = _xms.IsA20GloballyEnabled;
         A20LocalEnableCount = _xms.A20LocalEnableCount;
 
-        _allHandles = _xms.HandlesSnapshot
-            .Select(static x => new XmsHandleEntryViewModel(x.Key, x.Value))
-            .ToList();
+        _allHandles.Clear();
+        _allHandles.AddRange(_xms.HandlesSnapshot
+            .Select(static x => new XmsHandleEntryViewModel(x.Key, x.Value)));
 
-        _allBlocks = _xms.BlocksSnapshot
+        _allBlocks.Clear();
+        _allBlocks.AddRange(_xms.BlocksSnapshot
             .Select(static x => new XmsBlockEntryViewModel(x.IsFree, x.Handle, x.Offset, x.Length))
-            .OrderBy(static x => x.Offset)
-            .ToList();
+            .OrderBy(static x => x.Offset));
 
         ApplyHandleFilter(selectedHandle);
         ApplyBlockFilter(selectedOffset);
@@ -248,7 +248,7 @@ public partial class XmsViewModel : ViewModelBase, IEmulatorObjectViewModel, IMe
             filteredHandles = filteredHandles.Where(x => HandleMatchesSearch(x, trimmedSearch));
         }
 
-        Handles = new AvaloniaList<XmsHandleEntryViewModel>(filteredHandles);
+        ReplaceItems(Handles, filteredHandles);
         SelectedHandle = Handles.FirstOrDefault(x => x.Handle == selectedHandle) ?? Handles.FirstOrDefault();
     }
 
@@ -265,8 +265,13 @@ public partial class XmsViewModel : ViewModelBase, IEmulatorObjectViewModel, IMe
             filteredBlocks = filteredBlocks.Where(x => BlockMatchesSearch(x, trimmedSearch));
         }
 
-        Blocks = new AvaloniaList<XmsBlockEntryViewModel>(filteredBlocks);
+        ReplaceItems(Blocks, filteredBlocks);
         SelectedBlock = Blocks.FirstOrDefault(x => x.Offset == selectedOffset) ?? Blocks.FirstOrDefault();
+    }
+
+    private static void ReplaceItems<T>(AvaloniaList<T> target, IEnumerable<T> items) {
+        target.Clear();
+        target.AddRange(items);
     }
 
     private void RefreshSelectedBlockDocument() {
@@ -285,7 +290,12 @@ public partial class XmsViewModel : ViewModelBase, IEmulatorObjectViewModel, IMe
         }
 
         SelectedBlockDocument = new XmsBlockBinaryDocument(_xms.XmsRam, SelectedBlock.Offset, SelectedBlock.Length);
-        string handleText = SelectedBlock.IsFree ? "Free" : ConvertUtils.ToHex16((ushort)SelectedBlock.Handle);
+        string handleText;
+        if (SelectedBlock.IsFree) {
+            handleText = "Free";
+        } else {
+            handleText = ConvertUtils.ToHex16((ushort)SelectedBlock.Handle);
+        }
         SelectedBlockTitle = $"{SelectedBlock.State} block - Handle {handleText} - {ConvertUtils.ToHex32(SelectedBlock.Offset)} to {ConvertUtils.ToHex32(SelectedBlock.EndOffset)}";
         ResetSearchResult();
     }

--- a/src/Spice86/Views/Behaviors/ConnectionThemeBehavior.cs
+++ b/src/Spice86/Views/Behaviors/ConnectionThemeBehavior.cs
@@ -8,7 +8,8 @@ using Avalonia.Styling;
 
 using AvaloniaGraphControl;
 
-using Spice86.ViewModels;
+using Spice86.ViewModels.DataModels;
+using Spice86.ViewModels.Enums;
 using Spice86.Views.Converters;
 
 using System;

--- a/src/Spice86/Views/Behaviors/EdgeLabelThemeBehavior.cs
+++ b/src/Spice86/Views/Behaviors/EdgeLabelThemeBehavior.cs
@@ -5,7 +5,8 @@ using Avalonia.Controls;
 using Avalonia.Media;
 using Avalonia.Reactive;
 
-using Spice86.ViewModels;
+using Spice86.ViewModels.DataModels;
+using Spice86.ViewModels.Enums;
 using Spice86.Views.Converters;
 
 using System;

--- a/src/Spice86/Views/Behaviors/GraphThemeBehavior.cs
+++ b/src/Spice86/Views/Behaviors/GraphThemeBehavior.cs
@@ -1,0 +1,174 @@
+namespace Spice86.Views.Behaviors;
+
+using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Media;
+using Avalonia.Reactive;
+
+using AvaloniaGraphControl;
+
+using Spice86.ViewModels.DataModels;
+using Spice86.ViewModels.Enums;
+using Spice86.Views.Converters;
+
+using System;
+using System.Collections.Generic;
+using System.Runtime.CompilerServices;
+
+/// <summary>
+/// Shared theme behavior for AvaloniaGraphControl elements (TextSticker, Connection and edge-label TextBlock).
+/// </summary>
+public static class GraphThemeBehavior {
+    private static readonly ConditionalWeakTable<Control, WeakEventHandler> _eventHandlers = new();
+
+    public static readonly AttachedProperty<bool> EnableThemingProperty =
+        AvaloniaProperty.RegisterAttached<Control, bool>(
+            "EnableTheming",
+            typeof(GraphThemeBehavior),
+            defaultValue: false);
+
+    private static readonly Dictionary<CfgEdgeType, (string ResourceKey, IBrush Fallback)> EdgeColors = new() {
+        { CfgEdgeType.Normal, ("CfgEdgeNormalBrush", new SolidColorBrush(Color.FromRgb(0x90, 0x90, 0x90))) },
+        { CfgEdgeType.Jump, ("CfgEdgeJumpBrush", new SolidColorBrush(Color.FromRgb(0xD6, 0x89, 0x10))) },
+        { CfgEdgeType.Call, ("CfgEdgeCallBrush", new SolidColorBrush(Color.FromRgb(0x2E, 0x86, 0xC1))) },
+        { CfgEdgeType.Return, ("CfgEdgeReturnBrush", new SolidColorBrush(Color.FromRgb(0x8E, 0x44, 0xAD))) },
+        { CfgEdgeType.Selector, ("CfgEdgeSelectorBrush", new SolidColorBrush(Color.FromRgb(0x28, 0xB4, 0x63))) },
+        { CfgEdgeType.CallToReturn, ("CfgEdgeCallToReturnBrush", new SolidColorBrush(Color.FromRgb(0x1A, 0xBC, 0x9C))) },
+        { CfgEdgeType.CpuFault, ("CfgEdgeCpuFaultBrush", new SolidColorBrush(Color.FromRgb(0xCB, 0x43, 0x35))) },
+        { CfgEdgeType.IsolatedNodeLoop, (string.Empty, Brushes.Transparent) },
+    };
+
+    static GraphThemeBehavior() {
+        EnableThemingProperty.Changed.Subscribe(
+            new AnonymousObserver<AvaloniaPropertyChangedEventArgs<bool>>(OnEnableThemingChanged));
+    }
+
+    public static void SetEnableTheming(Control element, bool value) =>
+        element.SetValue(EnableThemingProperty, value);
+
+    public static bool GetEnableTheming(Control element) =>
+        element.GetValue(EnableThemingProperty);
+
+    private static void OnEnableThemingChanged(AvaloniaPropertyChangedEventArgs<bool> e) {
+        if (e.Sender is not Control control) {
+            return;
+        }
+
+        Application? application = Application.Current;
+        if (application is null) {
+            return;
+        }
+
+        if (_eventHandlers.TryGetValue(control, out WeakEventHandler? existingHandler)) {
+            existingHandler.Unsubscribe();
+            _eventHandlers.Remove(control);
+        }
+
+        if (e.NewValue.Value) {
+            WeakEventHandler handler = new(control, application);
+            _eventHandlers.Add(control, handler);
+            handler.Subscribe();
+            ApplyTheme(control);
+        }
+    }
+
+    private static void ApplyTheme(Control control) {
+        if (control is Border border) {
+            border.Background = HighlightingConverter.GetDefaultBackgroundBrush();
+            border.BorderBrush = HighlightingConverter.GetDefaultForegroundBrush();
+            border.BorderThickness = new Thickness(1.5);
+
+            if (border.DataContext is DosGraphNode dosGraphNode && dosGraphNode.Kind == DosGraphNodeKind.Mcb) {
+                border.BorderBrush = ConverterUtilities.GetResourceBrush(
+                    "CfgEdgeSelectorBrush",
+                    HighlightingConverter.GetDefaultForegroundBrush());
+                border.BorderThickness = new Thickness(2.0);
+            }
+
+            if (border.Child is TextBlock nodeTextBlock) {
+                nodeTextBlock.Foreground = HighlightingConverter.GetDefaultForegroundBrush();
+            }
+            return;
+        }
+
+        if (control is TextSticker textSticker) {
+            textSticker.TextForeground = HighlightingConverter.GetDefaultForegroundBrush();
+            textSticker.Background = HighlightingConverter.GetDefaultBackgroundBrush();
+            return;
+        }
+
+        if (control is Connection connection) {
+            CfgEdgeType edgeType = CfgEdgeType.Normal;
+            if (connection.DataContext is Edge edge && edge.Label is CfgGraphEdgeLabel edgeLabel) {
+                edgeType = edgeLabel.EdgeType;
+            }
+
+            if (EdgeColors.TryGetValue(edgeType, out (string ResourceKey, IBrush Fallback) entry)) {
+                connection.Brush = ConverterUtilities.GetResourceBrush(entry.ResourceKey, entry.Fallback);
+            }
+            return;
+        }
+
+        if (control is TextBlock textBlock) {
+            CfgEdgeType edgeType = CfgEdgeType.Normal;
+            if (textBlock.DataContext is CfgGraphEdgeLabel edgeLabel) {
+                edgeType = edgeLabel.EdgeType;
+            }
+
+            if (EdgeColors.TryGetValue(edgeType, out (string ResourceKey, IBrush Fallback) entry)) {
+                textBlock.Foreground = ConverterUtilities.GetResourceBrush(entry.ResourceKey, entry.Fallback);
+            }
+        }
+    }
+
+    private sealed class WeakEventHandler {
+        private readonly WeakReference<Control> _weakReference;
+        private readonly Application _application;
+        private readonly EventHandler _themeChangedHandler;
+        private readonly EventHandler<global::Avalonia.Interactivity.RoutedEventArgs> _unloadedHandler;
+        private readonly EventHandler _dataContextChangedHandler;
+
+        public WeakEventHandler(Control control, Application application) {
+            _weakReference = new WeakReference<Control>(control);
+            _application = application;
+            _themeChangedHandler = OnThemeChanged;
+            _unloadedHandler = OnUnloaded;
+            _dataContextChangedHandler = OnDataContextChanged;
+        }
+
+        public void Subscribe() {
+            if (_weakReference.TryGetTarget(out Control? control)) {
+                _application.ActualThemeVariantChanged += _themeChangedHandler;
+                control.Unloaded += _unloadedHandler;
+                control.DataContextChanged += _dataContextChangedHandler;
+            }
+        }
+
+        public void Unsubscribe() {
+            _application.ActualThemeVariantChanged -= _themeChangedHandler;
+            if (_weakReference.TryGetTarget(out Control? control)) {
+                control.Unloaded -= _unloadedHandler;
+                control.DataContextChanged -= _dataContextChangedHandler;
+            }
+        }
+
+        private void OnThemeChanged(object? sender, EventArgs e) {
+            if (_weakReference.TryGetTarget(out Control? control)) {
+                ApplyTheme(control);
+            }
+        }
+
+        private void OnDataContextChanged(object? sender, EventArgs e) {
+            if (_weakReference.TryGetTarget(out Control? control)) {
+                ApplyTheme(control);
+            }
+        }
+
+        private void OnUnloaded(object? sender, global::Avalonia.Interactivity.RoutedEventArgs e) {
+            Unsubscribe();
+            if (sender is Control control) {
+                _eventHandlers.Remove(control);
+            }
+        }
+    }
+}

--- a/src/Spice86/Views/BreakpointsView.axaml
+++ b/src/Spice86/Views/BreakpointsView.axaml
@@ -4,6 +4,7 @@
 			 xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
 			 xmlns:dialogHost="clr-namespace:DialogHostAvalonia;assembly=DialogHost.Avalonia"
 			 xmlns:viewModels="clr-namespace:Spice86.ViewModels"
+			 xmlns:dataModels="clr-namespace:Spice86.ViewModels.DataModels"
 			 xmlns:behaviors="clr-namespace:Spice86.Views.Behaviors"
 			 xmlns:controls="clr-namespace:Spice86.Views.Controls;assembly=Spice86"
 			 xmlns:userControls="clr-namespace:Spice86.Views.UserControls;assembly=Spice86"
@@ -119,7 +120,7 @@
 										PlaceholderText="e.g. 0x21, or * for all"
 										Margin="5,0,0,0">
 										<AutoCompleteBox.ItemTemplate>
-											<DataTemplate DataType="viewModels:KnownBreakpointSuggestion">
+											<DataTemplate DataType="dataModels:KnownBreakpointSuggestion">
 												<StackPanel Orientation="Horizontal" Spacing="8">
 													<TextBlock Text="{Binding HexValue}" FontWeight="Bold" FontFamily="Consolas,Menlo,Monaco,monospace" />
 													<TextBlock Text="{Binding Description}" Opacity="0.7" />
@@ -152,7 +153,7 @@
 										PlaceholderText="e.g. 0x21, 0x388, or * for all"
 										Margin="5,0,0,0">
 										<AutoCompleteBox.ItemTemplate>
-											<DataTemplate DataType="viewModels:KnownBreakpointSuggestion">
+											<DataTemplate DataType="dataModels:KnownBreakpointSuggestion">
 												<StackPanel Orientation="Horizontal" Spacing="8">
 													<TextBlock Text="{Binding HexValue}" FontWeight="Bold" FontFamily="Consolas,Menlo,Monaco,monospace" />
 													<TextBlock Text="{Binding Description}" Opacity="0.7" />

--- a/src/Spice86/Views/CfgCpuView.axaml
+++ b/src/Spice86/Views/CfgCpuView.axaml
@@ -6,6 +6,7 @@
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     xmlns:viewModels="clr-namespace:Spice86.ViewModels"
+    xmlns:dataModels="clr-namespace:Spice86.ViewModels.DataModels"
     xmlns:progRing="clr-namespace:AvaloniaProgressRing;assembly=AvaloniaProgressRing"
     xmlns:behaviors="clr-namespace:Spice86.Views.Behaviors"
     d:DesignHeight="450"
@@ -35,12 +36,12 @@
             <Setter Property="Padding" Value="10,6" />
             <Setter Property="BorderThickness" Value="1.5" />
             <Setter Property="BorderRadius" Value="4" />
-            <Setter Property="behaviors:TextStickerThemeBehavior.EnableTheming" Value="True" />
+            <Setter Property="behaviors:GraphThemeBehavior.EnableTheming" Value="True" />
         </Style>
 
         <!-- Connection coloring via behavior -->
         <Style Selector="agc|Connection">
-            <Setter Property="behaviors:ConnectionThemeBehavior.EnableTheming" Value="True" />
+            <Setter Property="behaviors:GraphThemeBehavior.EnableTheming" Value="True" />
         </Style>
 
         <!-- Edge labels (TextBlock children of GraphPanel) -->
@@ -143,13 +144,13 @@
                                             </Border>
                                         </DataTemplate>
                                         <!-- Colored edge label -->
-                                        <DataTemplate DataType="{x:Type viewModels:CfgGraphEdgeLabel}">
+                                        <DataTemplate DataType="{x:Type dataModels:CfgGraphEdgeLabel}">
                                             <TextBlock
                                             Text="{Binding Text}"
                                             FontSize="14"
                                             Background="{DynamicResource SystemControlBackgroundAltMediumHighBrush}"
                                             Padding="4,2"
-                                            behaviors:EdgeLabelThemeBehavior.EnableTheming="True" />
+                                            behaviors:GraphThemeBehavior.EnableTheming="True" />
                                         </DataTemplate>
                                     </agc:GraphPanel.DataTemplates>
                                 </agc:GraphPanel>

--- a/src/Spice86/Views/Controls/JumpLinesControl.cs
+++ b/src/Spice86/Views/Controls/JumpLinesControl.cs
@@ -3,9 +3,9 @@ namespace Spice86.Views.Controls;
 using Avalonia;
 using Avalonia.Controls;
 using Avalonia.Media;
-using Avalonia.Styling;
 
 using Spice86.ViewModels;
+using Spice86.ViewModels.Enums;
 
 using System.Collections.Generic;
 

--- a/src/Spice86/Views/Converters/LoadedConverter.cs
+++ b/src/Spice86/Views/Converters/LoadedConverter.cs
@@ -1,0 +1,24 @@
+namespace Spice86.Views.Converters;
+
+using Avalonia.Data.Converters;
+
+using System.Globalization;
+
+/// <summary>Converts a boolean "loaded" flag to "Loaded"/"Not loaded".</summary>
+public sealed class LoadedConverter : IValueConverter {
+    /// <summary>Shared instance.</summary>
+    public static readonly LoadedConverter Instance = new();
+
+    /// <inheritdoc />
+    public object? Convert(object? value, Type targetType, object? parameter, CultureInfo culture) {
+        if (value is bool b && b) {
+            return "Loaded";
+        }
+        return "Not loaded";
+    }
+
+    /// <inheritdoc />
+    public object? ConvertBack(object? value, Type targetType, object? parameter, CultureInfo culture) {
+        throw new NotSupportedException();
+    }
+}

--- a/src/Spice86/Views/CpuView.axaml.cs
+++ b/src/Spice86/Views/CpuView.axaml.cs
@@ -1,34 +1,9 @@
 namespace Spice86.Views;
 
-using Avalonia;
-using Avalonia.Controls;
-using Avalonia.Threading;
+using Spice86.Views.UserControls;
 
-using Spice86.ViewModels;
-using Spice86.ViewModels.Services;
-
-public partial class CpuView : UserControl {
-    private DispatcherTimer? _timer;
+public partial class CpuView : EmulatorObjectUserControl {
     public CpuView() {
         InitializeComponent();
-        this.DetachedFromVisualTree += OnDetachedFromVisualTree;
-    }
-
-    private void OnDetachedFromVisualTree(object? sender, VisualTreeAttachmentEventArgs e) {
-        if (DataContext is IEmulatorObjectViewModel vm) {
-            vm.IsVisible = false;
-            _timer?.Stop();
-            _timer = null;
-        }
-    }
-
-    protected override void OnDataContextChanged(EventArgs e) {
-        base.OnDataContextChanged(e);
-        if (DataContext is IEmulatorObjectViewModel vm) {
-            vm.IsVisible = this.IsVisible;
-            _timer = DispatcherTimerStarter.StartNewDispatcherTimer(
-                TimeSpan.FromMilliseconds(400), DispatcherPriority.Background,
-                vm.UpdateValues);
-        }
     }
 }

--- a/src/Spice86/Views/DebugWindow.axaml
+++ b/src/Spice86/Views/DebugWindow.axaml
@@ -131,6 +131,21 @@ mc:Ignorable="d">
 											Content="{Binding $parent[Window].DataContext.SelectedDeviceSubTab.ViewModel}" />
 						</Grid>
 					</dockModel:Document>
+					<dockModel:Document Id="Dos" Title="DOS" CanClose="False">
+						<Grid RowDefinitions="Auto,*">
+							<TabStrip Grid.Row="0"
+									  ItemsSource="{Binding $parent[Window].DataContext.DosSubTabs}"
+									  SelectedItem="{Binding $parent[Window].DataContext.SelectedDosSubTab}">
+								<TabStrip.ItemTemplate>
+									<DataTemplate DataType="{x:Type vm:DebuggerSubTabViewModel}">
+										<TextBlock Text="{Binding Header}" />
+									</DataTemplate>
+								</TabStrip.ItemTemplate>
+							</TabStrip>
+							<ContentControl Grid.Row="1"
+											Content="{Binding $parent[Window].DataContext.SelectedDosSubTab.ViewModel}" />
+						</Grid>
+					</dockModel:Document>
 					<dockModel:Document
 					Id="Breakpoints"
 					Title="Breakpoints"

--- a/src/Spice86/Views/DosMcbsView.axaml
+++ b/src/Spice86/Views/DosMcbsView.axaml
@@ -1,0 +1,43 @@
+<UserControl xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             xmlns:viewModels="clr-namespace:Spice86.ViewModels"
+             xmlns:userControls="clr-namespace:Spice86.Views.UserControls"
+             mc:Ignorable="d" d:DesignWidth="900" d:DesignHeight="560"
+             x:Class="Spice86.Views.DosMcbsView"
+             x:DataType="viewModels:DosMcbsViewModel">
+    <Grid RowDefinitions="Auto,Auto,*">
+        <TextBlock Grid.Row="0"
+                   Margin="6,4,6,2"
+                   FontFamily="{StaticResource RobotoMonoFont}"
+                   Text="{CompiledBinding LayoutSummary}" />
+        <Border Grid.Row="1"
+                Margin="6,2,6,6"
+                Height="32"
+                BorderBrush="{DynamicResource SystemControlForegroundBaseLowBrush}"
+                BorderThickness="1"
+                ClipToBounds="True">
+            <Grid x:Name="BarHost" />
+        </Border>
+        <Grid Grid.Row="2" ColumnDefinitions="280,*">
+            <ListBox Grid.Column="0"
+                     ItemsSource="{CompiledBinding Items}"
+                     SelectedItem="{CompiledBinding SelectedItem, Mode=TwoWay}">
+                <ListBox.ItemTemplate>
+                    <DataTemplate>
+                        <StackPanel Orientation="Horizontal" Spacing="6">
+                            <TextBlock Text="{Binding HeaderSegment}" FontWeight="Bold" />
+                            <TextBlock Text="{Binding Type}" Opacity="0.7" />
+                            <TextBlock Text="(free)" Foreground="Gray" IsVisible="{Binding IsFree}" />
+                            <TextBlock Text="{Binding OwnerName}" Opacity="0.85" />
+                        </StackPanel>
+                    </DataTemplate>
+                </ListBox.ItemTemplate>
+            </ListBox>
+            <userControls:InspectorPanel Grid.Column="1"
+                                         Header="Selected MCB"
+                                         Data="{CompiledBinding SelectedItem}" />
+        </Grid>
+    </Grid>
+</UserControl>

--- a/src/Spice86/Views/DosMcbsView.axaml.cs
+++ b/src/Spice86/Views/DosMcbsView.axaml.cs
@@ -1,0 +1,138 @@
+namespace Spice86.Views;
+
+using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Controls.Primitives;
+using Avalonia.Media;
+
+using Spice86.ViewModels;
+using Spice86.ViewModels.DataModels;
+using Spice86.Views.UserControls;
+
+using System.Collections.ObjectModel;
+using System.Collections.Specialized;
+
+/// <summary>Code-behind for the DOS MCBs view. Renders the conventional memory layout bar from the VM's blocks.</summary>
+public partial class DosMcbsView : EmulatorObjectUserControl {
+    private const string FreeBrushKey = "SystemControlBackgroundBaseLowBrush";
+    private const string UsedBrushKey = "SystemAccentColorBrush";
+    private const string LastEdgeBrushKey = "SystemControlHighlightAltAccentBrush";
+    private const string SeparatorBrushKey = "SystemControlForegroundBaseLowBrush";
+
+    private DosMcbsViewModel? _attachedVm;
+
+    /// <summary>Initializes a new <see cref="DosMcbsView"/>.</summary>
+    public DosMcbsView() {
+        InitializeComponent();
+        ActualThemeVariantChanged += OnThemeChanged;
+    }
+
+    private void OnThemeChanged(object? sender, System.EventArgs e) {
+        if (_attachedVm is not null) {
+            RebuildBar(_attachedVm.Blocks);
+        }
+    }
+
+    /// <inheritdoc />
+    protected override void OnDataContextChanged(EventArgs e) {
+        base.OnDataContextChanged(e);
+        if (_attachedVm is not null) {
+            _attachedVm.Blocks.CollectionChanged -= OnBlocksChanged;
+        }
+        _attachedVm = DataContext as DosMcbsViewModel;
+        if (_attachedVm is not null) {
+            if (IsViewModelEffectivelyVisible) {
+                _attachedVm.Blocks.CollectionChanged += OnBlocksChanged;
+            }
+            RebuildBar(_attachedVm.Blocks);
+        } else {
+            BarHost.Children.Clear();
+            BarHost.ColumnDefinitions.Clear();
+        }
+    }
+
+    /// <inheritdoc />
+    protected override void OnAttachedToVisualTree(VisualTreeAttachmentEventArgs e) {
+        base.OnAttachedToVisualTree(e);
+        if (_attachedVm is not null) {
+            _attachedVm.Blocks.CollectionChanged -= OnBlocksChanged;
+            _attachedVm.Blocks.CollectionChanged += OnBlocksChanged;
+            RebuildBar(_attachedVm.Blocks);
+        }
+    }
+
+    /// <inheritdoc />
+    protected override void OnDetachedFromVisualTree(VisualTreeAttachmentEventArgs e) {
+        if (_attachedVm is not null) {
+            _attachedVm.Blocks.CollectionChanged -= OnBlocksChanged;
+        }
+        base.OnDetachedFromVisualTree(e);
+    }
+
+    private void OnBlocksChanged(object? sender, NotifyCollectionChangedEventArgs e) {
+        if (_attachedVm is not null) {
+            RebuildBar(_attachedVm.Blocks);
+        }
+    }
+
+    private IBrush? FindBrush(string key) {
+        if (this.TryFindResource(key, ActualThemeVariant, out object? resource)
+            && resource is IBrush brush) {
+            return brush;
+        }
+        return null;
+    }
+
+    private void RebuildBar(ObservableCollection<DosMcbBarItem> blocks) {
+        BarHost.Children.Clear();
+        BarHost.ColumnDefinitions.Clear();
+        if (blocks.Count == 0) {
+            return;
+        }
+        long total = 0;
+        foreach (DosMcbBarItem block in blocks) {
+            total += block.SizeBytes;
+        }
+        if (total <= 0) {
+            return;
+        }
+        IBrush? freeBrush = FindBrush(FreeBrushKey);
+        IBrush? usedBrush = FindBrush(UsedBrushKey);
+        IBrush? lastEdgeBrush = FindBrush(LastEdgeBrushKey);
+        IBrush? separatorBrush = FindBrush(SeparatorBrushKey);
+        int column = 0;
+        foreach (DosMcbBarItem block in blocks) {
+            double weight;
+            if (block.SizeBytes <= 0) {
+                weight = 1;
+            } else {
+                weight = block.SizeBytes;
+            }
+            IBrush? backgroundBrush;
+            if (block.IsFree) {
+                backgroundBrush = freeBrush;
+            } else {
+                backgroundBrush = usedBrush;
+            }
+            IBrush? borderBrush;
+            Thickness borderThickness;
+            if (block.IsLast) {
+                borderBrush = lastEdgeBrush;
+                borderThickness = new Thickness(0, 0, 3, 0);
+            } else {
+                borderBrush = separatorBrush;
+                borderThickness = new Thickness(0, 0, 1, 0);
+            }
+            BarHost.ColumnDefinitions.Add(new ColumnDefinition(weight, GridUnitType.Star));
+            Border cell = new() {
+                Background = backgroundBrush,
+                BorderBrush = borderBrush,
+                BorderThickness = borderThickness
+            };
+            ToolTip.SetTip(cell, block.Tooltip);
+            Grid.SetColumn(cell, column);
+            BarHost.Children.Add(cell);
+            column++;
+        }
+    }
+}

--- a/src/Spice86/Views/DosMemoryOverviewView.axaml
+++ b/src/Spice86/Views/DosMemoryOverviewView.axaml
@@ -1,0 +1,89 @@
+<UserControl xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             xmlns:viewModels="clr-namespace:Spice86.ViewModels"
+             xmlns:converters="clr-namespace:Spice86.Views.Converters"
+             mc:Ignorable="d" d:DesignWidth="900" d:DesignHeight="600"
+             x:Class="Spice86.Views.DosMemoryOverviewView"
+             x:DataType="viewModels:DosMemoryOverviewViewModel">
+    <Grid RowDefinitions="*,Auto,*">
+        <!-- Top: vertical bar graph of MCBs -->
+        <DockPanel Grid.Row="0" LastChildFill="True" Margin="8,8,8,4">
+            <TextBlock DockPanel.Dock="Top" Margin="0,0,0,4"
+                       FontWeight="SemiBold"
+                       Text="Conventional Memory (MCBs)" />
+            <TextBlock DockPanel.Dock="Top" Margin="0,0,0,6"
+                       Foreground="{DynamicResource SystemControlForegroundBaseMediumBrush}"
+                       Text="{CompiledBinding ConventionalSummary}" />
+            <StackPanel DockPanel.Dock="Bottom" Orientation="Horizontal" Spacing="14" Margin="0,6,0,0">
+                <StackPanel Orientation="Horizontal" Spacing="4">
+                    <Border Width="14" Height="14" Background="#2E7D32" />
+                    <TextBlock Text="Free" />
+                </StackPanel>
+                <StackPanel Orientation="Horizontal" Spacing="4">
+                    <Border Width="14" Height="14" Background="#C62828" />
+                    <TextBlock Text="Allocated" />
+                </StackPanel>
+            </StackPanel>
+            <Border BorderBrush="{DynamicResource SystemControlForegroundBaseMediumBrush}"
+                    BorderThickness="1" Padding="4">
+                <Canvas x:Name="BarCanvas" ClipToBounds="True" />
+            </Border>
+        </DockPanel>
+
+        <GridSplitter Grid.Row="1" Height="4"
+                      HorizontalAlignment="Stretch"
+                      Background="{DynamicResource SystemControlForegroundBaseLowBrush}" />
+
+        <!-- Bottom: structured report -->
+        <DockPanel Grid.Row="2" LastChildFill="True" Margin="8,4,8,8">
+            <TextBlock DockPanel.Dock="Top" Margin="0,0,0,6"
+                       FontWeight="SemiBold"
+                       Text="System Memory Summary" />
+            <Grid DockPanel.Dock="Bottom" Margin="0,8,0,0"
+                  ColumnDefinitions="Auto,*,Auto,*,Auto,*"
+                  RowDefinitions="Auto,Auto">
+                <TextBlock Grid.Row="0" Grid.Column="0" Margin="0,0,8,4"
+                           FontWeight="SemiBold" Text="XMS driver:" />
+                <TextBlock Grid.Row="0" Grid.Column="1" Margin="0,0,16,4"
+                           Text="{CompiledBinding XmsLoaded, Converter={x:Static converters:LoadedConverter.Instance}}" />
+                <TextBlock Grid.Row="0" Grid.Column="2" Margin="0,0,8,4"
+                           FontWeight="SemiBold" Text="EMS driver:" />
+                <TextBlock Grid.Row="0" Grid.Column="3" Margin="0,0,16,4"
+                           Text="{CompiledBinding EmsLoaded, Converter={x:Static converters:LoadedConverter.Instance}}" />
+                <TextBlock Grid.Row="0" Grid.Column="4" Margin="0,0,8,4"
+                           FontWeight="SemiBold" Text="HMA:" />
+                <TextBlock Grid.Row="0" Grid.Column="5" Margin="0,0,0,4"
+                           Text="{CompiledBinding HmaStatus}" />
+
+                <TextBlock Grid.Row="1" Grid.Column="0" Margin="0,0,8,0"
+                           FontWeight="SemiBold" Text="XMS handles:" />
+                <TextBlock Grid.Row="1" Grid.Column="1" Margin="0,0,16,0"
+                           Text="{CompiledBinding XmsHandlesAllocated}" />
+                <TextBlock Grid.Row="1" Grid.Column="2" Margin="0,0,8,0"
+                           FontWeight="SemiBold" Text="EMS handles:" />
+                <TextBlock Grid.Row="1" Grid.Column="3" Margin="0,0,16,0"
+                           Text="{CompiledBinding EmsHandlesAllocated}" />
+                <TextBlock Grid.Row="1" Grid.Column="4" Margin="0,0,8,0"
+                           FontWeight="SemiBold" Text="Largest free XMS:" />
+                <TextBlock Grid.Row="1" Grid.Column="5"
+                           Text="{CompiledBinding LargestFreeXmsBytes, StringFormat='{}{0:N0} bytes'}" />
+            </Grid>
+            <DataGrid ItemsSource="{CompiledBinding Rows}"
+                      IsReadOnly="True"
+                      AutoGenerateColumns="False"
+                      GridLinesVisibility="Horizontal"
+                      CanUserResizeColumns="True"
+                      HeadersVisibility="Column">
+                <DataGrid.Columns>
+                    <DataGridTextColumn Header="Memory Type" Binding="{CompiledBinding Category}" Width="180" />
+                    <DataGridTextColumn Header="Total" Binding="{CompiledBinding TotalBytes, StringFormat='{}{0:N0} B'}" Width="140" />
+                    <DataGridTextColumn Header="Used" Binding="{CompiledBinding UsedBytes, StringFormat='{}{0:N0} B'}" Width="140" />
+                    <DataGridTextColumn Header="Free" Binding="{CompiledBinding FreeBytes, StringFormat='{}{0:N0} B'}" Width="140" />
+                    <DataGridTextColumn Header="Notes" Binding="{CompiledBinding Notes}" Width="*" />
+                </DataGrid.Columns>
+            </DataGrid>
+        </DockPanel>
+    </Grid>
+</UserControl>

--- a/src/Spice86/Views/DosMemoryOverviewView.axaml.cs
+++ b/src/Spice86/Views/DosMemoryOverviewView.axaml.cs
@@ -1,0 +1,154 @@
+namespace Spice86.Views;
+
+using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Controls.Shapes;
+using Avalonia.Media;
+
+using Spice86.ViewModels;
+using Spice86.ViewModels.DataModels;
+using Spice86.Views.UserControls;
+
+/// <summary>Code-behind for the combined DOS memory overview view.</summary>
+public partial class DosMemoryOverviewView : EmulatorObjectUserControl {
+    private static readonly IBrush FreeBrush = new SolidColorBrush(Color.FromRgb(0x2E, 0x7D, 0x32));
+    private static readonly IBrush UsedBrush = new SolidColorBrush(Color.FromRgb(0xC6, 0x28, 0x28));
+
+    private DosMemoryOverviewViewModel? _vm;
+    private Canvas? _barCanvas;
+
+    /// <summary>Initializes a new <see cref="DosMemoryOverviewView"/>.</summary>
+    public DosMemoryOverviewView() {
+        InitializeComponent();
+    }
+
+    /// <inheritdoc />
+    protected override void OnAttachedToVisualTree(VisualTreeAttachmentEventArgs e) {
+        base.OnAttachedToVisualTree(e);
+        _barCanvas = this.FindControl<Canvas>("BarCanvas");
+        if (_barCanvas is not null) {
+            _barCanvas.SizeChanged += OnBarCanvasSizeChanged;
+        }
+        RebuildBars();
+    }
+
+    /// <inheritdoc />
+    protected override void OnDetachedFromVisualTree(VisualTreeAttachmentEventArgs e) {
+        if (_barCanvas is not null) {
+            _barCanvas.SizeChanged -= OnBarCanvasSizeChanged;
+        }
+        if (_vm is not null) {
+            _vm.PropertyChanged -= OnViewModelPropertyChanged;
+            _vm = null;
+        }
+        base.OnDetachedFromVisualTree(e);
+    }
+
+    /// <inheritdoc />
+    protected override void OnDataContextChanged(EventArgs e) {
+        base.OnDataContextChanged(e);
+        if (_vm is not null) {
+            _vm.PropertyChanged -= OnViewModelPropertyChanged;
+            _vm.IsVisible = false;
+        }
+        _vm = DataContext as DosMemoryOverviewViewModel;
+        if (_vm is not null) {
+            _vm.PropertyChanged += OnViewModelPropertyChanged;
+            _vm.IsVisible = IsViewModelEffectivelyVisible;
+            RebuildBars();
+        }
+    }
+
+    private void OnBarCanvasSizeChanged(object? sender, SizeChangedEventArgs e) {
+        RebuildBars();
+    }
+
+    private void OnViewModelPropertyChanged(object? sender, System.ComponentModel.PropertyChangedEventArgs e) {
+        if (e.PropertyName == nameof(DosMemoryOverviewViewModel.SegmentsVersion)) {
+            RebuildBars();
+        }
+    }
+
+    private void RebuildBars() {
+        if (_barCanvas is null || _vm is null) {
+            return;
+        }
+
+        _barCanvas.Children.Clear();
+
+        double width = _barCanvas.Bounds.Width;
+        double height = _barCanvas.Bounds.Height;
+        if (width <= 1 || height <= 1) {
+            return;
+        }
+
+        IReadOnlyList<ConventionalMemorySegment> segments = _vm.Segments;
+        if (segments.Count == 0) {
+            return;
+        }
+
+        long maxSize = 0;
+        foreach (ConventionalMemorySegment seg in segments) {
+            if (seg.SizeBytes > maxSize) {
+                maxSize = seg.SizeBytes;
+            }
+        }
+        if (maxSize <= 0) {
+            return;
+        }
+
+        const double labelArea = 18;
+        double plotHeight = height - labelArea;
+        if (plotHeight < 4) {
+            plotHeight = height;
+        }
+
+        double gap = 2;
+        double barWidth = (width - gap * (segments.Count + 1)) / segments.Count;
+        if (barWidth < 1) {
+            barWidth = 1;
+            gap = 0;
+        }
+
+        for (int i = 0; i < segments.Count; i++) {
+            ConventionalMemorySegment seg = segments[i];
+            double ratio = (double)seg.SizeBytes / maxSize;
+            double barHeight = ratio * plotHeight;
+            if (barHeight < 1) {
+                barHeight = 1;
+            }
+
+            IBrush fill;
+            if (seg.IsFree) {
+                fill = FreeBrush;
+            } else {
+                fill = UsedBrush;
+            }
+
+            Rectangle bar = new() {
+                Width = barWidth,
+                Height = barHeight,
+                Fill = fill,
+                Stroke = Brushes.Black,
+                StrokeThickness = 0.5
+            };
+            string tip = $"Seg 0x{seg.StartSegment:X4}  /  {seg.SizeBytes:N0} bytes  /  {seg.Owner}";
+            ToolTip.SetTip(bar, tip);
+            double x = gap + i * (barWidth + gap);
+            double y = plotHeight - barHeight;
+            Canvas.SetLeft(bar, x);
+            Canvas.SetTop(bar, y);
+            _barCanvas.Children.Add(bar);
+        }
+
+        // Baseline
+        Rectangle baseline = new() {
+            Width = width,
+            Height = 1,
+            Fill = Brushes.Gray
+        };
+        Canvas.SetLeft(baseline, 0);
+        Canvas.SetTop(baseline, plotHeight);
+        _barCanvas.Children.Add(baseline);
+    }
+}

--- a/src/Spice86/Views/DosMemorySummaryView.axaml
+++ b/src/Spice86/Views/DosMemorySummaryView.axaml
@@ -1,0 +1,11 @@
+<UserControl xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             xmlns:viewModels="clr-namespace:Spice86.ViewModels"
+             xmlns:userControls="clr-namespace:Spice86.Views.UserControls"
+             mc:Ignorable="d" d:DesignWidth="800" d:DesignHeight="450"
+             x:Class="Spice86.Views.DosMemorySummaryView"
+             x:DataType="viewModels:DosMemorySummaryViewModel">
+    <userControls:InspectorPanel Header="DOS Memory Summary" Data="{CompiledBinding Info}" />
+</UserControl>

--- a/src/Spice86/Views/DosMemorySummaryView.axaml.cs
+++ b/src/Spice86/Views/DosMemorySummaryView.axaml.cs
@@ -1,0 +1,11 @@
+namespace Spice86.Views;
+
+using Spice86.Views.UserControls;
+
+/// <summary>Code-behind for the DOS memory summary view.</summary>
+public partial class DosMemorySummaryView : EmulatorObjectUserControl {
+    /// <summary>Initializes a new <see cref="DosMemorySummaryView"/>.</summary>
+    public DosMemorySummaryView() {
+        InitializeComponent();
+    }
+}

--- a/src/Spice86/Views/DosPspChainView.axaml
+++ b/src/Spice86/Views/DosPspChainView.axaml
@@ -1,0 +1,29 @@
+<UserControl xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             xmlns:viewModels="clr-namespace:Spice86.ViewModels"
+             xmlns:userControls="clr-namespace:Spice86.Views.UserControls"
+             mc:Ignorable="d" d:DesignWidth="900" d:DesignHeight="500"
+             x:Class="Spice86.Views.DosPspChainView"
+             x:DataType="viewModels:DosPspChainViewModel">
+    <Grid ColumnDefinitions="260,*">
+        <ListBox Grid.Column="0"
+                 ItemsSource="{CompiledBinding Items}"
+                 SelectedItem="{CompiledBinding SelectedItem, Mode=TwoWay}">
+            <ListBox.ItemTemplate>
+                <DataTemplate>
+                    <StackPanel Orientation="Horizontal" Spacing="6">
+                        <TextBlock Text="{Binding Segment}" FontWeight="Bold" />
+                        <TextBlock Text="(current)" Foreground="OrangeRed"
+                                   IsVisible="{Binding IsCurrent}" />
+                        <TextBlock Text="{Binding OwnerName}" Opacity="0.8" />
+                    </StackPanel>
+                </DataTemplate>
+            </ListBox.ItemTemplate>
+        </ListBox>
+        <userControls:InspectorPanel Grid.Column="1"
+                                     Header="Selected PSP"
+                                     Data="{CompiledBinding SelectedItem}" />
+    </Grid>
+</UserControl>

--- a/src/Spice86/Views/DosPspChainView.axaml.cs
+++ b/src/Spice86/Views/DosPspChainView.axaml.cs
@@ -1,0 +1,11 @@
+namespace Spice86.Views;
+
+using Spice86.Views.UserControls;
+
+/// <summary>Code-behind for the DOS PSP chain view.</summary>
+public partial class DosPspChainView : EmulatorObjectUserControl {
+    /// <summary>Initializes a new <see cref="DosPspChainView"/>.</summary>
+    public DosPspChainView() {
+        InitializeComponent();
+    }
+}

--- a/src/Spice86/Views/DosPspGraphView.axaml
+++ b/src/Spice86/Views/DosPspGraphView.axaml
@@ -1,0 +1,76 @@
+<UserControl xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             xmlns:viewModels="clr-namespace:Spice86.ViewModels"
+             xmlns:dataModels="clr-namespace:Spice86.ViewModels.DataModels"
+             xmlns:agc="clr-namespace:AvaloniaGraphControl;assembly=AvaloniaGraphControl"
+             xmlns:behaviors="clr-namespace:Spice86.Views.Behaviors"
+             mc:Ignorable="d" d:DesignWidth="900" d:DesignHeight="560"
+             x:Class="Spice86.Views.DosPspGraphView"
+             x:DataType="viewModels:DosPspGraphViewModel">
+    <UserControl.Styles>
+        <Style Selector="agc|TextSticker">
+            <Setter Property="FontSize" Value="13" />
+            <Setter Property="FontFamily" Value="Cascadia Mono, Consolas, Courier New, monospace" />
+            <Setter Property="Padding" Value="8,6" />
+            <Setter Property="BorderThickness" Value="1.5" />
+            <Setter Property="BorderRadius" Value="4" />
+            <Setter Property="behaviors:GraphThemeBehavior.EnableTheming" Value="True" />
+        </Style>
+
+        <Style Selector="agc|Connection">
+            <Setter Property="behaviors:GraphThemeBehavior.EnableTheming" Value="True" />
+        </Style>
+
+        <Style Selector="agc|GraphPanel > TextBlock">
+            <Setter Property="behaviors:GraphThemeBehavior.EnableTheming" Value="True" />
+            <Setter Property="Background" Value="{DynamicResource SystemControlBackgroundAltMediumHighBrush}" />
+            <Setter Property="Padding" Value="4,2" />
+        </Style>
+    </UserControl.Styles>
+
+    <Grid RowDefinitions="Auto,*">
+        <TextBlock Grid.Row="0" Margin="6,4,6,2" Text="{CompiledBinding StatusMessage}" />
+        <ScrollViewer Grid.Row="1" HorizontalScrollBarVisibility="Visible" VerticalScrollBarVisibility="Visible">
+            <Border Background="{DynamicResource SystemControlBackgroundAltHighBrush}">
+                <ZoomBorder
+                Name="ZoomBorder"
+                ToolTip.Tip="Middle click to pan, mouse wheel to zoom/dezoom"
+                Stretch="None"
+                ZoomSpeed="1.5"
+                EnableConstrains="True"
+                ClipToBounds="True"
+                Focusable="True"
+                VerticalAlignment="Stretch"
+                HorizontalAlignment="Stretch">
+                    <agc:GraphPanel Graph="{CompiledBinding Graph}" LayoutMethod="SugiyamaScheme">
+                        <agc:GraphPanel.DataTemplates>
+                            <DataTemplate DataType="{x:Type dataModels:DosGraphNode}">
+                                <Border
+                                CornerRadius="4"
+                                Padding="8,6"
+                                behaviors:GraphThemeBehavior.EnableTheming="True">
+                                    <TextBlock
+                                    Text="{Binding}"
+                                    FontSize="13"
+                                    FontFamily="Cascadia Mono, Consolas, Courier New, monospace"
+                                    TextWrapping="Wrap"
+                                    MaxWidth="520" />
+                                </Border>
+                            </DataTemplate>
+                            <DataTemplate DataType="{x:Type dataModels:CfgGraphEdgeLabel}">
+                                <TextBlock
+                                Text="{Binding Text}"
+                                FontSize="13"
+                                Background="{DynamicResource SystemControlBackgroundAltMediumHighBrush}"
+                                Padding="4,2"
+                                behaviors:GraphThemeBehavior.EnableTheming="True" />
+                            </DataTemplate>
+                        </agc:GraphPanel.DataTemplates>
+                    </agc:GraphPanel>
+                </ZoomBorder>
+            </Border>
+        </ScrollViewer>
+    </Grid>
+</UserControl>

--- a/src/Spice86/Views/DosPspGraphView.axaml.cs
+++ b/src/Spice86/Views/DosPspGraphView.axaml.cs
@@ -1,0 +1,11 @@
+namespace Spice86.Views;
+
+using Spice86.Views.UserControls;
+
+/// <summary>Code-behind for DOS PSP graph view.</summary>
+public partial class DosPspGraphView : EmulatorObjectUserControl {
+    /// <summary>Initializes a new <see cref="DosPspGraphView"/>.</summary>
+    public DosPspGraphView() {
+        InitializeComponent();
+    }
+}

--- a/src/Spice86/Views/EmsView.axaml.cs
+++ b/src/Spice86/Views/EmsView.axaml.cs
@@ -1,35 +1,9 @@
 namespace Spice86.Views;
 
-using Avalonia;
-using Avalonia.Controls;
-using Avalonia.Threading;
+using Spice86.Views.UserControls;
 
-using Spice86.ViewModels;
-using Spice86.ViewModels.Services;
-
-public partial class EmsView : UserControl {
-    private DispatcherTimer? _timer;
-
+public partial class EmsView : EmulatorObjectUserControl {
     public EmsView() {
         InitializeComponent();
-        DetachedFromVisualTree += OnDetachedFromVisualTree;
-    }
-
-    private void OnDetachedFromVisualTree(object? sender, VisualTreeAttachmentEventArgs e) {
-        if (DataContext is IEmulatorObjectViewModel vm) {
-            vm.IsVisible = false;
-            _timer?.Stop();
-            _timer = null;
-        }
-    }
-
-    protected override void OnDataContextChanged(EventArgs e) {
-        base.OnDataContextChanged(e);
-        if (DataContext is IEmulatorObjectViewModel vm) {
-            vm.IsVisible = IsVisible;
-            _timer = DispatcherTimerStarter.StartNewDispatcherTimer(
-                TimeSpan.FromMilliseconds(400), DispatcherPriority.Background,
-                vm.UpdateValues);
-        }
     }
 }

--- a/src/Spice86/Views/MidiView.axaml.cs
+++ b/src/Spice86/Views/MidiView.axaml.cs
@@ -1,34 +1,9 @@
 namespace Spice86.Views;
 
-using Avalonia;
-using Avalonia.Controls;
-using Avalonia.Threading;
+using Spice86.Views.UserControls;
 
-using Spice86.ViewModels;
-using Spice86.ViewModels.Services;
-
-public partial class MidiView : UserControl {
-    private DispatcherTimer? _timer;
+public partial class MidiView : EmulatorObjectUserControl {
     public MidiView() {
         InitializeComponent();
-        this.DetachedFromVisualTree += OnDetachedFromVisualTree;
-    }
-
-    private void OnDetachedFromVisualTree(object? sender, VisualTreeAttachmentEventArgs e) {
-        if (DataContext is IEmulatorObjectViewModel vm) {
-            vm.IsVisible = false;
-            _timer?.Stop();
-            _timer = null;
-        }
-    }
-
-    protected override void OnDataContextChanged(EventArgs e) {
-        base.OnDataContextChanged(e);
-        if (DataContext is IEmulatorObjectViewModel vm) {
-            vm.IsVisible = this.IsVisible;
-            _timer = DispatcherTimerStarter.StartNewDispatcherTimer(
-                TimeSpan.FromMilliseconds(400), DispatcherPriority.Background,
-                vm.UpdateValues);
-        }
     }
 }

--- a/src/Spice86/Views/PaletteView.axaml.cs
+++ b/src/Spice86/Views/PaletteView.axaml.cs
@@ -1,34 +1,9 @@
 namespace Spice86.Views;
 
-using Avalonia;
-using Avalonia.Controls;
-using Avalonia.Threading;
+using Spice86.Views.UserControls;
 
-using Spice86.ViewModels;
-using Spice86.ViewModels.Services;
-
-internal partial class PaletteView : UserControl {
-    private DispatcherTimer? _timer;
+internal partial class PaletteView : EmulatorObjectUserControl {
     public PaletteView() {
         InitializeComponent();
-        this.DetachedFromVisualTree += OnDetachedFromVisualTree;
-    }
-
-    private void OnDetachedFromVisualTree(object? sender, VisualTreeAttachmentEventArgs e) {
-        if (DataContext is IEmulatorObjectViewModel vm) {
-            vm.IsVisible = false;
-            _timer?.Stop();
-            _timer = null;
-        }
-    }
-
-    protected override void OnDataContextChanged(EventArgs e) {
-        base.OnDataContextChanged(e);
-        if (DataContext is IEmulatorObjectViewModel vm) {
-            vm.IsVisible = this.IsVisible;
-            _timer = DispatcherTimerStarter.StartNewDispatcherTimer(
-                TimeSpan.FromMilliseconds(400), DispatcherPriority.Background,
-                vm.UpdateValues);
-        }
     }
 }

--- a/src/Spice86/Views/UserControls/EmulatorObjectUserControl.cs
+++ b/src/Spice86/Views/UserControls/EmulatorObjectUserControl.cs
@@ -1,0 +1,86 @@
+namespace Spice86.Views.UserControls;
+
+using Avalonia;
+using Avalonia.Controls;
+
+using Spice86.ViewModels;
+
+/// <summary>
+/// Base control that keeps an <see cref="IEmulatorObjectViewModel"/> visibility state in sync with this control.
+/// A view-model is considered visible only when the control is attached to the visual tree and visible.
+/// </summary>
+public abstract class EmulatorObjectUserControl : UserControl {
+    private IEmulatorObjectViewModel? _emulatorViewModel;
+    private bool _isAttachedToVisualTree;
+
+    /// <summary>
+    /// Gets the currently bound emulator-backed view-model when available.
+    /// </summary>
+    protected IEmulatorObjectViewModel? EmulatorViewModel => _emulatorViewModel;
+
+    /// <inheritdoc />
+    protected override void OnAttachedToVisualTree(VisualTreeAttachmentEventArgs e) {
+        base.OnAttachedToVisualTree(e);
+        _isAttachedToVisualTree = true;
+        SynchronizeEmulatorVisibility();
+    }
+
+    /// <inheritdoc />
+    protected override void OnDetachedFromVisualTree(VisualTreeAttachmentEventArgs e) {
+        _isAttachedToVisualTree = false;
+        SynchronizeEmulatorVisibility();
+        base.OnDetachedFromVisualTree(e);
+    }
+
+    /// <inheritdoc />
+    protected override void OnDataContextChanged(EventArgs e) {
+        base.OnDataContextChanged(e);
+        SetEmulatorViewModel(DataContext as IEmulatorObjectViewModel);
+    }
+
+    /// <inheritdoc />
+    protected override void OnPropertyChanged(AvaloniaPropertyChangedEventArgs change) {
+        base.OnPropertyChanged(change);
+        if (change.Property == IsVisibleProperty) {
+            SynchronizeEmulatorVisibility();
+        }
+    }
+
+    /// <summary>
+    /// Called when the typed emulator view-model reference changes.
+    /// </summary>
+    protected virtual void OnEmulatorViewModelChanged() {
+    }
+
+    /// <summary>
+    /// Called after base synchronization updates <see cref="IEmulatorObjectViewModel.IsVisible"/>.
+    /// </summary>
+    protected virtual void OnEmulatorVisibilitySynchronized() {
+    }
+
+    /// <summary>
+    /// Returns whether this control is effectively visible for refresh purposes.
+    /// </summary>
+    protected bool IsViewModelEffectivelyVisible => _isAttachedToVisualTree && IsVisible;
+
+    private void SetEmulatorViewModel(IEmulatorObjectViewModel? viewModel) {
+        if (ReferenceEquals(_emulatorViewModel, viewModel)) {
+            return;
+        }
+
+        if (_emulatorViewModel is not null) {
+            _emulatorViewModel.IsVisible = false;
+        }
+
+        _emulatorViewModel = viewModel;
+        OnEmulatorViewModelChanged();
+        SynchronizeEmulatorVisibility();
+    }
+
+    private void SynchronizeEmulatorVisibility() {
+        if (_emulatorViewModel is not null) {
+            _emulatorViewModel.IsVisible = IsViewModelEffectivelyVisible;
+        }
+        OnEmulatorVisibilitySynchronized();
+    }
+}

--- a/src/Spice86/Views/UserControls/InspectorPanel.axaml
+++ b/src/Spice86/Views/UserControls/InspectorPanel.axaml
@@ -1,0 +1,19 @@
+<UserControl xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             xmlns:pgc="clr-namespace:Avalonia.PropertyGrid.Controls;assembly=Avalonia.PropertyGrid"
+             xmlns:controls="clr-namespace:Spice86.Views.Controls"
+             mc:Ignorable="d" d:DesignWidth="800" d:DesignHeight="450"
+             x:Class="Spice86.Views.UserControls.InspectorPanel"
+             x:Name="Root">
+    <ScrollViewer>
+        <controls:GroupBox Header="{Binding #Root.Header}">
+            <pgc:PropertyGrid DataContext="{Binding #Root.Data}">
+                <TextElement.FontFamily>
+                    <OnPlatform Default="{StaticResource RobotoMonoFont}" />
+                </TextElement.FontFamily>
+            </pgc:PropertyGrid>
+        </controls:GroupBox>
+    </ScrollViewer>
+</UserControl>

--- a/src/Spice86/Views/UserControls/InspectorPanel.axaml.cs
+++ b/src/Spice86/Views/UserControls/InspectorPanel.axaml.cs
@@ -1,0 +1,38 @@
+namespace Spice86.Views.UserControls;
+
+using Avalonia;
+using Avalonia.Controls;
+
+/// <summary>
+/// Reusable host for a single <see cref="Avalonia.PropertyGrid.Controls.PropertyGrid"/> bound to an Info object.
+/// </summary>
+public partial class InspectorPanel : UserControl {
+    /// <summary>
+    /// The Info object rendered by the inner property grid.
+    /// </summary>
+    public static readonly StyledProperty<object?> DataProperty =
+        AvaloniaProperty.Register<InspectorPanel, object?>(nameof(Data));
+
+    /// <summary>
+    /// The header displayed above the property grid.
+    /// </summary>
+    public static readonly StyledProperty<string> HeaderProperty =
+        AvaloniaProperty.Register<InspectorPanel, string>(nameof(Header), string.Empty);
+
+    /// <inheritdoc cref="DataProperty"/>
+    public object? Data {
+        get => GetValue(DataProperty);
+        set => SetValue(DataProperty, value);
+    }
+
+    /// <inheritdoc cref="HeaderProperty"/>
+    public string Header {
+        get => GetValue(HeaderProperty);
+        set => SetValue(HeaderProperty, value);
+    }
+
+    /// <summary>Initializes a new <see cref="InspectorPanel"/>.</summary>
+    public InspectorPanel() {
+        InitializeComponent();
+    }
+}

--- a/src/Spice86/Views/VideoCardView.axaml.cs
+++ b/src/Spice86/Views/VideoCardView.axaml.cs
@@ -1,34 +1,11 @@
 using Avalonia;
-using Avalonia.Controls;
-using Avalonia.Threading;
 
-using Spice86.ViewModels;
-using Spice86.ViewModels.Services;
+using Spice86.Views.UserControls;
 
 namespace Spice86.Views;
 
-public partial class VideoCardView : UserControl {
-    private DispatcherTimer? _timer;
+public partial class VideoCardView : EmulatorObjectUserControl {
     public VideoCardView() {
         InitializeComponent();
-        DetachedFromVisualTree += OnDetachedFromVisualTree;
-    }
-
-    private void OnDetachedFromVisualTree(object? sender, VisualTreeAttachmentEventArgs e) {
-        if (DataContext is IEmulatorObjectViewModel vm) {
-            vm.IsVisible = false;
-            _timer?.Stop();
-            _timer = null;
-        }
-    }
-
-    protected override void OnDataContextChanged(EventArgs e) {
-        base.OnDataContextChanged(e);
-        if (DataContext is IEmulatorObjectViewModel vm) {
-            vm.IsVisible = this.IsVisible;
-            _timer = DispatcherTimerStarter.StartNewDispatcherTimer(
-                TimeSpan.FromMilliseconds(400), DispatcherPriority.Background,
-                vm.UpdateValues);
-        }
     }
 }

--- a/src/Spice86/Views/XmsView.axaml.cs
+++ b/src/Spice86/Views/XmsView.axaml.cs
@@ -1,35 +1,9 @@
 namespace Spice86.Views;
 
-using Avalonia;
-using Avalonia.Controls;
-using Avalonia.Threading;
+using Spice86.Views.UserControls;
 
-using Spice86.ViewModels;
-using Spice86.ViewModels.Services;
-
-public partial class XmsView : UserControl {
-    private DispatcherTimer? _timer;
-
+public partial class XmsView : EmulatorObjectUserControl {
     public XmsView() {
         InitializeComponent();
-        DetachedFromVisualTree += OnDetachedFromVisualTree;
-    }
-
-    private void OnDetachedFromVisualTree(object? sender, VisualTreeAttachmentEventArgs e) {
-        if (DataContext is IEmulatorObjectViewModel vm) {
-            vm.IsVisible = false;
-            _timer?.Stop();
-            _timer = null;
-        }
-    }
-
-    protected override void OnDataContextChanged(EventArgs e) {
-        base.OnDataContextChanged(e);
-        if (DataContext is IEmulatorObjectViewModel vm) {
-            vm.IsVisible = IsVisible;
-            _timer = DispatcherTimerStarter.StartNewDispatcherTimer(
-                TimeSpan.FromMilliseconds(400), DispatcherPriority.Background,
-                vm.UpdateValues);
-        }
     }
 }

--- a/tests/Spice86.Tests/UI/CfgCpu/CfgCpuViewModelTest.cs
+++ b/tests/Spice86.Tests/UI/CfgCpu/CfgCpuViewModelTest.cs
@@ -24,9 +24,11 @@ using Spice86.Core.Emulator.VM.Breakpoint;
 using Spice86.Shared.Emulator.Memory;
 using Spice86.Shared.Interfaces;
 using Spice86.ViewModels;
+using Spice86.ViewModels.Enums;
 using Spice86.ViewModels.Services;
 
 using Xunit;
+using Spice86.ViewModels.DataModels;
 
 /// <summary>
 /// UI tests for <see cref="CfgCpuViewModel"/> validating block-centric rendering, indicators,


### PR DESCRIPTION
### Description of Changes
Adds DOS/BIOS debugger inspector tabs and related models/mappers for:
- DOS memory summary and memory overview
- DOS MCB chain
- DOS PSP chain and PSP graph

### Rationale behind Changes
These changes expand debugger visibility into DOS runtime state and make memory/process inspection more practical.  


### Suggested Testing Steps

- Manual UI checks:
  - Open debugger DOS tabs and verify memory summary/overview, MCBs, PSP chain, and PSP graph render correctly.
  - Confirm PSP owner names appear when available.
  - Switch tabs and verify polling/refresh behavior follows visibility.
  - Verify EMS/XMS views remain responsive during refresh/filter updates.