### PR TITLE
Fix: off-by-one column in pan shift logic for text and graphics modes

### DIFF
--- a/src/Spice86.Core/Emulator/Devices/Video/Renderer.cs
+++ b/src/Spice86.Core/Emulator/Devices/Video/Renderer.cs
@@ -634,25 +634,6 @@ public class Renderer : IVgaRenderer {
             frameBuffer[destinationAddress++] = attrMap[index];
         }
     }
-
-    private void Draw256ColorMode(Span<uint> frameBuffer, uint[] paletteMap, ref int destinationAddress, byte plane0, byte plane1, byte plane2, byte plane3) {
-        // 256-color mode is simply using the video memory bytes directly.
-        // Output 8 pixels by drawing each of the 4 pixels twice.
-        uint pixel12Color = paletteMap[plane0];
-        uint pixel34Color = paletteMap[plane1];
-        uint pixel56Color = paletteMap[plane2];
-        uint pixel78Color = paletteMap[plane3];
-        frameBuffer[destinationAddress++] = pixel12Color;
-        frameBuffer[destinationAddress++] = pixel12Color;
-        frameBuffer[destinationAddress++] = pixel34Color;
-        frameBuffer[destinationAddress++] = pixel34Color;
-        frameBuffer[destinationAddress++] = pixel56Color;
-        frameBuffer[destinationAddress++] = pixel56Color;
-        frameBuffer[destinationAddress++] = pixel78Color;
-        frameBuffer[destinationAddress++] = pixel78Color;
-    }
-
-
 }
 
 internal enum MemoryWidth {

--- a/src/Spice86.Core/Emulator/Devices/Video/Renderer.cs
+++ b/src/Spice86.Core/Emulator/Devices/Video/Renderer.cs
@@ -434,24 +434,16 @@ public class Renderer : IVgaRenderer {
         if (!inGraphicsMode) {
             return ComputeTextPanShift(pixelsPerChar);
         }
-        // In 256-color mode the hardware only honours bits 0-2 of AR13.
-        // In planar modes all 4 bits are valid.
-        int panUnits;
-        if (in256ColorMode) {
-            panUnits = _framePanShift & 0x07;
-        } else {
-            panUnits = _framePanShift & 0x0F;
-        }
+        // In 256-color mode the hardware only honours bits 0-2 of AR13 (matches DOSBox-staging).
+        // In planar/text modes all 4 bits are valid.
+        int panUnits = in256ColorMode ? _framePanShift & 0x07 : _framePanShift & 0x0F;
         if (panUnits == 0) {
             return 0;
         }
         if (_framePixelPanningCompatibility && !_frameAboveLineCompare) {
             return 0;
         }
-        if (in256ColorMode) {
-            return panUnits * 2;
-        }
-        return panUnits;
+        return in256ColorMode ? panUnits * 2 : panUnits;
     }
 
     /// <summary>

--- a/src/Spice86.Core/Emulator/Devices/Video/Renderer.cs
+++ b/src/Spice86.Core/Emulator/Devices/Video/Renderer.cs
@@ -201,7 +201,7 @@ public class Renderer : IVgaRenderer {
                 _frameScanLineBit0ForAddressBit14,
                 _frameCharRowScanline & 1);
 
-            int effectivePanShift = ComputeEffectivePanShift(in256ColorMode);
+            int effectivePanShift = ComputeEffectivePanShift(in256ColorMode, inGraphicsMode, pixelsPerChar);
             int visibleChars = _frameHorizontalDisplayEnd - _frameSkew;
 
             if (in256ColorMode && !_frameVerticalBlanking) {
@@ -424,15 +424,18 @@ public class Renderer : IVgaRenderer {
     }
 
     /// <summary>
-    ///     Computes the effective pixel-panning shift for the current scanline.
-    ///     In 256-color mode, each AR13 unit represents 2 displayed pixels (pixel-doubling
-    ///     granularity) and the hardware-valid range is 0–7 (3 bits), giving a max of 14 pixels.
-    ///     In all other modes the valid range is 0–15 (4 bits), one unit = one pixel.
-    ///     Returns 0 when below the line-compare boundary and PixelPanningCompatibility is set.
+    ///     Computes the effective AR13 horizontal panning shift for the current scanline.
     /// </summary>
-    private int ComputeEffectivePanShift(bool in256ColorMode) {
-        // In 256-color mode the hardware only honours bits 0-2 of AR13 (matches DOSBox-staging).
-        // In planar/text modes all 4 bits are valid.
+    /// <param name="in256ColorMode">Whether the current graphics mode uses the 256-color shift path.</param>
+    /// <param name="inGraphicsMode">Whether the current mode is graphics or text.</param>
+    /// <param name="pixelsPerChar">The number of output pixels generated for each text character cell.</param>
+    /// <returns>The number of output pixels to skip from the rendered scratch row.</returns>
+    private int ComputeEffectivePanShift(bool in256ColorMode, bool inGraphicsMode, int pixelsPerChar) {
+        if (!inGraphicsMode) {
+            return ComputeTextPanShift(pixelsPerChar);
+        }
+        // In 256-color mode the hardware only honours bits 0-2 of AR13.
+        // In planar modes all 4 bits are valid.
         int panUnits = in256ColorMode ? _framePanShift & 0x07 : _framePanShift & 0x0F;
         if (panUnits == 0) {
             return 0;
@@ -441,6 +444,25 @@ public class Renderer : IVgaRenderer {
             return 0;
         }
         return in256ColorMode ? panUnits * 2 : panUnits;
+    }
+
+    /// <summary>
+    ///     Computes the effective AR13 horizontal panning shift for text mode.
+    /// </summary>
+    /// <param name="pixelsPerChar">The number of output pixels generated for each text character cell.</param>
+    /// <returns>The number of output pixels to skip from the rendered scratch row.</returns>
+    private int ComputeTextPanShift(int pixelsPerChar) {
+        int panUnits = _framePanShift & 0x0F;
+        if (panUnits > 7) {
+            return 0;
+        }
+        if (_framePixelPanningCompatibility && !_frameAboveLineCompare) {
+            return 0;
+        }
+        if (pixelsPerChar == 9 && _state.AttributeControllerRegisters.AttributeControllerModeRegister.LineGraphicsEnabled) {
+            return panUnits + 1;
+        }
+        return panUnits;
     }
 
     /// <summary>

--- a/src/Spice86.Core/Emulator/Devices/Video/Renderer.cs
+++ b/src/Spice86.Core/Emulator/Devices/Video/Renderer.cs
@@ -472,7 +472,13 @@ public class Renderer : IVgaRenderer {
     /// </summary>
     private void ApplyPannedRow(Span<uint> frameBuffer, int panShift, int scratchLength) {
         int destStart = _frameDestinationAddressLatch;
-        int available = Math.Min(Width, scratchLength - panShift);
+        int destinationRemaining = frameBuffer.Length - destStart;
+        if (destinationRemaining <= 0) {
+            _frameDestinationAddress = destStart + Width;
+            return;
+        }
+        int sourceRemaining = scratchLength - panShift;
+        int available = Math.Min(destinationRemaining, sourceRemaining);
         if (available > 0) {
             _rowScratch.AsSpan(panShift, available).CopyTo(frameBuffer.Slice(destStart, available));
         }

--- a/src/Spice86.Core/Emulator/Devices/Video/Renderer.cs
+++ b/src/Spice86.Core/Emulator/Devices/Video/Renderer.cs
@@ -436,14 +436,22 @@ public class Renderer : IVgaRenderer {
         }
         // In 256-color mode the hardware only honours bits 0-2 of AR13.
         // In planar modes all 4 bits are valid.
-        int panUnits = in256ColorMode ? _framePanShift & 0x07 : _framePanShift & 0x0F;
+        int panUnits;
+        if (in256ColorMode) {
+            panUnits = _framePanShift & 0x07;
+        } else {
+            panUnits = _framePanShift & 0x0F;
+        }
         if (panUnits == 0) {
             return 0;
         }
         if (_framePixelPanningCompatibility && !_frameAboveLineCompare) {
             return 0;
         }
-        return in256ColorMode ? panUnits * 2 : panUnits;
+        if (in256ColorMode) {
+            return panUnits * 2;
+        }
+        return panUnits;
     }
 
     /// <summary>

--- a/tests/Spice86.Tests/Video/RendererTestsBase.cs
+++ b/tests/Spice86.Tests/Video/RendererTestsBase.cs
@@ -1343,6 +1343,57 @@ public abstract class RendererTestsBase {
             "panning=0: pixel 0 shows bit 7 of addr 0 normally");
     }
 
+    [SkippableFact]
+    public void HorizontalPixelPanning_TextMode_AR13_8OrAbove_ResultsInNoShift() {
+        EnsureSupported();
+        VideoState state = ConfigureTextMode(1);
+        (Renderer renderer, VideoMemory vram) = CreateRenderer(state);
+        SetIdentityAttributeMap(state);
+
+        // Character 0: font byte 0xFF (all pixels set) = foreground color
+        vram.Planes[2, 0] = 0xFF;
+        byte attribute = 0x07; // foreground index 7, background index 0
+        vram.Planes[0, 0] = 0x00; // char code 0
+        vram.Planes[1, 0] = attribute;
+
+        // AR13=8 is above the valid text-mode range (0-7); hardware clamps to no pan
+        state.AttributeControllerRegisters.HorizontalPixelPanning = 8;
+        state.IsRenderingDirty = true;
+        uint[] frame = RenderAndCapture(renderer, state);
+
+        frame[0].Should().Be(state.DacRegisters.AttributeMap[7],
+            "text mode AR13>=8 must produce no shift; first pixel = foreground");
+    }
+
+    [SkippableFact]
+    public void HorizontalPixelPanning_TextMode_9DotWithLineGraphics_AddsOnePan() {
+        EnsureSupported();
+        VideoState state = ConfigureTextMode(1);
+        (Renderer renderer, VideoMemory vram) = CreateRenderer(state);
+        SetIdentityAttributeMap(state);
+
+        // Enable 9-dot character clock
+        state.SequencerRegisters.ClockingModeRegister.DotsPerClock = 9;
+        // Enable line graphics so the 9th dot repeats the 8th for box-drawing characters
+        state.AttributeControllerRegisters.AttributeControllerModeRegister.LineGraphicsEnabled = true;
+
+        // Character 0 font: only bit 6 set (pixel 1 when unshifted)
+        vram.Planes[2, 0] = 0x40;
+        vram.Planes[0, 0] = 0x00; // char code 0
+        vram.Planes[1, 0] = 0x07; // attribute: fg=7, bg=0
+
+        // AR13=1 in 9-dot text mode with LineGraphicsEnabled shifts by panUnits+1=2 pixels
+        state.AttributeControllerRegisters.HorizontalPixelPanning = 1;
+        state.IsRenderingDirty = true;
+        uint[] frame = RenderAndCapture(renderer, state);
+
+        // Unshifted: pixel 0 = bg (bit 7=0), pixel 1 = fg (bit 6=1)
+        // With pan=1 and +1 for 9-dot LineGraphics: effective shift=2
+        // pixel 0 now corresponds to bit 5 of font byte 0x40 = 0 => background
+        frame[0].Should().Be(state.DacRegisters.AttributeMap[0],
+            "9-dot text mode with LineGraphicsEnabled: pan=1 becomes effective shift 2, pixel 0 = background");
+    }
+
     // -------------------------------------------------- Helper Methods --------------------------------------------------
 
     /// <summary>

--- a/tests/Spice86.Tests/Video/RendererTestsBase.cs
+++ b/tests/Spice86.Tests/Video/RendererTestsBase.cs
@@ -9,7 +9,6 @@ using Spice86.Core.Emulator.Devices.Video.Registers.CrtController;
 using Spice86.Core.Emulator.Devices.Video.Registers.Graphics;
 using Spice86.Core.Emulator.Memory;
 using Spice86.Logging;
-using Spice86.Shared.Interfaces;
 
 using Xunit;
 


### PR DESCRIPTION
### Description of Changes

- Adjusted VGA renderer horizontal panning calculation so text mode interprets AR13 differently from graphics modes.
- Added text-mode panning rules for AR13 values greater than 7 and 9-dot line graphics character cells.
- Updated renderer XML documentation for the panning helper methods.

### Rationale behind Changes

ROE2, Another World, Castle Adventure, and more exposed a text-mode rendering issue where the left edge of BIOS/text output could be clipped and stray characters appeared at the right edge. The root cause is that VGA text mode does not interpret AR13 exactly like planar or 256-color graphics modes. The updated logic follows the text-mode handling used by DOSBox Staging: text mode clamps AR13 values above 7 to no panning, and 9-dot line graphics mode uses one additional pan unit.

<img width="1553" height="852" alt="image" src="https://github.com/user-attachments/assets/2cdc3fe8-148b-49ce-8f71-1550ace95d79" />

<img width="1536" height="851" alt="image" src="https://github.com/user-attachments/assets/ed58c574-d5d9-410e-b75a-e32dfb2693f0" />


### Suggested Testing Steps

- Run `Spice86.Tests.Video.RendererTests`.
- Run `dotnet test`.
- Launch ROE2 and verify the startup text is no longer clipped on the left and no longer leaves stray right-edge characters.

Also tested quickly manually without regressions spotted:

* Dune (floppy)
* Dune CD
* EXODUS
* Krondor
* Day of the Tentacle
* Indiana Jones and the Fate of Atlantis
* Dune 2
* Where in Space is Carmen Sandiego
* Wolf 3D
* Civ 1
* The Summonning