### PR TITLE
Fix that vga rom is mapped into the emulators memory space

### DIFF
--- a/src/Spice86/Spice86DependencyInjection.cs
+++ b/src/Spice86/Spice86DependencyInjection.cs
@@ -336,6 +336,7 @@ public class Spice86DependencyInjection : IDisposable {
         VgaTimingEngine vgaTimingEngine = new(videoState, vgaScheduler,
             _emulatedClock, vgaRenderer, vgaBlinkState);
         VgaRom vgaRom = new();
+        memory.RegisterMapping(VgaRom.Segment << 4, vgaRom.Size, vgaRom);
         VgaFunctionality vgaFunctionality = new VgaFunctionality(memory,
             interruptVectorTable, ioPortDispatcher,
             biosDataArea, vgaRom,


### PR DESCRIPTION
### Description of Changes
Mapped the VGA BIOS ROM into guest memory at C000:0000 during emulator initialization so BIOS font pointers returned by INT 10h AX=1130h resolve to actual font data.

### Rationale behind Changes
Tom Long requests BIOS font pointers for its dialog text rendering. Spice86 was returning C000: font addresses, but the VGA ROM backing those addresses was not mapped into guest memory, so the game read zero glyph bytes and rendered no dialog options. Mapping VgaRom fixes the missing BIOS font data at the source instead of working around the symptom in game-specific code.

### Suggested Testing Steps
1. Build src/Spice86.sln in Debug.
2. Launch Tom Long and advance to the scene where dialog options should appear.
3. Verify the dialog text/options are now visible.
4. If needed, confirm font-related BIOS reads by checking that INT 10h AX=1130h returns C000: pointers and that those addresses now contain nonzero font data.
