### PR TITLE
perf: Optimize/simplify Alu.IsParity method.

### DIFF
--- a/src/Spice86.Core/Emulator/CPU/Alu.cs
+++ b/src/Spice86.Core/Emulator/CPU/Alu.cs
@@ -20,29 +20,6 @@ public abstract class Alu<TUnsigned, TSigned, TUnsignedUpper, TSignedUpper>
     where TUnsignedUpper : IUnsignedNumber<TUnsignedUpper>
     where TSignedUpper : ISignedNumber<TSignedUpper> {
     /// <summary>
-    /// Shifting this by the number we want to test gives 1 if number of bit is even and 0 if odd.<br/>
-    /// Hardcoded numbers:<br/>
-    /// 0 -> 0000: even -> 1<br/>
-    /// 1 -> 0001: 1 bit so odd -> 0<br/>
-    /// 2 -> 0010: 1 bit so odd -> 0<br/>
-    /// 3 -> 0011: 2 bit so even -> 1<br/>
-    /// 4 -> 0100: 1 bit so odd -> 0<br/>
-    /// 5 -> 0101: even -> 1<br/>
-    /// 6 -> 0110: even -> 1<br/>
-    /// 7 -> 0111: odd -> 0<br/>
-    /// 8 -> 1000: odd -> 0<br/>
-    /// 9 -> 1001: even -> 1<br/>
-    /// A -> 1010: even -> 1<br/>
-    /// B -> 1011: odd -> 0<br/>
-    /// C -> 1100: even -> 1<br/>
-    /// D -> 1101: odd -> 0<br/>
-    /// E -> 1110: odd -> 0<br/>
-    /// F -> 1111: even -> 1<br/>
-    /// => lookup table is 1001011001101001
-    /// </summary>
-    private const uint FourBitParityTable = 0b1001011001101001;
-
-    /// <summary>
     /// The mask value of 0x1F (or 31 in decimal) effectively discards all but the 5 least significant bits of the shift count, thus ensuring it is within the range 0-31.
     /// </summary>
     protected const int ShiftCountMask = 0x1F;
@@ -166,9 +143,7 @@ public abstract class Alu<TUnsigned, TSigned, TUnsignedUpper, TSignedUpper>
     /// Returns whether the given byte has even parity.
     /// </summary>
     private static bool IsParity(byte value) {
-        int low4 = value & 0xF;
-        int high4 = value >> 4 & 0xF;
-        return (FourBitParityTable >> low4 & 1) == (FourBitParityTable >> high4 & 1);
+        return (BitOperations.PopCount(value) & 1) == 0;
     }
 
     // from https://www.vogons.org/viewtopic.php?t=55377

--- a/src/Spice86.MicroBenchmarkTemplate/Program.cs
+++ b/src/Spice86.MicroBenchmarkTemplate/Program.cs
@@ -1,5 +1,7 @@
 ﻿namespace Spice86.MicroBenchmarkTemplate;
 
+using System.Numerics;
+
 using Xunit;
 
 /// <summary>
@@ -20,7 +22,47 @@ public class BenchmarkTest {
 
     [Benchmark]
     public SegmentedAddress Cached() => _instance.CachedSegmentedAddress;
+
+    [Benchmark]
+    [Arguments(42)]
+    [Arguments(69)]
+    public bool AluParity8_FourBit(byte value) {
+        const uint FourBitParityTable = 0b1001011001101001;
+        int low4 = value & 0xF;
+        int high4 = value >> 4 & 0xF;
+        return ((FourBitParityTable >> low4) & 1) == ((FourBitParityTable >> high4) & 1);
+    }
+
+    [Benchmark]
+    [Arguments(42)]
+    [Arguments(69)]
+    public bool AluParity8_PopCount(byte value) {
+        return (BitOperations.PopCount(value) & 1) == 0;
+    }
+
+    [Benchmark]
+    [Arguments(42)]
+    [Arguments(69)]
+    public bool AluParity8_PopCountFallback(byte value) {
+        // This simulates platforms which do not have a hardware-optimized population count implementation. The
+        // "SoftwareFallback" method was copied from BitOperations.PopCount on .NET 10.
+        return (SoftwareFallback(value) & 1) == 0;
+
+        static int SoftwareFallback(uint value) {
+            const uint c1 = 0x_55555555u;
+            const uint c2 = 0x_33333333u;
+            const uint c3 = 0x_0F0F0F0Fu;
+            const uint c4 = 0x_01010101u;
+
+            value -= (value >> 1) & c1;
+            value = (value & c2) + ((value >> 2) & c2);
+            value = (((value + (value >> 4)) & c3) * c4) >> 24;
+
+            return (int)value;
+        }
+    }
 }
+
 internal class Program {
     public static void Main() {
 #if RELEASE


### PR DESCRIPTION
### Description of Changes
Simplifies logic and slightly outperforms previous method by using hardware-optimized bit population count instead of two 4-bit shift-based lookup tables.

It's difficult to tell if this really improves performance, since it is a very small and low level CPU micro optimization (too many other random factors affecting runtime performance). Some of my testing with the Space Quest 5 intro shows that real world is maybe around 0% to 1% performance improvement with this change. Micro benchmarks shown below indicates that using POPCNT outperforms the previous implementation by at least a factor of 10 (see commit details for benchmarks used).

The software fallback method for `BitOperations.PopCount` is slightly slower than the existing `IsParity` implementation, but not by much (even though the JIT generates more x86 instructions when inspected with [SharpLab](https://sharplab.io/#v2:EYLgxg9gTgpgtADwGwBYA0AXEBDAzgWwB8ABABgAJiBGAOgDkBXfGKASzFwG4BYAKD+IBmSgCZyAYXIBvPuTnkADmwBu2DDHKQAdrgzkGrLXoBiEBlABCrDAAVsbDAE8AKtmAAbDQF5ypYFVJSAKoAoODAqh5+XnlFFTUNaiRyYAgId3IASVw7B0cAeTYAc0NsdwAKYEd1clV3BhgASmlZWPlDPXcIAHcUch86hvIAMl8EYyi29qNyAAtWItm+gbKhgD418j7R0nHJqcoAdnJy03MrW3trFzdPcg3yLt6R8ipmrx9Ts0trXOvXDwaB7zRbbV6NfZyAC+fFaciUrFUNSSKTSGWyfyclWqGkGTRaMQOxGO5Qu+QULDUrAgOhoNggCnEZiM5TxzVGb36PlIkPIMMJcjhcURCUoVGSqXSWRyVycAGUIAAzDDdewwYxldzAbBgADW2JqbIJByOJ3pjOZGAVytVsA17i1Ov1Ro5725vP5QpRHXI5qZDCM1pVavtjr15QMMyNMgFbW0un0PrAVH6YwA+gBWLPZrMMXmxeN6SN6MBibkINOCKvVqt5oUFmkJ4uaYTltOkYwdrvGOuxhs6ItJ5bpoKj4K9+vyPHkOCfacPTmjZP5qerbwnadLkTNADUJ1Za/um23L1LEMncmnn3KB/qGj3t/WmxQjXZLeaACpNC+j+QRCgogvU1yg6Ro8Q9PgoSAA)).

```
// * Summary *

BenchmarkDotNet v0.15.8, Windows 11 (10.0.26200.8457/25H2/2025Update/HudsonValley2)
AMD Ryzen 9 3900X 3.80GHz, 1 CPU, 24 logical and 12 physical cores
.NET SDK 10.0.300
  [Host]     : .NET 10.0.8 (10.0.8, 10.0.826.23019), X64 RyuJIT x86-64-v3
  DefaultJob : .NET 10.0.8 (10.0.8, 10.0.826.23019), X64 RyuJIT x86-64-v3


| Method                      | value | Mean      | Error     | StdDev    | Median    |
|---------------------------- |------ |----------:|----------:|----------:|----------:|
| AluParity8_FourBit          | 42    | 0.4043 ns | 0.0325 ns | 0.0304 ns | 0.3914 ns |
| AluParity8_PopCount         | 42    | 0.0040 ns | 0.0053 ns | 0.0044 ns | 0.0016 ns |
| AluParity8_PopCountFallback | 42    | 0.4124 ns | 0.0174 ns | 0.0163 ns | 0.4024 ns |
| AluParity8_FourBit          | 69    | 0.3894 ns | 0.0150 ns | 0.0140 ns | 0.3830 ns |
| AluParity8_PopCount         | 69    | 0.0208 ns | 0.0165 ns | 0.0154 ns | 0.0214 ns |
| AluParity8_PopCountFallback | 69    | 0.4084 ns | 0.0193 ns | 0.0181 ns | 0.4096 ns |

// * Warnings *
ZeroMeasurement
  BenchmarkTest.AluParity8_PopCount: Default -> The method duration is indistinguishable from the empty method duration
  BenchmarkTest.AluParity8_PopCount: Default -> The method duration is indistinguishable from the empty method duration
MultimodalDistribution
  BenchmarkTest.AluParity8_PopCountFallback: Default -> It seems that the distribution is bimodal (mValue = 3.33)
  BenchmarkTest.AluParity8_FourBit: Default          -> It seems that the distribution is bimodal (mValue = 3.75)

// * Hints *
Outliers
  BenchmarkTest.AluParity8_PopCount: Default -> 2 outliers were removed (1.50 ns, 1.53 ns)
```

### Rationale behind Changes
Try to improve performance and readability. Many ALU-related instructions call `IsParity` (as it is one of the EFLAGS that is typically set).

### Suggested Testing Steps
Tested on an AMD x64 CPU. Unknown if changes will negatively impact performance of other host CPU architectures (like ARM).
