### PR TITLE
Made MainWindow UI less cramped

### DIFF
--- a/src/Spice86.Core/Emulator/ProgramBootstrapper.cs
+++ b/src/Spice86.Core/Emulator/ProgramBootstrapper.cs
@@ -55,7 +55,7 @@ internal sealed class ProgramBootstrapper {
                 executableFileName, isDosProgram);
         }
 
-        ExecutableFileLoader loader = CreateLoader(executableFileName, isDosProgram, upperCaseExtension);
+        ExecutableFileLoader loader = CreateLoader(isDosProgram, upperCaseExtension);
 
         try {
             if (_configuration.InitializeDOS is null) {
@@ -72,7 +72,7 @@ internal sealed class ProgramBootstrapper {
         }
     }
 
-    private ExecutableFileLoader CreateLoader(string executableFileName, bool isDosProgram, string upperCaseExtension) {
+    private ExecutableFileLoader CreateLoader(bool isDosProgram, string upperCaseExtension) {
         if (!isDosProgram) {
             return new BiosLoader(_memory, _state, _loggerService);
         }

--- a/src/Spice86/Views/MainWindow.axaml
+++ b/src/Spice86/Views/MainWindow.axaml
@@ -35,7 +35,7 @@
 		<vm:MainWindowViewModel />
 	</Design.DataContext>
 	<Grid RowDefinitions="Auto,*,Auto">
-		<Grid x:Name="TopBar" IsTabStop="False" Focusable="False" Grid.ColumnDefinitions="Auto,Auto" Grid.Row="0">
+		<Grid x:Name="TopBar" IsTabStop="False" Focusable="False" Grid.ColumnDefinitions="Auto,8*" Grid.Row="0">
 			<Menu Grid.Column="0" Name="Menu" Focusable="False" IsTabStop="False" IsVisible="{Binding !IsDialogVisible}">
 				<MenuItem Header="Debug">
 					<MenuItem HotKey="Ctrl+Alt+F2" ToolTip.Tip="Ctrl+Alt+F2" IsEnabled="{Binding IsEmulatorRunning}">
@@ -49,75 +49,77 @@
 							<b:ShowAdditionnalWindowBehavior />
 						</Interaction.Behaviors>
 					</MenuItem>
-					<MenuItem>
-						<MenuItem.Header>
-							<StackPanel Orientation="Horizontal">
-								<fluent:SymbolIcon Symbol="Info" />
-								<Label Content="{Binding CurrentLogLevel, StringFormat='Log Level ({0})'}" />
-							</StackPanel>
-						</MenuItem.Header>
-						<MenuItem Header="Silent" Command="{Binding SetLogLevelToSilent}" />
-						<MenuItem Header="Verbose" Command="{Binding SetLogLevelToVerbose}" />
-						<MenuItem Header="Debug" Command="{Binding SetLogLevelToDebug}" />
-						<MenuItem Header="Information" Command="{Binding SetLogLevelToInformation}" />
-						<MenuItem Header="Warning" Command="{Binding SetLogLevelToWarning}" />
-						<MenuItem Header="Error" Command="{Binding SetLogLevelToError}" />
-						<MenuItem Header="Fatal" Command="{Binding SetLogLevelToFatal}" />
+					<MenuItem IsVisible="{Binding ShowHttp}" Header="HTTP">
+						<MenuItem Command="{Binding ShowHttpApiCommand}" CommandParameter="{Binding HttpApiPort}">
+							<MenuItem.Header>
+								<StackPanel Orientation="Horizontal">
+									<fluent:SymbolIcon Symbol="Info" />
+									<Label Content="Status and API Test" />
+								</StackPanel>
+							</MenuItem.Header>
+						</MenuItem>
 					</MenuItem>
-					<MenuItem
-					HotKey="Ctrl+Alt+D" ToolTip.Tip="Ctrl+Alt+D"
-					IsEnabled="{Binding IsEmulatorRunning}" Command="{Binding DumpEmulatorStateToFileCommand}">
-						<MenuItem.Header>
-							<StackPanel Orientation="Horizontal">
-								<fluent:SymbolIcon Symbol="Document" />
-								<Label Content="Dump emulator state to directory..." />
-							</StackPanel>
-						</MenuItem.Header>
+					<MenuItem Header="Audio" IsEnabled="{Binding IsEmulatorRunning}">
+						<MenuItem Command="{Binding ShowAudioMixerCommand}" CommandParameter="{StaticResource ShowAdditionnalWindowBehavior}">
+							<MenuItem.Header>
+								<StackPanel Orientation="Horizontal">
+									<fluent:SymbolIcon Symbol="MusicNote2" />
+									<Label Content="Audio Mixer &amp; Settings" />
+								</StackPanel>
+							</MenuItem.Header>
+						</MenuItem>
 					</MenuItem>
-				</MenuItem>
-				<MenuItem IsVisible="{Binding ShowHttp}" Header="HTTP">
-					<MenuItem Command="{Binding ShowHttpApiCommand}" CommandParameter="{Binding HttpApiPort}">
-						<MenuItem.Header>
-							<StackPanel Orientation="Horizontal">
-								<fluent:SymbolIcon Symbol="Info" />
-								<Label Content="Status and API Test" />
-							</StackPanel>
-						</MenuItem.Header>
+					<MenuItem Header="Video" IsEnabled="{Binding IsEmulatorRunning}">
+						<MenuItem>
+							<MenuItem.Header>
+								<CheckBox Content="Show Cursor" IsChecked="{Binding Display.ShowCursor}" />
+							</MenuItem.Header>
+						</MenuItem>
+						<MenuItem Command="{Binding SaveBitmapCommand}">
+							<MenuItem.Header>
+								<StackPanel Orientation="Horizontal">
+									<fluent:SymbolIcon Symbol="Image" />
+									<Label Content="Save Bitmap" />
+								</StackPanel>
+							</MenuItem.Header>
+						</MenuItem>
 					</MenuItem>
-				</MenuItem>
-				<MenuItem Header="Audio" IsEnabled="{Binding IsEmulatorRunning}">
-					<MenuItem Command="{Binding ShowAudioMixerCommand}" CommandParameter="{StaticResource ShowAdditionnalWindowBehavior}">
-						<MenuItem.Header>
-							<StackPanel Orientation="Horizontal">
-								<fluent:SymbolIcon Symbol="MusicNote2" />
-								<Label Content="Audio Mixer &amp; Settings" />
-							</StackPanel>
-						</MenuItem.Header>
+					<MenuItem Header="MCP">
+						<MenuItem Command="{Binding ShowMcpToolsCommand}" CommandParameter="{StaticResource ShowAdditionnalWindowBehavior}">
+							<MenuItem.Header>
+								<StackPanel Orientation="Horizontal">
+									<fluent:SymbolIcon Symbol="PlugConnected" />
+									<Label Content="Tools" />
+								</StackPanel>
+							</MenuItem.Header>
+						</MenuItem>
 					</MenuItem>
-				</MenuItem>
-				<MenuItem Header="Video" IsEnabled="{Binding IsEmulatorRunning}">
-					<MenuItem>
-						<MenuItem.Header>
-							<CheckBox Content="Show Cursor" IsChecked="{Binding Display.ShowCursor}" />
-						</MenuItem.Header>
-					</MenuItem>
-					<MenuItem Command="{Binding SaveBitmapCommand}">
-						<MenuItem.Header>
-							<StackPanel Orientation="Horizontal">
-								<fluent:SymbolIcon Symbol="Image" />
-								<Label Content="Save Bitmap" />
-							</StackPanel>
-						</MenuItem.Header>
-					</MenuItem>
-				</MenuItem>
-				<MenuItem Header="MCP">
-					<MenuItem Command="{Binding ShowMcpToolsCommand}" CommandParameter="{StaticResource ShowAdditionnalWindowBehavior}">
-						<MenuItem.Header>
-							<StackPanel Orientation="Horizontal">
-								<fluent:SymbolIcon Symbol="PlugConnected" />
-								<Label Content="Tools" />
-							</StackPanel>
-						</MenuItem.Header>
+					<MenuItem Header="Dumps">
+						<MenuItem>
+							<MenuItem.Header>
+								<StackPanel Orientation="Horizontal">
+									<fluent:SymbolIcon Symbol="Info" />
+									<Label Content="{Binding CurrentLogLevel, StringFormat='Log Level ({0})'}" />
+								</StackPanel>
+							</MenuItem.Header>
+							<MenuItem Header="Silent" Command="{Binding SetLogLevelToSilent}" />
+							<MenuItem Header="Verbose" Command="{Binding SetLogLevelToVerbose}" />
+							<MenuItem Header="Debug" Command="{Binding SetLogLevelToDebug}" />
+							<MenuItem Header="Information" Command="{Binding SetLogLevelToInformation}" />
+							<MenuItem Header="Warning" Command="{Binding SetLogLevelToWarning}" />
+							<MenuItem Header="Error" Command="{Binding SetLogLevelToError}" />
+							<MenuItem Header="Fatal" Command="{Binding SetLogLevelToFatal}" />
+						</MenuItem>
+						<MenuItem
+							HotKey="Ctrl+Alt+D" ToolTip.Tip="Ctrl+Alt+D"
+							IsEnabled="{Binding IsEmulatorRunning}" Command="{Binding DumpEmulatorStateToFileCommand}">
+							<MenuItem.Header>
+								<StackPanel Orientation="Horizontal">
+									<fluent:SymbolIcon Symbol="Document" />
+									<Label Content="Dump emulator state to directory..." />
+								</StackPanel>
+							</MenuItem.Header>
+						</MenuItem>
 					</MenuItem>
 				</MenuItem>
 				<MenuItem Header="Drives"
@@ -163,20 +165,20 @@
 					</MenuItem.ItemTemplate>
 				</MenuItem>
 			</Menu>
-			<StackPanel Grid.Column="1" Focusable="False" IsTabStop="False" IsEnabled="{Binding IsEmulatorRunning}" Grid.Row="0" Margin="160,0,0,0" HorizontalAlignment="Left" VerticalAlignment="Top" Orientation="Horizontal">
-				<Label IsVisible="{Binding ShowCyclesLimitingUI}" Focusable="False" IsTabStop="False" VerticalAlignment="Center" Content="Cycles/ms:" />
-				<Button IsVisible="{Binding ShowCyclesLimitingUI}" Margin="10,0,5,0" HotKey="Ctrl+F11" Focusable="False" IsTabStop="False" IsEnabled="{Binding !IsPaused}" Command="{Binding DecreaseTargetCyclesCommand}" Content="-" />
-				<NumericUpDown x:Name="CyclesLimitingNumericUpDown" IsVisible="{Binding ShowCyclesLimitingUI}" Focusable="False" IsTabStop="False" FormatString="0" IsReadOnly="True" IsEnabled="{Binding !IsPaused}" Text="{Binding TargetCyclesPerMs, FallbackValue=1}" Minimum="100" Maximum="60000" />
-				<Button IsVisible="{Binding ShowCyclesLimitingUI}" Margin="5,0,10,0" HotKey="Ctrl+F12" Focusable="False" IsTabStop="False" IsEnabled="{Binding !IsPaused}" Command="{Binding IncreaseTargetCyclesCommand}" Content="+" />
-				<Button Focusable="False" IsTabStop="False" Command="{Binding PauseCommand}" Margin="5,0,5,0" ToolTip.Tip="Pause (Ctrl+Shift+F5)" HotKey="Ctrl+Shift+F5" IsVisible="{Binding !IsPaused}">
+			<StackPanel Orientation="Horizontal" Grid.Column="1" Focusable="False" IsTabStop="False" IsEnabled="{Binding IsEmulatorRunning}" Grid.Row="0" Margin="160,0,0,0" HorizontalAlignment="Left" VerticalAlignment="Top">
+				<Label Grid.Column="0" IsVisible="{Binding ShowCyclesLimitingUI}" Focusable="False" IsTabStop="False" VerticalAlignment="Center" Content="Cycles/ms:" />
+				<Button Grid.Column="1" IsVisible="{Binding ShowCyclesLimitingUI}" Margin="10,0,5,0" HotKey="Ctrl+F11" Focusable="False" IsTabStop="False" IsEnabled="{Binding !IsPaused}" Command="{Binding DecreaseTargetCyclesCommand}" Content="-" />
+				<NumericUpDown Grid.Column="2" x:Name="CyclesLimitingNumericUpDown" IsVisible="{Binding ShowCyclesLimitingUI}" Focusable="False" IsTabStop="False" FormatString="0" IsReadOnly="True" IsEnabled="{Binding !IsPaused}" Text="{Binding TargetCyclesPerMs, FallbackValue=1}" Minimum="100" Maximum="60000" />
+				<Button Grid.Column="3" IsVisible="{Binding ShowCyclesLimitingUI}" Margin="5,0,10,0" HotKey="Ctrl+F12" Focusable="False" IsTabStop="False" IsEnabled="{Binding !IsPaused}" Command="{Binding IncreaseTargetCyclesCommand}" Content="+" />
+				<Button Grid.Column="4" Focusable="False" IsTabStop="False" Command="{Binding PauseCommand}" Margin="5,0,5,0" ToolTip.Tip="Pause (Ctrl+Shift+F5)" HotKey="Ctrl+Shift+F5" IsVisible="{Binding !IsPaused}">
 					<fluent:SymbolIcon Symbol="Pause" />
 				</Button>
-				<Button Focusable="False" IsTabStop="False" Command="{Binding PlayCommand}" Margin="5,0,5,0" ToolTip.Tip="Continue (F5)" HotKey="F5" IsVisible="{Binding IsPaused}">
+				<Button Grid.Column="5" Focusable="False" IsTabStop="False" Command="{Binding PlayCommand}" Margin="5,0,5,0" ToolTip.Tip="Continue (F5)" HotKey="F5" IsVisible="{Binding IsPaused}">
 					<fluent:SymbolIcon Symbol="Play" />
 				</Button>
-				<Label Focusable="False" IsTabStop="False" VerticalAlignment="Center" Content="Time Modifier:" />
-				<NumericUpDown x:Name="TimeMultiplierNumericUpDown" FormatString="0" Focusable="False" IsTabStop="False" Margin="5,0,5,0" Value="{Binding TimeMultiplier, FallbackValue=1}" Minimum="1" />
-				<Button Focusable="False" IsTabStop="False" Margin="2,0,5,0" HotKey="F4" Command="{Binding ResetTimeMultiplierCommand}">
+				<Label Grid.Column="6" Focusable="False" IsTabStop="False" VerticalAlignment="Center" Content="Time Modifier:" />
+				<NumericUpDown Grid.Column="7" x:Name="TimeMultiplierNumericUpDown" FormatString="0" Focusable="False" IsTabStop="False" Margin="5,0,5,0" Value="{Binding TimeMultiplier, FallbackValue=1}" Minimum="1" />
+				<Button Grid.Column="8" Focusable="False" IsTabStop="False" Margin="2,0,5,0" HotKey="F4" Command="{Binding ResetTimeMultiplierCommand}">
 					<fluent:SymbolIcon Symbol="ArrowReset" />
 				</Button>
 			</StackPanel>
@@ -205,16 +207,6 @@
 			</controls:StatusBarItem>
 			<Separator />
 			<controls:StatusBarItem>
-				<TextBlock Text="{Binding Configuration.GdbPort, StringFormat='GDB port: {0}'}"
-						   IsVisible="{Binding Configuration.GdbPort, Converter={StaticResource NullableToBooleanConverter}}" />
-			</controls:StatusBarItem>
-			<Separator />
-			<controls:StatusBarItem>
-				<TextBlock Text="{Binding HttpApiPort, StringFormat='HTTP port: {0}'}"
-						   IsVisible="{Binding HttpApiPort, Converter={StaticResource NullableToBooleanConverter}}" />
-			</controls:StatusBarItem>
-			<Separator />
-			<controls:StatusBarItem>
 				<TextBlock Text="{Binding Display.EmulatorMouseCursorInfo, StringFormat='Mouse: {0}'}" />
 			</controls:StatusBarItem>
 			<Separator />
@@ -226,10 +218,12 @@
 							<TextBlock Text="{Binding McpStatusViewModel.NetworkStatusTooltip}" TextWrapping="Wrap" />
 							<TextBlock Text="Green: MCP endpoint reachable. Red: endpoint unreachable." Opacity="0.75" TextWrapping="Wrap" />
 							<TextBlock Text="{Binding McpStatusViewModel.ServerEndpoint, StringFormat='Endpoint: {0}'}" Opacity="0.75" TextWrapping="Wrap" />
+							<TextBlock Text="{Binding Configuration.GdbPort, StringFormat='GDB port: {0}'}" IsVisible="{Binding Configuration.GdbPort, Converter={StaticResource NullableToBooleanConverter}}" />
+							<TextBlock Text="{Binding HttpApiPort, StringFormat='HTTP port: {0}'}" IsVisible="{Binding HttpApiPort, Converter={StaticResource NullableToBooleanConverter}}" />
 						</StackPanel>
 					</ToolTip.Tip>
 					<Ellipse Width="10" Height="10" VerticalAlignment="Center" Fill="{Binding McpStatusViewModel.NetworkStatusColor}" />
-					<TextBlock Text="MCP" FontWeight="SemiBold" />
+					<TextBlock Text="Servers" FontWeight="SemiBold" />
 				</StackPanel>
 			</controls:StatusBarItem>
 			<Separator />


### PR DESCRIPTION
### Description of Changes

<img width="1545" height="1461" alt="image" src="https://github.com/user-attachments/assets/3dd766d1-343b-4d3e-9676-7ede0aedb4d0" />

Also removed an unused parameter in the ProgramBootStrapper class.

### Rationale behind Changes

Somestimes perf text would get out of range in the statusbar.

Showing both the time modifier UI and cycles UI made part of the UI get out of range.

Both issues are fixed.

### Suggested Testing Steps

Already tested.