### PR TITLE
chore: Update Nugets: Avalonia v12.1, SkiaSharp v4 (better perfs)

### DIFF
--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -4,15 +4,15 @@
     <CentralPackageTransitivePinningEnabled>true</CentralPackageTransitivePinningEnabled>
   </PropertyGroup>
   <ItemGroup>
-    <PackageVersion Include="Avalonia" Version="12.0.3" />
-    <PackageVersion Include="Avalonia.Desktop" Version="12.0.3" />
-    <PackageVersion Include="Avalonia.Fonts.Inter" Version="12.0.3" />
-    <PackageVersion Include="Avalonia.Headless" Version="12.0.3" />
+    <PackageVersion Include="Avalonia" Version="12.1.0" />
+    <PackageVersion Include="Avalonia.Desktop" Version="12.1.0" />
+    <PackageVersion Include="Avalonia.Fonts.Inter" Version="12.1.0" />
+    <PackageVersion Include="Avalonia.Headless" Version="12.1.0" />
     <PackageVersion Include="AvaloniaUI.DiagnosticsSupport" Version="2.2.1" />
     <PackageVersion Include="AvaloniaGraphControl" Version="0.8.0" />
     <PackageVersion Include="AvaloniaHex" Version="0.1.13" />
     <PackageVersion Include="BenchmarkDotNet" Version="0.15.8" />
-    <PackageVersion Include="bodong.Avalonia.PropertyGrid" Version="12.0.0" />
+    <PackageVersion Include="bodong.Avalonia.PropertyGrid" Version="12.0.4.1" />
     <PackageVersion Include="bodong.PropertyModels" Version="12.0.0" />
     <PackageVersion Include="Spectre.Console.Cli" Version="0.55.0" />
     <PackageVersion Include="CommunityToolkit.HighPerformance" Version="8.4.2" />
@@ -25,14 +25,14 @@
     <PackageVersion Include="Dock.Model.Avalonia" Version="12.0.0.2" />
     <PackageVersion Include="Dock.Model.Mvvm" Version="12.0.0.2" />
     <PackageVersion Include="ErrorProne.NET.CoreAnalyzers" Version="0.1.2" />
-    <PackageVersion Include="FluentIcons.Avalonia" Version="2.1.326" />
+    <PackageVersion Include="FluentIcons.Avalonia" Version="2.1.331" />
     <PackageVersion Include="Iced" Version="1.21.0" />
-    <PackageVersion Include="JetBrains.Annotations" Version="2025.2.4" />
+    <PackageVersion Include="JetBrains.Annotations" Version="2026.2.0" />
     <PackageVersion Include="JvE.Structurizer" Version="1.2.0" />
     <PackageVersion Include="MeltySynth" Version="2.4.1" />
-    <PackageVersion Include="ModelContextProtocol.AspNetCore" Version="1.3.0" />
-    <PackageVersion Include="ModelContextProtocol.Core" Version="1.3.0" />
-    <PackageVersion Include="Microsoft.AspNetCore.OpenApi" Version="10.0.8" />
+    <PackageVersion Include="ModelContextProtocol.AspNetCore" Version="1.4.1" />
+    <PackageVersion Include="ModelContextProtocol.Core" Version="1.4.1" />
+    <PackageVersion Include="Microsoft.AspNetCore.OpenApi" Version="10.0.9" />
     <PackageVersion Include="Microsoft.OpenApi" Version="2.7.5" />
     <PackageVersion Include="Mt32emu.net" Version="1.0.0" />
     <PackageVersion Include="NSubstitute" Version="5.3.0" />
@@ -41,25 +41,25 @@
     <PackageVersion Include="PanAndZoom" Version="12.0.0.1" />
     <PackageVersion Include="Roslynator.Analyzers" Version="4.15.0" />
     <PackageVersion Include="Roslynator.CodeAnalysis.Analyzers" Version="4.15.0" />
-    <PackageVersion Include="Semi.Avalonia" Version="12.0.1" />
+    <PackageVersion Include="Semi.Avalonia" Version="12.0.3" />
     <PackageVersion Include="Semi.Avalonia.Dock" Version="12.0.0.2" />
     <PackageVersion Include="Spice86.DataGrid" Version="0.1.2" />
-    <PackageVersion Include="Serilog" Version="4.3.1" />
+    <PackageVersion Include="Serilog" Version="4.4.0" />
     <PackageVersion Include="Serilog.Extensions.Hosting" Version="10.0.0" />
     <PackageVersion Include="Serilog.Sinks.Async" Version="2.1.0" />
     <PackageVersion Include="Serilog.Sinks.Console" Version="6.1.1" />
     <PackageVersion Include="Serilog.Sinks.Debug" Version="3.0.0" />
     <PackageVersion Include="Serilog.Sinks.File" Version="7.0.0" />
-    <PackageVersion Include="Swashbuckle.AspNetCore" Version="10.1.7" />
-    <PackageVersion Include="SkiaSharp" Version="3.119.4-preview.1.1" />
+    <PackageVersion Include="Swashbuckle.AspNetCore" Version="10.2.3" />
+    <PackageVersion Include="SkiaSharp" Version="4.150.0" />
     <PackageVersion Include="System.Buffers" Version="4.6.1" />
     <PackageVersion Include="System.Memory" Version="4.6.3" />
     <PackageVersion Include="System.Text.Encoding.CodePages" Version="10.0.0" />
     <PackageVersion Include="System.Text.Json" Version="10.0.0" />
-    <PackageVersion Include="Xaml.Behaviors.Avalonia" Version="12.0.0.1" />
+    <PackageVersion Include="Xaml.Behaviors.Avalonia" Version="12.0.5" />
     <PackageVersion Include="Spice86.Audio" Version="11.4.0" />
     <PackageVersion Include="FastExpressionCompiler" Version="5.4.1" />
     <PackageVersion Include="Silk.NET.SDL" Version="2.23.0" />
-    <PackageVersion Include="Tmds.DBus.Protocol" Version="0.92.0" />
+    <PackageVersion Include="Tmds.DBus.Protocol" Version="0.94.1" />
   </ItemGroup>
 </Project>

--- a/src/Spice86/ViewModels/Services/HostStorageProvider.cs
+++ b/src/Spice86/ViewModels/Services/HostStorageProvider.cs
@@ -49,12 +49,12 @@ public class HostStorageProvider(
         if (CanSave && CanPickFolder) {
             FilePickerSaveOptions options = new() {
                 Title = "Save bitmap image...",
-                DefaultExtension = "bmp",
+                DefaultExtension = "png",
                 SuggestedStartLocation = await TryGetWellKnownFolderAsync(WellKnownFolder.Documents)
             };
             string? file = (await SaveFilePickerAsync(options))?.TryGetLocalPath();
             if (!string.IsNullOrWhiteSpace(file)) {
-                bitmap.Save(file);
+                bitmap.Save(file, options: new PngBitmapEncoderOptions());
             }
         }
     }

--- a/tests/Directory.Packages.props
+++ b/tests/Directory.Packages.props
@@ -7,10 +7,10 @@
     <PackageVersion Include="coverlet.collector" Version="10.0.1" />
     <PackageVersion Include="ErrorProne.NET.CoreAnalyzers" Version="0.1.2" />
     <PackageVersion Include="FluentAssertions" Version="8.10.0" />
-    <PackageVersion Include="JetBrains.Annotations" Version="2025.2.4" />
-    <PackageVersion Include="Microsoft.CodeAnalysis.CSharp" Version="5.0.0" />
+    <PackageVersion Include="JetBrains.Annotations" Version="2026.2.0" />
+    <PackageVersion Include="Microsoft.CodeAnalysis.CSharp" Version="5.6.0" />
     <PackageVersion Include="Microsoft.OpenApi" Version="2.7.5" />
-    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.5.1" />
+    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.7.0" />
     <PackageVersion Include="NSubstitute" Version="5.3.0" />
     <PackageVersion Include="NSubstitute.Analyzers.CSharp" Version="1.0.17" />
     <PackageVersion Include="Roslynator.Analyzers" Version="4.15.0" />
@@ -21,12 +21,12 @@
     <PackageVersion Include="SingleStepTests.Intel80386.67.80-67.FF" Version="2025.11.5" />
     <PackageVersion Include="SingleStepTests.Intel80386.68-FF" Version="2025.11.5" />
     <PackageVersion Include="System.Text.Json" Version="10.0.0" />
-    <PackageVersion Include="Avalonia.Headless" Version="12.0.3" />
-    <PackageVersion Include="Avalonia.Headless.XUnit" Version="12.0.3" />
+    <PackageVersion Include="Avalonia.Headless" Version="12.1.0" />
+    <PackageVersion Include="Avalonia.Headless.XUnit" Version="12.1.0" />
     <PackageVersion Include="xunit.v3" Version="3.2.2" />
     <PackageVersion Include="xunit.runner.visualstudio" Version="3.1.5" />
     <PackageVersion Include="Xunit.SkippableFact" Version="1.5.61" />
-    <PackageVersion Include="Tmds.DBus.Protocol" Version="0.92.0" />
+    <PackageVersion Include="Tmds.DBus.Protocol" Version="0.94.1" />
     <PackageVersion Include="xunit.v3.assert" Version="3.2.2" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
### Description of Changes

Updates all nuget packages.

### Rationale behind Changes

Avalonia v12.1 and SkiaSharp v4 bring better performance.

Avalonia v12.1 is also compatible with the modern Linux platform (ie. Wayland).

### Suggested Testing Steps

Already tested.