### PR TITLE
fix: Show 16 bytes per row in the memory view of the internal debugger

### DIFF
--- a/src/Spice86/Views/MemoryView.axaml.cs
+++ b/src/Spice86/Views/MemoryView.axaml.cs
@@ -25,6 +25,7 @@ public partial class MemoryView : UserControl {
         DataContextChanged += OnDataContextChanged;
 
         this.HexViewer.DoubleTapped += OnHexViewerDoubleTapped;
+        HexViewer.HexView.BytesPerLine = 16;
     }
 
     private void OnHexViewerDoubleTapped(object? sender, TappedEventArgs e) {


### PR DESCRIPTION
Previously it showed 13 (or 0x13) columns which didn't make sense