### PR TITLE
fix: match .editorconfig to actual practice

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -130,12 +130,12 @@ csharp_style_allow_embedded_statements_on_same_line_experimental = true
 #### C# Formatting Rules ####
 
 # New line preferences
-csharp_new_line_before_open_brace = none
-csharp_new_line_before_catch = false
-csharp_new_line_before_else = false
-csharp_new_line_before_finally = false
-csharp_new_line_before_members_in_anonymous_types = false
-csharp_new_line_before_members_in_object_initializers = false
+csharp_new_line_before_open_brace = all
+csharp_new_line_before_catch = true
+csharp_new_line_before_else = true
+csharp_new_line_before_finally = true
+csharp_new_line_before_members_in_anonymous_types = true
+csharp_new_line_before_members_in_object_initializers = true
 csharp_new_line_between_query_expression_clauses = true
 
 # Indentation preferences


### PR DESCRIPTION
Now Visual Studio formatting leaves files unchanged. Tested on src/Spice86/ViewModels/DisassemblyViewModel.cs