### PR TITLE
fix: Internal debugger crash when instruction would read 2 bytes starting at 0xFFFF

### DIFF
--- a/src/Spice86/ViewModels/DisassemblyViewModel.cs
+++ b/src/Spice86/ViewModels/DisassemblyViewModel.cs
@@ -444,7 +444,14 @@ public partial class DisassemblyViewModel : ViewModelWithErrorDialog, IDisassemb
         for (int i = clampedFirst; i <= clampedLast; i++)
         {
             DebuggerLineViewModel line = sortedLines[i];
-            line.EvaluatedOperands = _evaluationService.FormatOperandValues(line.InstructionInfo);
+            try
+            {
+                line.EvaluatedOperands = _evaluationService.FormatOperandValues(line.InstructionInfo);
+            }
+            catch
+            {
+                line.EvaluatedOperands = null;
+            }
         }
     }
 


### PR DESCRIPTION
When a function exit poped 0xffff into si, an instruction far away that read 16 bits from si made the debugger crash because it extended past the segment end. Now the debugger shows no actual values for that instruction, but should be fixed when it's about to execute and registers have differente values.