### PR TITLE
Update NukedOPL3Sharp package version to 1.2.0

### DIFF
--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -37,7 +37,7 @@
     <PackageVersion Include="Mt32emu.net" Version="1.0.0" />
     <PackageVersion Include="NSubstitute" Version="5.3.0" />
     <PackageVersion Include="NSubstitute.Analyzers.CSharp" Version="1.0.17" />
-    <PackageVersion Include="NukedOPL3Sharp" Version="1.1.0" />
+    <PackageVersion Include="NukedOPL3Sharp" Version="1.2.0" />
     <PackageVersion Include="PanAndZoom" Version="12.0.0.1" />
     <PackageVersion Include="Roslynator.Analyzers" Version="4.15.0" />
     <PackageVersion Include="Roslynator.CodeAnalysis.Analyzers" Version="4.15.0" />


### PR DESCRIPTION
### Description of Changes
Bump NukedOPL3Sharp to 1.2.0

### Rationale behind Changes
v1.1.0 had some divergences compared against the reference implementation.

### Suggested Testing Steps
Test your favorite OPL2/OPL3 games ;)
