### PR TITLE
Fix running Spice86 with the UI (in non-headless mode) on Linux

### DIFF
--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -52,6 +52,7 @@
     <PackageVersion Include="Serilog.Sinks.File" Version="7.0.0" />
     <PackageVersion Include="Swashbuckle.AspNetCore" Version="10.2.3" />
     <PackageVersion Include="SkiaSharp" Version="4.150.0" />
+    <PackageVersion Include="SkiaSharp.NativeAssets.Linux" Version="4.150.1" />
     <PackageVersion Include="System.Buffers" Version="4.6.1" />
     <PackageVersion Include="System.Memory" Version="4.6.3" />
     <PackageVersion Include="System.Text.Encoding.CodePages" Version="10.0.0" />

--- a/src/Spice86.Core/Spice86.Core.csproj
+++ b/src/Spice86.Core/Spice86.Core.csproj
@@ -35,6 +35,7 @@
         <FrameworkReference Include="Microsoft.AspNetCore.App" />
         <PackageReference Include="Serilog.Extensions.Hosting" />
         <PackageReference Include="SkiaSharp" />
+        <PackageReference Include="SkiaSharp.NativeAssets.Linux" />
         <PackageReference Include="ModelContextProtocol.Core"/>
         <PackageReference Include="ModelContextProtocol.AspNetCore" />
     </ItemGroup>


### PR DESCRIPTION
At some point the Spice86 UI stopped working on Linux. Games would still ran in headless mode (with `--HeadlessMode Minimal` in the command line arguments), but not by default with the main interface (or with `--HeadlessMode Avalonia`, which is the default). Instead the SkiaSharp library threw an exception that indicated that a different version of the native Skia library was present on the system than the one supported by the version of SkiaSharp that Spice86 was compiled with.

```
Using Spice86 Debug build: /home/dev/Spice86/src/Spice86/bin/Debug/net10.0
Unhandled exception. System.TypeInitializationException: The type initializer for 'SkiaSharp.SKImageInfo' threw an exception.
 ---> System.TypeInitializationException: The type initializer for 'SkiaSharp.SkiaApi' threw an exception.
 ---> System.InvalidOperationException: The version of the native libSkiaSharp library (119.0) is incompatible with this version of SkiaSharp. Supported versions of the native libSkiaSharp library are in the range [150.0, 151.0).
   at SkiaSharp.SkiaSharpVersion.CheckNativeLibraryCompatible(Version minSupported, Version current, Boolean throwIfIncompatible)
   at SkiaSharp.SkiaSharpVersion.CheckNativeLibraryCompatible(Boolean throwIfIncompatible)
   at SkiaSharp.SkiaApi..cctor()
   --- End of inner exception stack trace ---
   at SkiaSharp.SkiaApi.sk_colortype_get_default_8888()
   at SkiaSharp.SkiaApi.sk_colortype_get_default_8888()
   at SkiaSharp.SKImageInfo..cctor()
   --- End of inner exception stack trace ---
   at Avalonia.Skia.PlatformRenderInterface..ctor(Nullable`1 maxResourceBytes, Nullable`1 useStencilBuffers)
   at Avalonia.Skia.SkiaPlatform.Initialize(SkiaOptions options)
   at Avalonia.SkiaApplicationExtensions.<>c.<UseSkia>b__0_0()
   at Avalonia.AppBuilder.SetupUnsafe()
   at Avalonia.AppBuilder.Setup()
   at Avalonia.AppBuilder.SetupWithLifetime(IApplicationLifetime lifetime)
   at Avalonia.ClassicDesktopStyleApplicationLifetimeExtensions.StartWithClassicDesktopLifetime(AppBuilder builder, String[] args, ShutdownMode shutdownMode)
   at Spice86.Program.Main(String[] args) in /home/dev/Spice86/src/Spice86/Program.cs:line 47
Aborted                    (core dumped)
```

After digging into it, I discovered that SkiaSharp depends on SkiaSharp.NativeAssets.Win32 and SkiaSharp.NativeAssets.macOS to ensure that they are always the correct versions for Windows and macOS, but it does no such thing for Linux. I added SkiaSharp.NativeAssets.Linux explicitly to the Spice86 dependencies (since it isn't implicitly pulled in as a transitive dependency of SkiaSharp like the Windows and macOS versions are), rebuilt, and that fixed the issue. I can now run Spice86 again with the full UI on Linux.

The unit tests didn't catch this bug because Spice86 still compiled on Linux. It just didn't run with the UI. The unit tests don't try to run it with the UI either. They run it in minimal mode with no UI - which makes sense. This was just a gap in the test coverage that happened to regress. I thought about how to introduce tests for it, but I think that would require integration tests, not just unit tests, and that it's not worth it for this fix. It's easier to just add the new dependency. It's unlikely that it will regress again in this way in the future now that it's there.

I'm sure that there's a specific commit that introduced this regression since I used to be able to run Spice86 on Linux, but I don't know what it was. Ideally I should have tracked it down and referenced it in this commit, but it was easier to just fix it than to bisect, so I didn't.