### PR TITLE
fix: repeated keyboard input when INT 16h polls an empty 8042 buffer

### DIFF
--- a/src/Spice86.Core/Emulator/InterruptHandlers/Input/Keyboard/BiosKeyboardInt9Handler.cs
+++ b/src/Spice86.Core/Emulator/InterruptHandlers/Input/Keyboard/BiosKeyboardInt9Handler.cs
@@ -72,6 +72,15 @@ public class BiosKeyboardInt9Handler : InterruptHandler {
 
     /// <inheritdoc />
     public override void Run() {
+        // INT 16h may invoke INT 09h as a polling mechanism.
+        // Do not reprocess the controller's previous data byte when
+        // the output buffer contains no new data.
+        byte status = _ps2Controller.ReadByte(KeyboardPorts.StatusRegister);
+        if ((status & 0x01) == 0) {
+            _dualPic.AcknowledgeInterrupt(1);
+            return;
+        }
+
         // Disable keyboard first - otherwise Prince of Persia reads it before us!
         _ps2Controller.WriteByte(KeyboardPorts.Command, (byte)KeyboardCommand.DisablePortKbd);
 


### PR DESCRIPTION
### Description of Changes

Added a check in `BiosKeyboardInt9Handler.Run()` for the Intel 8042 output-buffer-full/data-pending status bit before reading keyboard data from port `0x60`.

If no new keyboard data is pending, the handler acknowledges IRQ1 and returns without processing a scancode.

### Rationale behind Changes

The in-memory INT 16h handler invokes INT 09h when the BIOS keyboard buffer is empty in order to fetch pending keyboard input.

However, `BiosKeyboardInt9Handler.Run()` previously read port `0x60` unconditionally. `Intel8042Controller.ReadByte()` intentionally returns the previous data byte when no new data is pending.

This meant that when INT 16h invoked INT 09h while the 8042 output buffer was empty, the previous keyboard scancode could be processed again as if it were new input. In affected software, this caused a single physical key press to be duplicated repeatedly.

The issue was reproduced with the text adventure game **Solus (1988)**. With `SOLUS.COM`: pressing `L` once resulted in a rapid flood of `l` characters despite the input pipeline receiving exactly one key-down and one key-up event. Pressing `Enter` once similarly resulted in multiple Enter key events being processed.

### Suggested Testing Steps

1. Run `SOLUS.COM` and wait for its text parser prompt.
2. Tap a letter key such as `L` once, or press `Enter` once.

   * Before this change, a single key press can be processed repeatedly.
   * After this change, a single key press should be processed exactly once.