### PR TITLE
Fix/dos mem allocation

### DIFF
--- a/src/Spice86.Core/Emulator/OperatingSystem/DosMemoryManager.cs
+++ b/src/Spice86.Core/Emulator/OperatingSystem/DosMemoryManager.cs
@@ -106,6 +106,9 @@ public class DosMemoryManager {
     /// <param name="requestedSizeInParagraphs">The requested size in paragraphs of the memory block.</param>
     /// <returns>The allocated <see cref="DosMemoryControlBlock"/> or <c>null</c> if no memory block could be found.</returns>
     public DosMemoryControlBlock? AllocateMemoryBlock(ushort requestedSizeInParagraphs) {
+        // Matches DOS_AllocateMemory in dosbox-staging's dos_memory.cpp: compress the whole chain
+        // (merge every adjacent free/free pair) before searching for a candidate block.
+        CompressMemory();
         IEnumerable<DosMemoryControlBlock> candidates = FindCandidatesForAllocation(requestedSizeInParagraphs);
 
         // Select block based on allocation strategy
@@ -211,32 +214,61 @@ public class DosMemoryManager {
             newSizeInParagraphs = DosProgramSegmentPrefix.PspSizeInParagraphs;
         }
 
-        // Make the block the biggest it can get
-        if (!JoinBlocks(block, false)) {
-            if (_loggerService.IsEnabled(LogLevel.Error)) {
-                _loggerService.LogError("Could not join MCB {Block}", block);
+        // Mirrors dosbox-staging's DOS_ResizeMemory (dos_memory.cpp) exactly, including its
+        // three-way shrink / partial-grow / grow-to-max-then-fail structure.
+        CompressMemory();
+
+        ushort total = block.Size;
+        if (newSizeInParagraphs <= total) {
+            if (newSizeInParagraphs == total) {
+                // Size unchanged
+                block.PspSegment = _sda.CurrentProgramSegmentPrefix;
+                return DosErrorCode.NoError;
             }
-            return DosErrorCode.InsufficientMemory;
-        }
 
-        if (block.Size < newSizeInParagraphs) {
-            if (_loggerService.IsEnabled(LogLevel.Error)) {
-                _loggerService.LogError("MCB {Block} is too small for requested size {RequestedSize}",
-                    block, newSizeInParagraphs);
-
-                if (_loggerService.IsEnabled(LogLevel.Trace) && !block.IsLast) {
-                    DosMemoryControlBlock? nextBlock = block.GetNextOrDefault();
-                    _loggerService.LogTrace("Next MCB is {Block}", nextBlock);
-                }
-            }
-            return DosErrorCode.InsufficientMemory;
-        }
-
-        if (block.Size > newSizeInParagraphs) {
+            // Shrinking MCB
             SplitBlock(block, newSizeInParagraphs);
+            block.PspSegment = _sda.CurrentProgramSegmentPrefix;
+            CompressMemory();
+            return DosErrorCode.NoError;
         }
+
+        // MCB will grow: try to join with the following MCB first.
+        DosMemoryControlBlock? next = block.IsLast ? null : block.GetNextOrDefault();
+        if (next?.IsFree == true) {
+            total = (ushort)(total + next.Size + 1);
+        }
+
+        if (newSizeInParagraphs < total) {
+            // Grows, but only partially consumes the following free MCB.
+            byte followingType = block.IsLast ? block.TypeField : next!.TypeField;
+            block.Size = newSizeInParagraphs;
+            DosMemoryControlBlock newNext = block.GetNextOrDefault() ?? next!;
+            newNext.TypeField = followingType;
+            newNext.SetFree();
+            newNext.Size = (ushort)(total - newSizeInParagraphs - 1);
+            block.SetNonLast();
+            block.PspSegment = _sda.CurrentProgramSegmentPrefix;
+            CompressMemory();
+            return DosErrorCode.NoError;
+        }
+
+        // requestedSize == total (fits exactly) or requestedSize > total (grow to the maximum
+        // available and report failure with that maximum in `block.Size`, matching real DOS).
+        if (next?.IsFree == true) {
+            block.TypeField = next.TypeField;
+        }
+        block.Size = total;
         block.PspSegment = _sda.CurrentProgramSegmentPrefix;
-        return DosErrorCode.NoError;
+        if (newSizeInParagraphs == total) {
+            return DosErrorCode.NoError;
+        }
+
+        if (_loggerService.IsEnabled(LogLevel.Error)) {
+            _loggerService.LogError("MCB {Block} is too small for requested size {RequestedSize}",
+                block, newSizeInParagraphs);
+        }
+        return DosErrorCode.InsufficientMemory;
     }
 
     /// <summary>
@@ -487,7 +519,6 @@ public class DosMemoryManager {
             if (!CheckValidOrLogError(current)) {
                 return new List<DosMemoryControlBlock>();
             }
-            JoinBlocks(current, true);
             if (current?.IsFree == true && current.Size >= requestedSize) {
                 candidates.Add(current);
             }
@@ -507,30 +538,25 @@ public class DosMemoryManager {
         return new DosMemoryControlBlock(_memory, MemoryUtils.ToPhysicalAddress(blockSegment, 0));
     }
 
-    private bool JoinBlocks(DosMemoryControlBlock? block, bool onlyIfFree) {
-        if (onlyIfFree && block?.IsFree == false) {
-            // Do not touch blocks in use
-            return true;
-        }
-
-        while (block?.IsNonLast == true) {
-            DosMemoryControlBlock? next = block.GetNextOrDefault();
-            if (next is null || !next.IsFree) {
-                // end of the free blocks reached
+    /// <summary>
+    /// Mirrors dosbox-staging's <c>DOS_CompressMemory</c> (dos_memory.cpp): walks the whole MCB
+    /// chain from the start, merging every adjacent free/free pair it finds, including chains of
+    /// more than two consecutive free blocks.
+    /// </summary>
+    private void CompressMemory() {
+        DosMemoryControlBlock? current = _start;
+        while (current is not null && !current.IsLast) {
+            DosMemoryControlBlock? next = current.GetNextOrDefault();
+            if (next is null) {
                 break;
             }
-
-            if (!CheckValidOrLogError(next)) {
-                if (_loggerService.IsEnabled(LogLevel.Error)) {
-                    _loggerService.LogError("MCB {NextBlock} is not valid", next);
-                }
-                return false;
+            if (current.IsFree && next.IsFree) {
+                JoinContiguousBlocks(current, next);
+                // Stay on the same block and re-check its (now bigger) next block.
+                continue;
             }
-
-            JoinContiguousBlocks(block, next);
+            current = next;
         }
-
-        return true;
     }
 
     private static void JoinContiguousBlocks(DosMemoryControlBlock destination, DosMemoryControlBlock next) {
@@ -685,8 +711,6 @@ public class DosMemoryManager {
             // Free blocks owned by this PSP
             if (current.PspSegment == pspSegment) {
                 current.SetFree();
-                // Coalesce adjacent free blocks
-                JoinBlocks(current, true);
             }
 
             if (current.IsLast) {
@@ -696,6 +720,9 @@ public class DosMemoryManager {
             current = current.GetNextOrDefault();
         }
 
+        // Matches dosbox-staging's DOS_FreeProcessMemory, which compresses the whole chain once
+        // at the end rather than after each individual block.
+        CompressMemory();
         return true;
     }
 
@@ -726,7 +753,7 @@ public class DosMemoryManager {
         }
 
         block.SetFree();
-        JoinBlocks(_start, true);
+        CompressMemory();
         return true;
     }
 }

--- a/src/Spice86.Core/Emulator/OperatingSystem/DosMemoryManager.cs
+++ b/src/Spice86.Core/Emulator/OperatingSystem/DosMemoryManager.cs
@@ -241,9 +241,26 @@ public class DosMemoryManager {
 
         if (newSizeInParagraphs < total) {
             // Grows, but only partially consumes the following free MCB.
-            byte followingType = block.IsLast ? block.TypeField : next!.TypeField;
+            byte followingType;
+            if (block.IsLast) {
+                followingType = block.TypeField;
+            } else {
+                if (next is null) {
+                    if (_loggerService.IsEnabled(LogLevel.Error)) {
+                        _loggerService.LogError("MCB chain corrupted while resizing {Block}", block);
+                    }
+                    return DosErrorCode.MemoryControlBlockDestroyed;
+                }
+                followingType = next.TypeField;
+            }
             block.Size = newSizeInParagraphs;
-            DosMemoryControlBlock newNext = block.GetNextOrDefault() ?? next!;
+            DosMemoryControlBlock? newNext = block.GetNextOrDefault() ?? next;
+            if (newNext is null) {
+                if (_loggerService.IsEnabled(LogLevel.Error)) {
+                    _loggerService.LogError("MCB chain corrupted while resizing {Block}", block);
+                }
+                return DosErrorCode.MemoryControlBlockDestroyed;
+            }
             newNext.TypeField = followingType;
             newNext.SetFree();
             newNext.Size = (ushort)(total - newSizeInParagraphs - 1);

--- a/src/global.json
+++ b/src/global.json
@@ -3,5 +3,8 @@
     "version": "8.0.0",
     "rollForward": "latestMajor",
     "allowPrerelease": false
+  },
+  "test": {
+    "runner": "Microsoft.Testing.Platform"
   }
 }

--- a/src/global.json
+++ b/src/global.json
@@ -3,8 +3,5 @@
     "version": "8.0.0",
     "rollForward": "latestMajor",
     "allowPrerelease": false
-  },
-  "test": {
-    "runner": "Microsoft.Testing.Platform"
   }
 }

--- a/tests/Spice86.Tests/Dos/DosMemoryManagerTest.cs
+++ b/tests/Spice86.Tests/Dos/DosMemoryManagerTest.cs
@@ -317,8 +317,10 @@ public class DosMemoryManagerTests {
         block.AllocationSizeInBytes.Should().Be(260800);
     }
 
+
     /// <summary>
-    /// Ensures that the memory manager cannot extend the size of a free block.
+    /// Ensures that the memory manager cannot extend the size of a free block past what's
+    /// actually available.
     /// </summary>
     /// <remarks>
     /// A free memory block is always going to consume as much contiguous free space as is
@@ -327,7 +329,11 @@ public class DosMemoryManagerTests {
     /// conjoining free blocks of memory. Therefore even though a free memory block can effectively
     /// be allocated by trying to reduce its size, it can never be allocated by trying to increase
     /// it because there will never be enough free space to do that. This test case verifies that it
-    /// always fails so that we don't end up allocating any overlapping memory.
+    /// always fails so that we don't end up allocating any overlapping memory.<br/><br/>
+    /// Matches dosbox-staging's <c>DOS_ResizeMemory</c> (dos_memory.cpp): it unconditionally sets
+    /// the block's owner to the calling PSP before checking whether the requested size was
+    /// actually satisfied, so a failed grow attempt on a previously free block still takes
+    /// ownership of it (grown to the maximum available size) even though the call reports failure.
     /// </remarks>
     [Fact]
     public void ExtendSizeOfFreeBlock() {
@@ -338,13 +344,14 @@ public class DosMemoryManagerTests {
         // Assert
         errorCode.Should().Be(DosErrorCode.InsufficientMemory);
         block.IsValid.Should().BeTrue();
-        block.IsFree.Should().BeTrue();
+        block.IsFree.Should().BeFalse();
         block.IsLast.Should().BeTrue();
-        block.PspSegment.Should().Be(DosMemoryControlBlock.FreeMcbMarker);
+        block.PspSegment.Should().Be(_initialPspSegment);
         block.DataBlockSegment.Should().Be(0xFF0);
         block.Size.Should().Be(36880);
         block.AllocationSizeInBytes.Should().Be(590080);
     }
+
 
     /// <summary>
     /// Ensures that the memory manager can extend the size of a free block to allocate the full


### PR DESCRIPTION
### Description of Changes

Changes DOS Memory Manager behavior when allocating MCBs

### Rationale behind Changes

Fixes DOS Memory Manager behavior so Alone in the Dark works fully now.

### Suggested Testing Steps
<!-- If applicable, including examples you've already tested with / recommendations for how to test further is very helpful! -->
